### PR TITLE
feat: add `killAllBuffersOnDisable` option

### DIFF
--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -7,24 +7,26 @@ Plugin config
 Default values:
 >
   NoNeckPain.options = {
-      -- the width of the focused buffer when enabling NNP.
+      -- The width of the focused buffer when enabling NNP.
       -- If the available window size is less than `width`, the buffer will take the whole screen.
       width = 100,
-      -- prints useful logs about what event are triggered, and reasons actions are executed.
+      -- Prints useful logs about what event are triggered, and reasons actions are executed.
       debug = false,
-      -- disable NNP if the last valid buffer in the list has been closed.
+      -- Disables NNP if the last valid buffer in the list has been closed.
       disableOnLastBuffer = false,
-      -- options related to the side buffers
+      -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
+      killAllBuffersOnDisable = false,
+      -- Options related to the side buffers
       buffers = {
-          -- if set to `false`, the `left` padding buffer won't be created.
+          -- When `false`, the `left` padding buffer won't be created.
           left = true,
-          -- if set to `false`, the `right` padding buffer won't be created.
+          -- When `false`, the `right` padding buffer won't be created.
           right = true,
-          -- if set to `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
+          -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
           showName = false,
-          -- the buffer options when creating the buffer
+          -- The buffer options when creating the buffer
           options = {
-              -- buffer-scoped options, below are the default values, but any `vim.bo` options are valid.
+              -- Buffer-scoped options, below are the default values, but any `vim.bo` options are valid and will be forwarded to the buffer creation.
               bo = {
                   filetype = "no-neck-pain",
                   buftype = "nofile",
@@ -33,7 +35,7 @@ Default values:
                   buflisted = false,
                   swapfile = false,
               },
-              -- window-scoped options, below are the default values, but any `vim.wo` options are valid.
+              -- Window-scoped options, below are the default values, but any `vim.wo` options are valid and will be forwarded to the buffer creation.
               wo = {
                   cursorline = false,
                   cursorcolumn = false,

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -5,24 +5,26 @@ local NoNeckPain = {}
 --- Default values:
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
 NoNeckPain.options = {
-    -- the width of the focused buffer when enabling NNP.
+    -- The width of the focused buffer when enabling NNP.
     -- If the available window size is less than `width`, the buffer will take the whole screen.
     width = 100,
-    -- prints useful logs about what event are triggered, and reasons actions are executed.
+    -- Prints useful logs about what event are triggered, and reasons actions are executed.
     debug = false,
-    -- disable NNP if the last valid buffer in the list has been closed.
+    -- Disables NNP if the last valid buffer in the list has been closed.
     disableOnLastBuffer = false,
-    -- options related to the side buffers
+    -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
+    killAllBuffersOnDisable = false,
+    -- Options related to the side buffers
     buffers = {
-        -- if set to `false`, the `left` padding buffer won't be created.
+        -- When `false`, the `left` padding buffer won't be created.
         left = true,
-        -- if set to `false`, the `right` padding buffer won't be created.
+        -- When `false`, the `right` padding buffer won't be created.
         right = true,
-        -- if set to `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
+        -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         showName = false,
-        -- the buffer options when creating the buffer
+        -- The buffer options when creating the buffer
         options = {
-            -- buffer-scoped options, below are the default values, but any `vim.bo` options are valid.
+            -- Buffer-scoped options, below are the default values, but any `vim.bo` options are valid and will be forwarded to the buffer creation.
             bo = {
                 filetype = "no-neck-pain",
                 buftype = "nofile",
@@ -31,7 +33,7 @@ NoNeckPain.options = {
                 buflisted = false,
                 swapfile = false,
             },
-            -- window-scoped options, below are the default values, but any `vim.wo` options are valid.
+            -- Window-scoped options, below are the default values, but any `vim.wo` options are valid and will be forwarded to the buffer creation.
             wo = {
                 cursorline = false,
                 cursorcolumn = false,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -303,7 +303,9 @@ function NoNeckPain.disable()
         vim.fn.win_gotoid(NoNeckPain.state.win.curr)
     end
 
-    vim.cmd("only")
+    if options.killAllBuffersOnDisable then
+        vim.cmd("only")
+    end
 
     NoNeckPain.state = {
         enabled = false,

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -48,6 +48,7 @@ T["setup()"]["sets exposed methods and config"] = function()
     expect_config("width", 100)
     expect_config("debug", false)
     expect_config("disableOnLastBuffer", false)
+    expect_config("killAllBuffersOnDisable", false)
     expect_config("buffers.left", true)
     expect_config("buffers.right", true)
     expect_config("buffers.showName", false)
@@ -72,6 +73,7 @@ T["setup()"]["overrides default values"] = function()
         width = 42,
         debug = true,
         disableOnLastBuffer = true,
+        killAllBuffersOnDisable = true,
         buffers = {
             left = false,
             right = false,
@@ -104,6 +106,7 @@ T["setup()"]["overrides default values"] = function()
     expect_config("width", 42)
     expect_config("debug", true)
     expect_config("disableOnLastBuffer", true)
+    expect_config("killAllBuffersOnDisable", true)
     expect_config("buffers.left", false)
     expect_config("buffers.right", false)
     expect_config("buffers.showName", true)


### PR DESCRIPTION
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/36

we previously closed all buffers except the main one when disabling NNP, it's unexpected but worth leaving it configurable.