### PR TITLE
fix: quit Neovim when killing one of the last NNP buffer

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -160,7 +160,7 @@ function NoNeckPain.enable()
                     )
                 end
 
-                local buffers, total = W.bufferListWithoutNNP("WinEnter", NoNeckPain.state.win)
+                local buffers, total = W.bufferListWithoutNNP("WinEnter")
                 local focusedWin = vim.api.nvim_get_current_win()
 
                 if total == 0 or not M.contains(buffers, focusedWin) then
@@ -214,8 +214,7 @@ function NoNeckPain.enable()
                     return NoNeckPain.disable()
                 end
 
-                local _, total =
-                    W.bufferListWithoutNNP("WinClosed, BufDelete", NoNeckPain.state.win)
+                local _, total = W.bufferListWithoutNNP("WinClosed, BufDelete")
 
                 if
                     options.disableOnLastBuffer
@@ -316,10 +315,8 @@ function NoNeckPain.disable()
     NoNeckPain.state.enabled = false
     vim.api.nvim_del_augroup_by_id(NoNeckPain.state.augroup)
 
-    if not options.killAllBuffersOnDisable then
-        W.close("Disable left", NoNeckPain.state.win.left)
-        W.close("Disable right", NoNeckPain.state.win.right)
-    end
+    W.close("Disable left", NoNeckPain.state.win.left)
+    W.close("Disable right", NoNeckPain.state.win.right)
 
     -- shutdowns gracefully by focusing the stored `curr` buffer, if possible
     if

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -95,7 +95,7 @@ T["curr buffer"]["have the default width from the config"] = function()
     eq_buf_width(child, "curr", 48)
 end
 
-T["curr buffer"]["closing `curr` buffer kills side buffers"] = function()
+T["curr buffer"]["closing `curr` buffer without any other window open closes Neovim"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
@@ -106,7 +106,10 @@ T["curr buffer"]["closing `curr` buffer kills side buffers"] = function()
 
     child.lua("vim.api.nvim_win_close(1000, false)")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1002 })
+    -- neovim is closed, we can't run anything against it
+    helpers.expect.error(function()
+        child.lua_get("vim.api.nvim_list_wins()")
+    end)
 end
 
 T["auto command"] = new_set()


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/62

Closing a side buffer without any other valid window open now quits Neovim (e.g. closing `curr` but there's no other active window left). If we close a side buffer but `curr` or `split` is still there, we will just disable NNP.