### PR TITLE
fix: color leaving non-colored blocks

### DIFF
--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -46,7 +46,12 @@ function C.init(win, colorCode)
         win,
         "winhl",
         string.format(
-            "Normal:%s,NormalNC:%s,NonText:%s,EndOfBuffer:%s,WinSeparator:%s,VertSplit:%s",
+            "Normal:%s,NormalNC:%s,CursorColumn:%s,CursorColumnNr:%s,SignColumn:%s,Cursor:%sLineNr:%s,NonText:%s,EndOfBuffer:%s,WinSeparator:%s,VertSplit:%s",
+            groupName,
+            groupName,
+            groupName,
+            groupName,
+            groupName,
             groupName,
             groupName,
             groupName,


### PR DESCRIPTION
## 📃 Summary

There was some missing blocks in the color group

## 📸 Preview

|Before|After|
|---|---|
| <img width="1280" alt="Screenshot 2022-12-17 at 22 49 35" src="https://user-images.githubusercontent.com/20689156/208267183-2c848980-4f75-4a16-b980-56ae41df956d.png"> | <img width="1280" alt="Screenshot 2022-12-17 at 22 39 09" src="https://user-images.githubusercontent.com/20689156/208267185-a21ed247-7076-4b49-b226-74c68b6d0f2b.png"> |

