### PR TITLE
fix: highlight group typo

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -4,11 +4,7 @@ local NNP = {}
 function NNP.toggle()
     local main = require("no-neck-pain.main")
 
-    main.toggle()
-
-    NNP.state = main.state
-
-    if main.state.enabled then
+    if main.toggle() then
         NNP.internal = {
             toggle = main.toggle,
             enable = main.enable,
@@ -21,6 +17,8 @@ function NNP.toggle()
             disable = nil,
         }
     end
+
+    NNP.state = main.state
 end
 
 -- starts NNP and set internal functions and state.

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -1,3 +1,4 @@
+local D = require("no-neck-pain.util.debug")
 local C = {}
 
 -- tries to match the provided `colorCode` to an integration name, defaults to the provided string if not successful.
@@ -30,11 +31,23 @@ function C.matchIntegrationToHexCode(colorCode)
 end
 
 -- creates an highlight group `NoNeckPain` with the given `colorCode` and assign it to the side buffer of the given `id`.
+-- `cmd` is used instead of native commands for backward compatibility with Neovim 0.7
 function C.init(win, colorCode)
-    local groupName = "NoNeckPain"
+    local groupName = "nnpcolorname"
+
+    D.print(
+        "Color.init: initializing background mode with groupname "
+            .. groupName
+            .. " for win "
+            .. win
+            .. " with color "
+            .. colorCode
+    )
+
+    vim.cmd(string.format([[highlight! clear %s NONE]], groupName))
     vim.cmd(
         string.format(
-            [[highlight %s guifg=%s guibg=%s]],
+            [[highlight! %s guifg=%s guibg=%s]],
             groupName,
             colorCode,
             colorCode,
@@ -46,7 +59,7 @@ function C.init(win, colorCode)
         win,
         "winhl",
         string.format(
-            "Normal:%s,NormalNC:%s,CursorColumn:%s,CursorColumnNr:%s,SignColumn:%s,Cursor:%sLineNr:%s,NonText:%s,EndOfBuffer:%s,WinSeparator:%s,VertSplit:%s",
+            "Normal:%s,NormalNC:%s,CursorColumn:%s,CursorColumnNr:%s,NonText:%s,SignColumn:%s,Cursor:%s,LineNr:%s,EndOfBuffer:%s,WinSeparator:%s,VertSplit:%s",
             groupName,
             groupName,
             groupName,

--- a/lua/no-neck-pain/util/debug.lua
+++ b/lua/no-neck-pain/util/debug.lua
@@ -1,9 +1,8 @@
-local options = require("no-neck-pain.config").options
 local D = {}
 
 -- prints only if debug is true.
 function D.print(...)
-    if not options.debug then
+    if _G.NoNeckPain.config ~= nil and not _G.NoNeckPain.config.debug then
         return
     end
 
@@ -19,7 +18,7 @@ end
 
 -- prints table only if debug is true.
 function D.tprint(table, indent)
-    if not options.debug then
+    if _G.NoNeckPain.config ~= nil and not _G.NoNeckPain.config.debug then
         return
     end
 


### PR DESCRIPTION
## 📃 Summary

- [x] fix typo causing error in highlight group
- [x] prevent `config` requirement in `debug` by leveraging the global variable
- [x] check if NNP is enabled before running a hook, to prevent unwanted side effects
