### PR TITLE
fix: prevent config reset

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,4 +1,3 @@
-local U = require("no-neck-pain.util.debug")
 local NNP = {}
 
 -- toggles NNP switch between enabled/disable state.


### PR DESCRIPTION
## 📃 Summary

This unused var causes the config to reset its state.
