### PR TITLE
chore: better snippets for dashboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ require("no-neck-pain").setup({
 ### Enable on `VimEnter`
 
 > **Warning**
-> If you use [`dashboard-nvim`](https://github.com/glepnir/dashboard-nvim) or a similar plugin, make sure to use [the following snippet instead](https://github.com/glepnir/dashboard-nvim)
+> If you use [`dashboard-nvim`](https://github.com/glepnir/dashboard-nvim) or a similar plugin, make sure to use [the following snippet instead](#enable-on-vimenter-or-bufwinenter)
 
 ```lua
 vim.api.nvim_create_augroup("OnVimEnter", { clear = true })

--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ require("no-neck-pain").setup({
 |-------------|----------------------------|
 |`:NoNeckPain`| Toggle the `enabled` state.|
 
-### Enable on VimEnter
+## Automate NNP startup
 
-> The following snippet will start the plugin after entering NeoVim.
+### Enable on `VimEnter`
+
+> **Warning**
+> If you use [`dashboard-nvim`](https://github.com/glepnir/dashboard-nvim) or a similar plugin, make sure to use [the following snippet instead](https://github.com/glepnir/dashboard-nvim)
 
 ```lua
 vim.api.nvim_create_augroup("OnVimEnter", { clear = true })
@@ -61,7 +64,47 @@ vim.api.nvim_create_autocmd({ "VimEnter" }, {
 	pattern = "*",
 	callback = function()
 		vim.schedule(function()
-			require("no-neck-pain").start()
+			require("no-neck-pain").enable()
+		end)
+	end,
+})
+```
+
+### Enable on `VimEnter` **or** `BufWinEnter`
+
+```lua
+vim.api.nvim_create_augroup("OnVimEnter", { clear = true })
+vim.api.nvim_create_autocmd({ "VimEnter" }, {
+	group = "OnVimEnter",
+	pattern = "*",
+	callback = function()
+		vim.schedule(function()
+			-- do not trigger when opening dashboard (e.g. dashboard-nvim)
+			if vim.bo.filetype == "dashboard" then
+				return
+			end
+
+			-- enable NNP on VimEnter
+			require("no-neck-pain").enable()
+		end)
+	end,
+})
+
+vim.api.nvim_create_augroup("OnBufWinEnter", { clear = true })
+vim.api.nvim_create_autocmd({ "BufWinEnter" }, {
+	group = "OnBufWinEnter",
+	pattern = "*",
+	callback = function()
+		vim.schedule(function()
+			-- do not trigger when opening dashboard (e.g. dashboard-nvim)
+			if vim.bo.filetype == "dashboard" then
+				return
+			end
+
+			-- ensure NNP is loaded and not already started
+			if _G.NoNeckPainLoaded and _G.NoNeckPain.state == nil then
+				require("no-neck-pain").enable()
+			end
 		end)
 	end,
 })

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,7 +1,10 @@
 local NNP = {}
 
-function NNP.start()
+-- toggles NNP
+function NNP.toggle()
     local main = require("no-neck-pain.main")
+
+    main.toggle()
 
     NNP.state = main.state
     NNP.internal = {
@@ -9,10 +12,23 @@ function NNP.start()
         enable = main.enable,
         disable = main.disable,
     }
-
-    main.toggle()
 end
 
+-- starts NNP
+function NNP.enable()
+    local main = require("no-neck-pain.main")
+
+    main.enable()
+
+    NNP.state = main.state
+    NNP.internal = {
+        toggle = main.toggle,
+        enable = main.enable,
+        disable = main.disable,
+    }
+end
+
+-- setup NNP
 function NNP.setup(opts)
     NNP.config = {
         options = require("no-neck-pain.config").setup(opts),

--- a/plugin/no-neck-pain.lua
+++ b/plugin/no-neck-pain.lua
@@ -1,9 +1,9 @@
-if _G.noNeckPainLoaded then
+if _G.NoNeckPainLoaded then
     return
 end
 
-_G.noNeckPainLoaded = true
+_G.NoNeckPainLoaded = true
 
 vim.api.nvim_create_user_command("NoNeckPain", function()
-    require("no-neck-pain").start()
+    require("no-neck-pain").toggle()
 end, {})

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -23,7 +23,7 @@ local T = new_set({
 T["require()"] = new_set()
 
 T["require()"]["sets global loaded variable"] = function()
-    eq(child.lua_get("type(_G.noNeckPainLoaded)"), "boolean")
+    eq(child.lua_get("type(_G.NoNeckPainLoaded)"), "boolean")
 end
 
 ----------------- setup
@@ -36,7 +36,8 @@ T["setup()"]["sets exposed methods and config"] = function()
     eq(child.lua_get("type(_G.NoNeckPain)"), "table")
 
     -- public methods
-    eq(child.lua_get("type(_G.NoNeckPain.start)"), "function")
+    eq(child.lua_get("type(_G.NoNeckPain.toggle)"), "function")
+    eq(child.lua_get("type(_G.NoNeckPain.enable)"), "function")
     eq(child.lua_get("type(_G.NoNeckPain.setup)"), "function")
 
     -- config
@@ -63,12 +64,12 @@ T["setup()"]["overrides default values"] = function()
     expect_config("leftPaddingOnly", true)
 end
 
------------------ start
+----------------- enable
 
-T["start()"] = new_set()
+T["enable()"] = new_set()
 
-T["start()"]["sets state and internal methods"] = function()
-    child.lua([[M = require('no-neck-pain').start()]])
+T["enable()"]["sets state and internal methods"] = function()
+    child.lua([[M = require('no-neck-pain').enable()]])
 
     -- internal methods
     eq(child.lua_get("type(_G.NoNeckPain.internal.toggle)"), "function")
@@ -103,6 +104,77 @@ T["start()"]["sets state and internal methods"] = function()
     expect_state("win.curr", 1000)
     expect_state("win.left", 1001)
     expect_state("win.right", 1002)
+    expect_state("win.split", vim.NIL)
+end
+
+----------------- toggle
+
+T["toggle()"] = new_set()
+
+T["toggle()"]["sets state and internal methods"] = function()
+    child.lua([[M = require('no-neck-pain').toggle()]])
+
+    -- internal methods
+    eq(child.lua_get("type(_G.NoNeckPain.internal.toggle)"), "function")
+    eq(child.lua_get("type(_G.NoNeckPain.internal.enable)"), "function")
+    eq(child.lua_get("type(_G.NoNeckPain.internal.disable)"), "function")
+
+    -- state
+    eq(child.lua_get("type(_G.NoNeckPain.state)"), "table")
+
+    local expect_state = function(field, value)
+        eq(child.lua_get("_G.NoNeckPain.state." .. field), value)
+    end
+
+    -- status
+    expect_state("enabled", true)
+
+    -- opts for side buffers
+    expect_state("win.opts.bo.buftype", "nofile")
+    expect_state("win.opts.bo.bufhidden", "hide")
+    expect_state("win.opts.bo.modifiable", false)
+    expect_state("win.opts.bo.buflisted", false)
+    expect_state("win.opts.bo.swapfile", false)
+
+    expect_state("win.opts.wo.cursorline", false)
+    expect_state("win.opts.wo.cursorcolumn", false)
+    expect_state("win.opts.wo.number", false)
+    expect_state("win.opts.wo.relativenumber", false)
+    expect_state("win.opts.wo.foldenable", false)
+    expect_state("win.opts.wo.list", false)
+
+    -- stored window ids
+    expect_state("win.curr", 1000)
+    expect_state("win.left", 1001)
+    expect_state("win.right", 1002)
+    expect_state("win.split", vim.NIL)
+end
+
+T["toggle()"]["resets everything once toggled again"] = function()
+    child.lua([[M = require('no-neck-pain').toggle()]])
+
+    local expect_state = function(field, value)
+        eq(child.lua_get("_G.NoNeckPain.state." .. field), value)
+    end
+
+    -- status
+    expect_state("enabled", true)
+
+    -- stored window ids
+    expect_state("win.curr", 1000)
+    expect_state("win.left", 1001)
+    expect_state("win.right", 1002)
+    expect_state("win.split", vim.NIL)
+
+    child.lua([[require('no-neck-pain').toggle()]])
+
+    -- status
+    expect_state("enabled", false)
+
+    -- stored window ids
+    expect_state("win.curr", vim.NIL)
+    expect_state("win.left", vim.NIL)
+    expect_state("win.right", vim.NIL)
     expect_state("win.split", vim.NIL)
 end
 


### PR DESCRIPTION
- [x] partially fixes https://github.com/shortcuts/no-neck-pain.nvim/issues/17
- [x] closes https://github.com/shortcuts/no-neck-pain.nvim/issues/22 

It is not possible for NNP to support `dashboard-nvim`, as it does not support split/vsplit buffers. We can however provide better snippets on how to automate the NNP enablement with dashboard support. 