### PR TITLE
chore: make README usage more straight forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,45 +36,14 @@ Plug "shortcuts/no-neck-pain.nvim" , { "tag": "*" }
 Plug "shortcuts/no-neck-pain.nvim"
 ```
 
-## Setup
+## Usage
+
+Simply get started by calling the `setup` method.
+
+> If you wish to tweak the plugin, either call `:h NoNeckPain.options`, or [take a look at the documentation!](https://github.com/shortcuts/no-neck-pain.nvim/blob/main/doc/no-neck-pain.txt#L4)
 
 ```lua
--- values below are the default
-require("no-neck-pain").setup({
-    -- the width of the focused buffer when enabling NNP.
-    -- If the available window size is less than `width`, the buffer will take the whole screen.
-    width = 100,
-    -- prints useful logs about what event are triggered, and reasons actions are executed.
-    debug = false,
-    -- options related to the side buffers
-    buffers = {
-        -- if set to `false`, the `left` padding buffer won't be created.
-        left = true,
-        -- if set to `false`, the `right` padding buffer won't be created.
-        right = true,
-        -- if set to `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
-        showName = false,
-        -- the buffer options when creating the buffer
-        options = {
-            bo = {
-                filetype = "no-neck-pain",
-                buftype = "nofile",
-                bufhidden = "hide",
-                modifiable = false,
-                buflisted = false,
-                swapfile = false,
-            },
-            wo = {
-                cursorline = false,
-                cursorcolumn = false,
-                number = false,
-                relativenumber = false,
-                foldenable = false,
-                list = false,
-            },
-        },
-    },
-})
+require("no-neck-pain").setup()
 ```
 
 ## Commands

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -22,7 +22,7 @@ Default values:
           showName = false,
           -- the buffer options when creating the buffer
           options = {
-              -- vim.bo buffer scoped options
+              -- buffer-scoped options, below are the default values, but any `vim.bo` options are valid.
               bo = {
                   filetype = "no-neck-pain",
                   buftype = "nofile",
@@ -31,7 +31,7 @@ Default values:
                   buflisted = false,
                   swapfile = false,
               },
-              -- vim.wo window scoped options
+              -- window-scoped options, below are the default values, but any `vim.wo` options are valid.
               wo = {
                   cursorline = false,
                   cursorcolumn = false,

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -20,7 +20,7 @@ NoNeckPain.options = {
         showName = false,
         -- the buffer options when creating the buffer
         options = {
-            -- vim.bo buffer scoped options
+            -- buffer-scoped options, below are the default values, but any `vim.bo` options are valid.
             bo = {
                 filetype = "no-neck-pain",
                 buftype = "nofile",
@@ -29,7 +29,7 @@ NoNeckPain.options = {
                 buflisted = false,
                 swapfile = false,
             },
-            -- vim.wo window scoped options
+            -- window-scoped options, below are the default values, but any `vim.wo` options are valid.
             wo = {
                 cursorline = false,
                 cursorcolumn = false,


### PR DESCRIPTION
- [x] prevent many definitions of the options
- [x] link to doc