### PR TITLE
feat: add `disableOnLastBuffer` option

### DIFF
--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -12,6 +12,8 @@ Default values:
       width = 100,
       -- prints useful logs about what event are triggered, and reasons actions are executed.
       debug = false,
+      -- disable NNP if the last valid buffer in the list has been closed.
+      disableOnLastBuffer = false,
       -- options related to the side buffers
       buffers = {
           -- if set to `false`, the `left` padding buffer won't be created.

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -10,6 +10,8 @@ NoNeckPain.options = {
     width = 100,
     -- prints useful logs about what event are triggered, and reasons actions are executed.
     debug = false,
+    -- disable NNP if the last valid buffer in the list has been closed.
+    disableOnLastBuffer = false,
     -- options related to the side buffers
     buffers = {
         -- if set to `false`, the `left` padding buffer won't be created.

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -214,7 +214,21 @@ function NoNeckPain.enable()
                     return NoNeckPain.disable()
                 end
 
-                if util.tsize(buffers) > 1 then
+                local size = util.nbBuffersWithoutNNP(NoNeckPain.state.win)
+
+                if
+                    options.disableOnLastBuffer
+                    and size == 0
+                    and vim.api.nvim_buf_get_option(0, "buftype") == ""
+                    and vim.api.nvim_buf_get_option(0, "filetype") == ""
+                    and vim.api.nvim_buf_get_option(0, "bufhidden") == "wipe"
+                then
+                    util.print(
+                        "WinClosed, BufDelete: found last `wipe` buffer in list, disabling..."
+                    )
+
+                    return NoNeckPain.disable()
+                elseif util.tsize(buffers) > 1 then
                     return util.print(
                         "WinClosed, BufDelete: more than one buffer left, no killed split to handle"
                     )

--- a/lua/no-neck-pain/util.lua
+++ b/lua/no-neck-pain/util.lua
@@ -42,6 +42,24 @@ function Util.tsize(map)
     return count
 end
 
+-- returns the number of buffers without the NNP one.
+function Util.nbBuffersWithoutNNP(nnpBuffers)
+    local buffers = vim.api.nvim_list_wins()
+    local size = 0
+
+    for _, buffer in pairs(buffers) do
+        if
+            buffer ~= nnpBuffers.curr
+            and buffer ~= nnpBuffers.left
+            and buffer ~= nnpBuffers.right
+        then
+            size = size + 1
+        end
+    end
+
+    return size
+end
+
 -- returns true if the given `map` contains the element.
 function Util.contains(map, el)
     for _, v in pairs(map) do

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -47,6 +47,7 @@ T["setup()"]["sets exposed methods and config"] = function()
 
     expect_config("width", 100)
     expect_config("debug", false)
+    expect_config("disableOnLastBuffer", false)
     expect_config("buffers.left", true)
     expect_config("buffers.right", true)
     expect_config("buffers.showName", false)
@@ -70,6 +71,7 @@ T["setup()"]["overrides default values"] = function()
     child.lua([[M = require('no-neck-pain').setup({
         width = 42,
         debug = true,
+        disableOnLastBuffer = true,
         buffers = {
             left = false,
             right = false,
@@ -101,6 +103,7 @@ T["setup()"]["overrides default values"] = function()
 
     expect_config("width", 42)
     expect_config("debug", true)
+    expect_config("disableOnLastBuffer", true)
     expect_config("buffers.left", false)
     expect_config("buffers.right", false)
     expect_config("buffers.showName", true)


### PR DESCRIPTION
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/20

Provide an option to disable NNP if the last buffer has been closed, the check is ugly but should be refactored in https://github.com/shortcuts/no-neck-pain.nvim/issues/35