### PR TITLE
fix: side buffers not closing when `killAllBuffersOnDisable` is false

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -294,6 +294,11 @@ function NoNeckPain.disable()
         clear = true,
     })
 
+    if not options.killAllBuffersOnDisable then
+        util.close(NoNeckPain.state.win.left)
+        util.close(NoNeckPain.state.win.right)
+    end
+
     -- shutdowns gracefully by focusing the stored `curr` buffer, if possible
     if
         NoNeckPain.state.win.curr ~= nil

--- a/lua/no-neck-pain/util.lua
+++ b/lua/no-neck-pain/util.lua
@@ -105,4 +105,11 @@ function Util.isRelativeWindow(scope, win)
     end
 end
 
+-- closes a window if it exists and is valid.
+function Util.close(win)
+    if win ~= nil and vim.api.nvim_win_is_valid(win) then
+        vim.api.nvim_win_close(win, true)
+    end
+end
+
 return Util


### PR DESCRIPTION
follow up of https://github.com/shortcuts/no-neck-pain.nvim/pull/41

side buffers were killed by the `only` command, but left open with `killAllBuffersOnDisable` as `false`.