### PR TITLE
feat: close side buffers when no space left

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 deps
+**.DS_Store

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -171,7 +171,10 @@ end
 T["enable()"] = MiniTest.new_set()
 
 T["enable()"]["sets state and internal methods"] = function()
-    child.lua([[require('no-neck-pain').enable()]])
+    child.lua([[
+        require('no-neck-pain').setup({width=50})
+        require('no-neck-pain').enable()
+    ]])
 
     -- internal methods
     eq_type_global(child, "_G.NoNeckPain.internal.toggle", "function")
@@ -215,7 +218,10 @@ T["toggle()"] = MiniTest.new_set()
 
 T["toggle()"]["sets state and internal methods and resets everything when toggled again"] =
     function()
-        child.lua([[require('no-neck-pain').toggle()]])
+        child.lua([[
+        require('no-neck-pain').setup({width=50})
+        require('no-neck-pain').enable()
+    ]])
 
         -- internal methods
         eq_type_global(child, "_G.NoNeckPain.internal.toggle", "function")

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -114,6 +114,18 @@ end
 
 T["auto command"] = new_set()
 
+T["auto command"]["does not create side buffers window's width < options.width"] = function()
+    child.lua([[
+            require('no-neck-pain').setup({width=100})
+            require('no-neck-pain').enable()
+        ]])
+
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+    eq_state(child, "win.curr", 1000)
+    eq_state(child, "win.left", vim.NIL)
+    eq_state(child, "win.right", vim.NIL)
+end
+
 T["auto command"]["closing `curr` makes `split` the new `curr`"] = function()
     child.lua([[
             require('no-neck-pain').setup({width=50})


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/42

This PR prevents creating side buffers when there's not enough space on the screen to do it, it also re-creates them if the window is resized.
