### PR TITLE
feat: support same buffer splits

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -128,44 +128,44 @@ function NoNeckPain.enable()
         desc = "Resizes side windows after shell has been resized",
     })
 
-    vim.api.nvim_create_autocmd({ "BufWinEnter" }, {
+    vim.api.nvim_create_autocmd({ "WinEnter" }, {
         callback = function()
             vim.schedule(function()
                 if
                     NoNeckPain.state.win.split ~= nil
                     -- we don't want close action on float window to impact NNP
-                    or W.isRelativeWindow("BufWinEnter")
+                    or W.isRelativeWindow("WinEnter")
                 then
                     return D.print(
-                        "BufWinEnter: already in split view or float window detected, nothing more to do"
+                        "WinEnter: already in split view or float window detected, nothing more to do"
                     )
                 end
 
-                local buffers, total = W.bufferListWithoutNNP("BufWinEnter", NoNeckPain.state.win)
+                local buffers, total = W.bufferListWithoutNNP("WinEnter", NoNeckPain.state.win)
                 local focusedWin = vim.api.nvim_get_current_win()
 
                 if total == 0 or not M.contains(buffers, focusedWin) then
-                    return D.print("BufWinEnter: no valid buffers to handle, no split to handle")
+                    return D.print("WinEnter: no valid buffers to handle, no split to handle")
                 end
 
-                D.print("BufWinEnter: found ", total, " remaining valid buffers")
+                D.print("WinEnter: found ", total, " remaining valid buffers")
 
                 -- start by saving the split, because steps below will trigger `WinClosed`
                 NoNeckPain.state.win.split = focusedWin
 
-                local ok = W.close("BufWinEnter", NoNeckPain.state.win.left)
+                local ok = W.close("WinEnter", NoNeckPain.state.win.left)
                 if ok then
                     NoNeckPain.state.win.left = nil
                 end
 
-                ok = W.close("BufWinEnter", NoNeckPain.state.win.right)
+                ok = W.close("WinEnter", NoNeckPain.state.win.right)
                 if ok then
                     NoNeckPain.state.win.right = nil
                 end
             end)
         end,
         group = "NoNeckPain",
-        desc = "BufWinEnter covers the split/vsplit management",
+        desc = "WinEnter covers the split/vsplit management",
     })
 
     vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {

--- a/tests/test_side_buffers.lua
+++ b/tests/test_side_buffers.lua
@@ -71,4 +71,31 @@ T["auto command"]["hides side buffers after split"] = function()
     expect_state("win.right", 1005)
 end
 
+T["auto command"]["hides side buffers after vsplit"] = function()
+    child.lua([[
+        M = require('no-neck-pain').enable()
+    ]])
+
+    local expect_state = function(field, value)
+        eq(child.lua_get("_G.NoNeckPain.state." .. field), value)
+    end
+
+    -- At start 1 win automatically sorrounded with side buffers
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    expect_state("win.left", 1001)
+    expect_state("win.right", 1002)
+
+    -- Opening vsplit hides side buffers
+    child.cmd("vsplit")
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1003, 1000 })
+    expect_state("win.left", vim.NIL)
+    expect_state("win.right", vim.NIL)
+
+    -- Closing vsplit and returning to last window opens side buffers again
+    child.cmd("close")
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1000, 1005 })
+    expect_state("win.left", 1004)
+    expect_state("win.right", 1005)
+end
+
 return T

--- a/tests/test_side_buffers.lua
+++ b/tests/test_side_buffers.lua
@@ -42,4 +42,33 @@ T["curr buffer"]["have the default width from the config"] = function()
     eq(child.lua_get("vim.api.nvim_win_get_width(_G.NoNeckPain.state.win.curr)"), 48)
 end
 
+T["auto command"] = new_set()
+
+T["auto command"]["hides side buffers after split"] = function()
+    child.lua([[
+        M = require('no-neck-pain').enable()
+    ]])
+
+    local expect_state = function(field, value)
+        eq(child.lua_get("_G.NoNeckPain.state." .. field), value)
+    end
+
+    -- At start 1 win automatically sorrounded with side buffers
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    expect_state("win.left", 1001)
+    expect_state("win.right", 1002)
+
+    -- Opening split hides side buffers
+    child.cmd("split")
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1003, 1000 })
+    expect_state("win.left", vim.NIL)
+    expect_state("win.right", vim.NIL)
+
+    -- Closing split and returning to last window opens side buffers again
+    child.cmd("close")
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1000, 1005 })
+    expect_state("win.left", 1004)
+    expect_state("win.right", 1005)
+end
+
 return T


### PR DESCRIPTION
Replacing the event `BufWinEnter` with `WinEnter` will add support for a split command, which opens the same buffer in a new window. Now, when you do `<c-w>v` or `<c-w>s` it will hide side buffers as well.