### PR TITLE
feat: allow customizing bg color of side buffers

### DIFF
--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -16,15 +16,29 @@ Default values:
       disableOnLastBuffer = false,
       -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
       killAllBuffersOnDisable = false,
-      -- Options related to the side buffers
+      -- Options related to the side buffers.
       buffers = {
+          -- The background options of the side buffer(s).
+          background = {
+              -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+              -- popular theme are supported by their name:
+              -- - catpuccin-frappe
+              -- - catpuccin-latte
+              -- - catpuccin-macchiato
+              -- - catpuccin-mocha
+              -- - tokyonight-day
+              -- - tokyonight-moon
+              -- - tokyonight-night
+              -- - tokyonight-storm
+              colorCode = nil,
+          },
           -- When `false`, the `left` padding buffer won't be created.
           left = true,
           -- When `false`, the `right` padding buffer won't be created.
           right = true,
           -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
           showName = false,
-          -- The buffer options when creating the buffer
+          -- The buffer options when creating the buffer.
           options = {
               -- Buffer-scoped options, below are the default values, but any `vim.bo` options are valid and will be forwarded to the buffer creation.
               bo = {
@@ -52,14 +66,14 @@ Default values:
 
 ------------------------------------------------------------------------------
                                                             *NoNeckPain.setup()*
-                          `NoNeckPain.setup`({config})
+                         `NoNeckPain.setup`({options})
 Define your no-neck-pain setup.
 
 Parameters~
-{config} `(table)` Module config table. See |NoNeckPain.config|.
+{options} `(table)` Module config table. See |NoNeckPain.config|.
 
 Usage~
-`require("no-neck-pain").setup()` (add `{}` with your `config` table)
+`require("no-neck-pain").setup()` (add `{}` with your |NoNeckPain.config| table)
 
 
 ==============================================================================

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -22,10 +22,10 @@ Default values:
           background = {
               -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
               -- popular theme are supported by their name:
-              -- - catpuccin-frappe
-              -- - catpuccin-latte
-              -- - catpuccin-macchiato
-              -- - catpuccin-mocha
+              -- - catppuccin-frappe
+              -- - catppuccin-latte
+              -- - catppuccin-macchiato
+              -- - catppuccin-mocha
               -- - tokyonight-day
               -- - tokyonight-moon
               -- - tokyonight-night

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -1,3 +1,5 @@
+local C = require("no-neck-pain.util.color")
+
 local NoNeckPain = {}
 
 --- Plugin config
@@ -14,15 +16,29 @@ NoNeckPain.options = {
     disableOnLastBuffer = false,
     -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
     killAllBuffersOnDisable = false,
-    -- Options related to the side buffers
+    -- Options related to the side buffers.
     buffers = {
+        -- The background options of the side buffer(s).
+        background = {
+            -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+            -- popular theme are supported by their name:
+            -- - catppuccin-frappe
+            -- - catppuccin-latte
+            -- - catppuccin-macchiato
+            -- - catppuccin-mocha
+            -- - tokyonight-day
+            -- - tokyonight-moon
+            -- - tokyonight-night
+            -- - tokyonight-storm
+            colorCode = nil,
+        },
         -- When `false`, the `left` padding buffer won't be created.
         left = true,
         -- When `false`, the `right` padding buffer won't be created.
         right = true,
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         showName = false,
-        -- The buffer options when creating the buffer
+        -- The buffer options when creating the buffer.
         options = {
             -- Buffer-scoped options, below are the default values, but any `vim.bo` options are valid and will be forwarded to the buffer creation.
             bo = {
@@ -48,11 +64,15 @@ NoNeckPain.options = {
 
 --- Define your no-neck-pain setup.
 ---
----@param config table Module config table. See |NoNeckPain.config|.
+---@param options table Module config table. See |NoNeckPain.config|.
 ---
----@usage `require("no-neck-pain").setup()` (add `{}` with your `config` table)
-function NoNeckPain.setup(config)
-    NoNeckPain.options = vim.tbl_deep_extend("keep", config or {}, NoNeckPain.options)
+---@usage `require("no-neck-pain").setup()` (add `{}` with your |NoNeckPain.config| table)
+function NoNeckPain.setup(options)
+    options = vim.tbl_deep_extend("keep", options or {}, NoNeckPain.options)
+    options.buffers.background.colorCode =
+        C.matchIntegrationToHexCode(options.buffers.background.colorCode)
+
+    NoNeckPain.options = options
 
     return NoNeckPain.options
 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -65,7 +65,7 @@ local function createBuf(name, cmd, padding, moveTo)
     vim.cmd(moveTo)
 
     if options.buffers.background.colorCode ~= nil then
-        D.print("CreateWin: setting `colorCode` for side buffers")
+        D.print("CreateWin: setting `colorCode` for buffer"..id)
 
         C.init(id, options.buffers.background.colorCode)
     end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -100,33 +100,11 @@ local function createWin(action)
             NoNeckPain.state.namespaceID = C.init(options.buffers.background.colorCode)
 
             if NoNeckPain.state.win.left ~= nil then
-                if vim.fn.has("nvim-0.8") then
-                    vim.api.nvim_win_set_hl_ns(
-                        NoNeckPain.state.win.left,
-                        NoNeckPain.state.namespaceID
-                    )
-                else
-                    vim.api.nvim_win_set_option(
-                        NoNeckPain.state.win.left,
-                        "winhl",
-                        "VertSplit:NoNeckPain,WinSeparator:NoNeckPain,EndOfBuffer:NoNeckPain,NormalNC:NoNeckPain,Normal:NoNeckPain"
-                    )
-                end
+                vim.api.nvim_win_set_hl_ns(NoNeckPain.state.win.left, NoNeckPain.state.namespaceID)
             end
 
             if NoNeckPain.state.win.right ~= nil then
-                if vim.fn.has("nvim-0.7") then
-                    vim.api.nvim_win_set_hl_ns(
-                        NoNeckPain.state.win.right,
-                        NoNeckPain.state.namespaceID
-                    )
-                else
-                    vim.api.nvim_win_set_option(
-                        NoNeckPain.state.win.right,
-                        "winhl",
-                        "VertSplit:NoNeckPain,WinSeparator:NoNeckPain,EndOfBuffer:NoNeckPain,NormalNC:NoNeckPain,Normal:NoNeckPain"
-                    )
-                end
+                vim.api.nvim_win_set_hl_ns(NoNeckPain.state.win.right, NoNeckPain.state.namespaceID)
             end
         end
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -95,14 +95,38 @@ local function createWin(action)
         vim.o.splitbelow, vim.o.splitright = splitbelow, splitright
 
         if options.buffers.background.colorCode ~= nil then
+            D.print("CreateWin: setting `colorCode` for side buffers")
+
             NoNeckPain.state.namespaceID = C.init(options.buffers.background.colorCode)
 
             if NoNeckPain.state.win.left ~= nil then
-                vim.api.nvim_win_set_hl_ns(NoNeckPain.state.win.left, NoNeckPain.state.namespaceID)
+                if vim.fn.has("nvim-0.8") then
+                    vim.api.nvim_win_set_hl_ns(
+                        NoNeckPain.state.win.left,
+                        NoNeckPain.state.namespaceID
+                    )
+                else
+                    vim.api.nvim_win_set_option(
+                        NoNeckPain.state.win.left,
+                        "winhl",
+                        "VertSplit:NoNeckPain,WinSeparator:NoNeckPain,EndOfBuffer:NoNeckPain,NormalNC:NoNeckPain,Normal:NoNeckPain"
+                    )
+                end
             end
 
             if NoNeckPain.state.win.right ~= nil then
-                vim.api.nvim_win_set_hl_ns(NoNeckPain.state.win.right, NoNeckPain.state.namespaceID)
+                if vim.fn.has("nvim-0.7") then
+                    vim.api.nvim_win_set_hl_ns(
+                        NoNeckPain.state.win.right,
+                        NoNeckPain.state.namespaceID
+                    )
+                else
+                    vim.api.nvim_win_set_option(
+                        NoNeckPain.state.win.right,
+                        "winhl",
+                        "VertSplit:NoNeckPain,WinSeparator:NoNeckPain,EndOfBuffer:NoNeckPain,NormalNC:NoNeckPain,Normal:NoNeckPain"
+                    )
+                end
             end
         end
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -9,7 +9,6 @@ local NoNeckPain = {
     state = {
         enabled = false,
         augroup = nil,
-        namespaceID = nil,
         win = {
             curr = nil,
             left = nil,
@@ -65,6 +64,12 @@ local function createBuf(name, cmd, padding, moveTo)
 
     vim.cmd(moveTo)
 
+    if options.buffers.background.colorCode ~= nil then
+        D.print("CreateWin: setting `colorCode` for side buffers")
+
+        C.init(id, options.buffers.background.colorCode)
+    end
+
     return id
 end
 
@@ -93,20 +98,6 @@ local function createWin(action)
         end
 
         vim.o.splitbelow, vim.o.splitright = splitbelow, splitright
-
-        if options.buffers.background.colorCode ~= nil then
-            D.print("CreateWin: setting `colorCode` for side buffers")
-
-            NoNeckPain.state.namespaceID = C.init(options.buffers.background.colorCode)
-
-            if NoNeckPain.state.win.left ~= nil then
-                vim.api.nvim_win_set_hl_ns(NoNeckPain.state.win.left, NoNeckPain.state.namespaceID)
-            end
-
-            if NoNeckPain.state.win.right ~= nil then
-                vim.api.nvim_win_set_hl_ns(NoNeckPain.state.win.right, NoNeckPain.state.namespaceID)
-            end
-        end
 
         return
     end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -65,7 +65,7 @@ local function createBuf(name, cmd, padding, moveTo)
     vim.cmd(moveTo)
 
     if options.buffers.background.colorCode ~= nil then
-        D.print("CreateWin: setting `colorCode` for buffer"..id)
+        D.print("CreateWin: setting `colorCode` for buffer" .. id)
 
         C.init(id, options.buffers.background.colorCode)
     end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -1,13 +1,15 @@
 local options = require("no-neck-pain.config").options
+local C = require("no-neck-pain.util.color")
 local D = require("no-neck-pain.util.debug")
-local W = require("no-neck-pain.util.win")
 local M = require("no-neck-pain.util.map")
+local W = require("no-neck-pain.util.win")
 local SIDES = { "left", "right" }
 
 local NoNeckPain = {
     state = {
         enabled = false,
         augroup = nil,
+        namespaceID = nil,
         win = {
             curr = nil,
             left = nil,
@@ -91,6 +93,18 @@ local function createWin(action)
         end
 
         vim.o.splitbelow, vim.o.splitright = splitbelow, splitright
+
+        if options.buffers.background.colorCode ~= nil then
+            NoNeckPain.state.namespaceID = C.init(options.buffers.background.colorCode)
+
+            if NoNeckPain.state.win.left ~= nil then
+                vim.api.nvim_win_set_hl_ns(NoNeckPain.state.win.left, NoNeckPain.state.namespaceID)
+            end
+
+            if NoNeckPain.state.win.right ~= nil then
+                vim.api.nvim_win_set_hl_ns(NoNeckPain.state.win.right, NoNeckPain.state.namespaceID)
+            end
+        end
 
         return
     end

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -1,0 +1,55 @@
+local C = {}
+
+-- tries to match the provided `colorCode` to an integration name, defaults to the provided string if not successful.
+function C.matchIntegrationToHexCode(colorCode)
+    if colorCode == nil then
+        return colorCode
+    end
+
+    if colorCode == "catppuccin-frappe" then
+        colorCode = "#292C3C"
+    elseif colorCode == "catppuccin-latte" then
+        colorCode = "#E6E9EF"
+    elseif colorCode == "catppuccin-macchiato" then
+        colorCode = "#1E2030"
+    elseif colorCode == "catppuccin-mocha" then
+        colorCode = "#181825"
+    elseif colorCode == "tokyonight-day" then
+        colorCode = "#16161e"
+    elseif colorCode == "tokyonight-moon" then
+        colorCode = "#1e2030"
+    elseif colorCode == "tokyonight-night" then
+        colorCode = "#16161e"
+    elseif colorCode == "tokyonight-storm" then
+        colorCode = "#1f2335"
+    end
+
+    return colorCode
+end
+
+-- creates a namespace for `no-neck-pain`, and assign the provided `colorCode` to the side buffers.
+function C.init(colorCode)
+    local namespaceID = vim.api.nvim_create_namespace("no-neck-pain")
+
+    vim.api.nvim_set_hl(namespaceID, "Normal", {
+        bg = colorCode,
+    })
+    vim.api.nvim_set_hl(namespaceID, "NormalNC", {
+        bg = colorCode,
+    })
+    vim.api.nvim_set_hl(namespaceID, "EndOfBuffer", {
+        fg = colorCode,
+    })
+    vim.api.nvim_set_hl(namespaceID, "WinSeparator", {
+        bg = colorCode,
+        fg = colorCode,
+    })
+    vim.api.nvim_set_hl(namespaceID, "VertSplit", {
+        bg = colorCode,
+        fg = colorCode,
+    })
+
+    return namespaceID
+end
+
+return C

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -29,13 +29,16 @@ end
 
 -- creates a namespace for `no-neck-pain`, and assign the provided `colorCode` to the side buffers.
 function C.init(colorCode)
-    local namespaceID = vim.api.nvim_create_namespace("no-neck-pain")
+    local namespaceID = vim.api.nvim_create_namespace("NoNeckPain")
 
     vim.api.nvim_set_hl(namespaceID, "Normal", {
         bg = colorCode,
     })
     vim.api.nvim_set_hl(namespaceID, "NormalNC", {
         bg = colorCode,
+    })
+    vim.api.nvim_set_hl(namespaceID, "NonText", {
+        fg = colorCode,
     })
     vim.api.nvim_set_hl(namespaceID, "EndOfBuffer", {
         fg = colorCode,

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -28,31 +28,31 @@ function C.matchIntegrationToHexCode(colorCode)
 end
 
 -- creates a namespace for `no-neck-pain`, and assign the provided `colorCode` to the side buffers.
-function C.init(colorCode)
-    local namespaceID = vim.api.nvim_create_namespace("NoNeckPain")
-
-    vim.api.nvim_set_hl(namespaceID, "Normal", {
-        bg = colorCode,
-    })
-    vim.api.nvim_set_hl(namespaceID, "NormalNC", {
-        bg = colorCode,
-    })
-    vim.api.nvim_set_hl(namespaceID, "NonText", {
-        fg = colorCode,
-    })
-    vim.api.nvim_set_hl(namespaceID, "EndOfBuffer", {
-        fg = colorCode,
-    })
-    vim.api.nvim_set_hl(namespaceID, "WinSeparator", {
-        bg = colorCode,
-        fg = colorCode,
-    })
-    vim.api.nvim_set_hl(namespaceID, "VertSplit", {
-        bg = colorCode,
-        fg = colorCode,
-    })
-
-    return namespaceID
+function C.init(win, colorCode)
+    local groupName = "NoNeckPain"
+    vim.cmd(
+        string.format(
+            [[highlight %s guifg=%s guibg=%s]],
+            groupName,
+            colorCode,
+            colorCode,
+            colorCode,
+            colorCode
+        )
+    )
+    vim.api.nvim_win_set_option(
+        win,
+        "winhl",
+        string.format(
+            "Normal:%s,NormalNC:%s,NonText:%s,EndOfBuffer:%s,WinSeparator:%s,VertSplit:%s",
+            groupName,
+            groupName,
+            groupName,
+            groupName,
+            groupName,
+            groupName
+        )
+    )
 end
 
 return C

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -27,7 +27,7 @@ function C.matchIntegrationToHexCode(colorCode)
     return colorCode
 end
 
--- creates a namespace for `no-neck-pain`, and assign the provided `colorCode` to the side buffers.
+-- creates an highlight group `NoNeckPain` with the given `colorCode` and assign it to the side buffer of the given `id`.
 function C.init(win, colorCode)
     local groupName = "NoNeckPain"
     vim.cmd(

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -238,7 +238,6 @@ T["enable()"]["sets state and internal methods"] = function()
     -- status
     expect_state("enabled", true)
     expect_state("augroup", 15)
-    expect_state("namespaceID", vim.NIL)
 
     -- stored window ids
     expect_state("win.curr", 1000)
@@ -267,29 +266,12 @@ T["toggle()"]["sets state and internal methods"] = function()
     -- status
     expect_state("enabled", true)
     expect_state("augroup", 15)
-    expect_state("namespaceID", vim.NIL)
 
     -- stored window ids
     expect_state("win.curr", 1000)
     expect_state("win.left", 1001)
     expect_state("win.right", 1002)
     expect_state("win.split", vim.NIL)
-end
-
-T["toggle()"]["set namespaceID when colorCode is defined"] = function()
-    child.lua([[
-        local NNP = require('no-neck-pain')
-        NNP.setup({
-            buffers = {
-                background = {
-                    colorCode = "#2E1E2E",
-                },
-            },
-        })
-        NNP.toggle()
-    ]])
-
-    eq(child.lua_get("_G.NoNeckPain.state.namespaceID"), 1)
 end
 
 T["toggle()"]["resets everything once toggled again"] = function()

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -42,6 +42,10 @@ T["setup()"]["sets exposed methods and config"] = function()
     eq(child.lua_get("type(_G.NoNeckPain.config)"), "table")
     eq(child.lua_get("type(_G.NoNeckPain.config.options)"), "table")
     eq(child.lua_get("type(_G.NoNeckPain.config.options.buffers)"), "table")
+    eq(child.lua_get("type(_G.NoNeckPain.config.options.buffers.background)"), "table")
+    eq(child.lua_get("type(_G.NoNeckPain.config.options.buffers.options)"), "table")
+    eq(child.lua_get("type(_G.NoNeckPain.config.options.buffers.options.bo)"), "table")
+    eq(child.lua_get("type(_G.NoNeckPain.config.options.buffers.options.wo)"), "table")
 
     local expect_config = function(field, value)
         eq(child.lua_get("_G.NoNeckPain.config.options." .. field), value)
@@ -54,6 +58,8 @@ T["setup()"]["sets exposed methods and config"] = function()
     expect_config("buffers.left", true)
     expect_config("buffers.right", true)
     expect_config("buffers.showName", false)
+
+    expect_config("buffers.background.colorCode", vim.NIL)
 
     expect_config("buffers.options.bo.filetype", "no-neck-pain")
     expect_config("buffers.options.bo.buftype", "nofile")
@@ -77,6 +83,9 @@ T["setup()"]["overrides default values"] = function()
         disableOnLastBuffer = true,
         killAllBuffersOnDisable = true,
         buffers = {
+            background = {
+                colorCode = "#2E1E2E"
+            },
             left = false,
             right = false,
             showName = true,
@@ -113,6 +122,8 @@ T["setup()"]["overrides default values"] = function()
     expect_config("buffers.right", false)
     expect_config("buffers.showName", true)
 
+    expect_config("buffers.background.colorCode", "#2E1E2E")
+
     expect_config("buffers.options.bo.filetype", "my-file-type")
     expect_config("buffers.options.bo.buftype", "help")
     expect_config("buffers.options.bo.bufhidden", "")
@@ -126,6 +137,85 @@ T["setup()"]["overrides default values"] = function()
     expect_config("buffers.options.wo.relativenumber", true)
     expect_config("buffers.options.wo.foldenable", true)
     expect_config("buffers.options.wo.list", true)
+end
+
+T["setup()"]["colorCode: map integration name to a value"] = function()
+    child.lua([[M = require('no-neck-pain').setup({
+        buffers = {
+            background = {
+                colorCode = "catppuccin-frappe"
+            },
+        },
+    })]])
+
+    local expect_config = function(field, value)
+        eq(child.lua_get("_G.NoNeckPain.config.options." .. field), value)
+    end
+
+    expect_config("buffers.background.colorCode", "#292C3C")
+
+    child.lua([[M = require('no-neck-pain').setup({
+        buffers = {
+            background = {
+                colorCode = "catppuccin-latte"
+            },
+        },
+    })]])
+    expect_config("buffers.background.colorCode", "#E6E9EF")
+
+    child.lua([[M = require('no-neck-pain').setup({
+        buffers = {
+            background = {
+                colorCode = "catppuccin-macchiato"
+            },
+        },
+    })]])
+    expect_config("buffers.background.colorCode", "#1E2030")
+
+    child.lua([[M = require('no-neck-pain').setup({
+        buffers = {
+            background = {
+                colorCode = "catppuccin-mocha"
+            },
+        },
+    })]])
+    expect_config("buffers.background.colorCode", "#181825")
+
+    child.lua([[M = require('no-neck-pain').setup({
+        buffers = {
+            background = {
+                colorCode = "tokyonight-day"
+            },
+        },
+    })]])
+    expect_config("buffers.background.colorCode", "#16161e")
+
+    child.lua([[M = require('no-neck-pain').setup({
+        buffers = {
+            background = {
+                colorCode = "tokyonight-moon"
+            },
+        },
+    })]])
+    expect_config("buffers.background.colorCode", "#1e2030")
+
+    child.lua([[M = require('no-neck-pain').setup({
+        buffers = {
+            background = {
+                colorCode = "tokyonight-night"
+            },
+        },
+    })]])
+    expect_config("buffers.background.colorCode", "#16161e")
+
+    child.lua([[M = require('no-neck-pain').setup({
+        buffers = {
+            background = {
+                colorCode = "tokyonight-storm"
+            },
+        },
+    })]])
+    expect_config("buffers.background.colorCode", "#1f2335")
 end
 
 T["enable()"] = new_set()
@@ -148,6 +238,7 @@ T["enable()"]["sets state and internal methods"] = function()
     -- status
     expect_state("enabled", true)
     expect_state("augroup", 15)
+    expect_state("namespaceID", vim.NIL)
 
     -- stored window ids
     expect_state("win.curr", 1000)
@@ -176,12 +267,29 @@ T["toggle()"]["sets state and internal methods"] = function()
     -- status
     expect_state("enabled", true)
     expect_state("augroup", 15)
+    expect_state("namespaceID", vim.NIL)
 
     -- stored window ids
     expect_state("win.curr", 1000)
     expect_state("win.left", 1001)
     expect_state("win.right", 1002)
     expect_state("win.split", vim.NIL)
+end
+
+T["toggle()"]["set namespaceID when colorCode is defined"] = function()
+    child.lua([[
+        local NNP = require('no-neck-pain')
+        NNP.setup({
+            buffers = {
+                background = {
+                    colorCode = "#2E1E2E",
+                },
+            },
+        })
+        NNP.toggle()
+    ]])
+
+    eq(child.lua_get("_G.NoNeckPain.state.namespaceID"), 1)
 end
 
 T["toggle()"]["resets everything once toggled again"] = function()


### PR DESCRIPTION
## Summary

This PR adds a new option for the side buffers to configure the background color.

The goal is not to provide some theme features in NNP, but to make the side buffer "blend" in the user's theme.

The option supports hexadecimal codes, but the end goal is to provide aliases for popular integration such as:
- [x] catppuccin-frappe
- [x] catppuccin-latte
- [x] catppuccin-macchiato
- [x] catppuccin-mocha
- [x] tokyonight-day
- [x] tokyonight-moon
- [x] tokyonight-night
- [x] tokyonight-storm

## Preview

| with value `catppucin-frappe` | with arbitrary value |
|:---------:|:---------:|
| <img alt="Screenshot 2022-12-16 at 22 34 35" src="https://user-images.githubusercontent.com/20689156/208194828-bbd8ed3b-8321-4cd3-a873-4d9c7c7c5ba9.png"> | <img alt="Screenshot 2022-12-17 at 10 26 52" src="https://user-images.githubusercontent.com/20689156/208235401-672183aa-42a5-4c7e-a1a3-00ffc9b5960e.png"> |

