### PR TITLE
feat!: refactor setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 deps
 **.DS_Store
+.luarc.json

--- a/README.md
+++ b/README.md
@@ -73,16 +73,28 @@ require("no-neck-pain").setup({
     killAllBuffersOnDisable = false,
     -- Options related to the side buffers.
     -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
-    showBufferNames = false,
+    setBufferNames = false,
     buffers = {
         left = {
+            -- When `false` the buffer won't be created.
             enabled = true,
-            -- Hex color for setting the background color of the NNP buffer as well as some other
-            -- highlight groups to make it look clean
+            -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+            -- popular theme are supported by their name:
+            -- - catppuccin-frappe
+            -- - catppuccin-latte
+            -- - catppuccin-macchiato
+            -- - catppuccin-mocha
+            -- - tokyonight-day
+            -- - tokyonight-moon
+            -- - tokyonight-night
+            -- - tokyonight-storm
+            -- - rose-pine
+            -- - rose-pine-moon
+            -- - rose-pine-dawn
             backgroundColor = nil,
+            -- buffer-scoped options
+            -- Note: any `vim.bo` options will work here
             bo = {
-                -- buffer-scoped options
-                -- Note: any `vim.bo` options will work here
                 filetype = "no-neck-pain",
                 buftype = "nofile",
                 bufhidden = "hide",
@@ -90,9 +102,9 @@ require("no-neck-pain").setup({
                 buflisted = false,
                 swapfile = false
             },
+            -- window-scoped options
+            -- Note: any `vim.wo` options will work here
             wo = {
-                -- window-scoped options
-                -- Note: any `vim.wo` options will work here
                 cursorline = false,
                 cursorcolumn = false,
                 number = false,
@@ -102,10 +114,22 @@ require("no-neck-pain").setup({
             }
         },
         right = {
+            -- When `false` the buffer won't be created.
             enabled = true,
-            -- Hex color for setting the background color of the NNP buffer as well as some other
-            -- highlight groups to make it look clean
-            color = nil,
+            -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+            -- popular theme are supported by their name:
+            -- - catppuccin-frappe
+            -- - catppuccin-latte
+            -- - catppuccin-macchiato
+            -- - catppuccin-mocha
+            -- - tokyonight-day
+            -- - tokyonight-moon
+            -- - tokyonight-night
+            -- - tokyonight-storm
+            -- - rose-pine
+            -- - rose-pine-moon
+            -- - rose-pine-dawn
+            backgroundColor = nil,
             bo = {
                 -- buffer-scoped options
                 -- Note: any `vim.bo` options will work here

--- a/README.md
+++ b/README.md
@@ -71,82 +71,18 @@ require("no-neck-pain").setup({
     disableOnLastBuffer = false,
     -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
     killAllBuffersOnDisable = false,
-    -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
-    setBufferNames = false,
-    -- Options related to the side buffers.
+    --- Options related to the side buffers. See |NoNeckPain.bufferOptions|.
     buffers = {
-        left = {
-            -- When `false` the buffer won't be created.
-            enabled = true,
-            -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-            -- popular theme are supported by their name:
-            -- - catppuccin-frappe
-            -- - catppuccin-latte
-            -- - catppuccin-macchiato
-            -- - catppuccin-mocha
-            -- - tokyonight-day
-            -- - tokyonight-moon
-            -- - tokyonight-night
-            -- - tokyonight-storm
-            -- - rose-pine
-            -- - rose-pine-moon
-            -- - rose-pine-dawn
-            backgroundColor = nil,
-            -- buffer-scoped options: any `vim.bo` options is accepted here.
-            bo = {
-                filetype = "no-neck-pain",
-                buftype = "nofile",
-                bufhidden = "hide",
-                modifiable = false,
-                buflisted = false,
-                swapfile = false,
-            },
-            -- window-scoped options: any `vim.wo` options is accepted here.
-            wo = {
-                cursorline = false,
-                cursorcolumn = false,
-                number = false,
-                relativenumber = false,
-                foldenable = false,
-                list = false,
-            },
-        },
-        right = {
-            -- When `false` the buffer won't be created.
-            enabled = true,
-            -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-            -- popular theme are supported by their name:
-            -- - catppuccin-frappe
-            -- - catppuccin-latte
-            -- - catppuccin-macchiato
-            -- - catppuccin-mocha
-            -- - tokyonight-day
-            -- - tokyonight-moon
-            -- - tokyonight-night
-            -- - tokyonight-storm
-            -- - rose-pine
-            -- - rose-pine-moon
-            -- - rose-pine-dawn
-            backgroundColor = nil,
-            -- buffer-scoped options: any `vim.bo` options is accepted here.
-            bo = {
-                filetype = "no-neck-pain",
-                buftype = "nofile",
-                bufhidden = "hide",
-                modifiable = false,
-                buflisted = false,
-                swapfile = false,
-            },
-            -- window-scoped options: any `vim.wo` options is accepted here.
-            wo = {
-                cursorline = false,
-                cursorcolumn = false,
-                number = false,
-                relativenumber = false,
-                foldenable = false,
-                list = false,
-            },
-        },
+        -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
+        setNames = false,
+        -- Common options are set to both buffers, for option scoped to the `left` and/or `right` buffer, see `buffers.left` and `buffers.right`.
+        common = NoNeckPain.bufferOptions,
+        --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
+        --- When `nil`, the buffer won't be created.
+        left = NoNeckPain.bufferOptions,
+        --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
+        --- When `nil`, the buffer won't be created.
+        right = NoNeckPain.bufferOptions,
     },
     -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
     integrations = {
@@ -157,6 +93,43 @@ require("no-neck-pain").setup({
         },
     },
 })
+
+NoNeckPain.bufferOptions = {
+    -- When `false`, the buffer won't be created.
+    enabled = true,
+    -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+    -- popular theme are supported by their name:
+    -- - catppuccin-frappe
+    -- - catppuccin-latte
+    -- - catppuccin-macchiato
+    -- - catppuccin-mocha
+    -- - tokyonight-day
+    -- - tokyonight-moon
+    -- - tokyonight-night
+    -- - tokyonight-storm
+    -- - rose-pine
+    -- - rose-pine-moon
+    -- - rose-pine-dawn
+    backgroundColor = nil,
+    -- buffer-scoped options: any `vim.bo` options is accepted here.
+    bo = {
+        filetype = "no-neck-pain",
+        buftype = "nofile",
+        bufhidden = "hide",
+        modifiable = false,
+        buflisted = false,
+        swapfile = false,
+    },
+    -- window-scoped options: any `vim.wo` options is accepted here.
+    wo = {
+        cursorline = false,
+        cursorcolumn = false,
+        number = false,
+        relativenumber = false,
+        foldenable = false,
+        list = false,
+    },
+}
 ```
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -72,52 +72,62 @@ require("no-neck-pain").setup({
     -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
     killAllBuffersOnDisable = false,
     -- Options related to the side buffers.
+    -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
+    showBufferNames = false,
     buffers = {
-        -- The background options of the side buffer(s).
-        background = {
-            -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-            -- popular theme are supported by their name:
-            -- - catppuccin-frappe
-            -- - catppuccin-latte
-            -- - catppuccin-macchiato
-            -- - catppuccin-mocha
-            -- - tokyonight-day
-            -- - tokyonight-moon
-            -- - tokyonight-night
-            -- - tokyonight-storm
-            -- - rose-pine
-            -- - rose-pine-moon
-            -- - rose-pine-dawn
-            colorCode = nil,
-        },
-        -- When `false`, the `left` padding buffer won't be created.
-        left = true,
-        -- When `false`, the `right` padding buffer won't be created.
-        right = true,
-        -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
-        showName = false,
-        -- The buffer options when creating the buffer.
-        options = {
-            -- Buffer-scoped options, below are the default values, but any `vim.bo` options are valid and will be forwarded to the buffer creation.
+        left = {
+            enabled = true,
+            -- Hex color for setting the background color of the NNP buffer as well as some other
+            -- highlight groups to make it look clean
+            color = nil,
             bo = {
+                -- buffer-scoped options
+                -- Note: any `vim.bo` options will work here
                 filetype = "no-neck-pain",
                 buftype = "nofile",
                 bufhidden = "hide",
                 modifiable = false,
                 buflisted = false,
-                swapfile = false,
+                swapfile = false
             },
-            -- Window-scoped options, below are the default values, but any `vim.wo` options are valid and will be forwarded to the buffer creation.
             wo = {
+                -- window-scoped options
+                -- Note: any `vim.wo` options will work here
                 cursorline = false,
                 cursorcolumn = false,
                 number = false,
                 relativenumber = false,
                 foldenable = false,
-                list = false,
-            },
+                list = false
+            }
         },
-    },
+        right = {
+            enabled = true,
+            -- Hex color for setting the background color of the NNP buffer as well as some other
+            -- highlight groups to make it look clean
+            color = nil,
+            bo = {
+                -- buffer-scoped options
+                -- Note: any `vim.bo` options will work here
+                filetype = "no-neck-pain",
+                buftype = "nofile",
+                bufhidden = "hide",
+                modifiable = false,
+                buflisted = false,
+                swapfile = false
+            },
+            wo = {
+                -- window-scoped options
+                -- Note: any `vim.wo` options will work here
+                cursorline = false,
+                cursorcolumn = false,
+                number = false,
+                relativenumber = false,
+                foldenable = false,
+                list = false
+            }
+        }
+    }
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ require("no-neck-pain").setup({
             enabled = true,
             -- Hex color for setting the background color of the NNP buffer as well as some other
             -- highlight groups to make it look clean
-            color = nil,
+            backgroundColor = nil,
             bo = {
                 -- buffer-scoped options
                 -- Note: any `vim.bo` options will work here

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you wish to enable the plugin on Neovim start: [-> take a look at the guide <
 
 ## Configuration
 
-> The options are also available from Neovim, `:h NoNeckPain.options`.
+> The options are also available from Neovim, use `:h NoNeckPain.options` to see all the options, and `:h NoNeckPain.bufferOptions` for the buffer ones.
 
 ```lua
 require("no-neck-pain").setup({

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -1,5 +1,51 @@
 ==============================================================================
 ------------------------------------------------------------------------------
+                                                      *NoNeckPain.bufferOptions*
+                           `NoNeckPain.bufferOptions`
+NoNeckPain buffer options
+
+Default values:
+>
+  NoNeckPain.bufferOptions = {
+      -- When `false`, the buffer won't be created.
+      enabled = true,
+      -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+      -- popular theme are supported by their name:
+      -- - catppuccin-frappe
+      -- - catppuccin-latte
+      -- - catppuccin-macchiato
+      -- - catppuccin-mocha
+      -- - tokyonight-day
+      -- - tokyonight-moon
+      -- - tokyonight-night
+      -- - tokyonight-storm
+      -- - rose-pine
+      -- - rose-pine-moon
+      -- - rose-pine-dawn
+      backgroundColor = nil,
+      -- buffer-scoped options: any `vim.bo` options is accepted here.
+      bo = {
+          filetype = "no-neck-pain",
+          buftype = "nofile",
+          bufhidden = "hide",
+          modifiable = false,
+          buflisted = false,
+          swapfile = false,
+      },
+      -- window-scoped options: any `vim.wo` options is accepted here.
+      wo = {
+          cursorline = false,
+          cursorcolumn = false,
+          number = false,
+          relativenumber = false,
+          foldenable = false,
+          list = false,
+      },
+  }
+
+<
+
+------------------------------------------------------------------------------
                                                             *NoNeckPain.options*
                               `NoNeckPain.options`
 Plugin config
@@ -16,86 +62,18 @@ Default values:
       disableOnLastBuffer = false,
       -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
       killAllBuffersOnDisable = false,
-      -- Options related to the side buffers.
-      -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
-      setBufferNames = false,
+      --- Options related to the side buffers. See |NoNeckPain.bufferOptions|.
       buffers = {
-          left = {
-              -- When `false` the buffer won't be created.
-              enabled = true,
-              -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-              -- popular theme are supported by their name:
-              -- - catppuccin-frappe
-              -- - catppuccin-latte
-              -- - catppuccin-macchiato
-              -- - catppuccin-mocha
-              -- - tokyonight-day
-              -- - tokyonight-moon
-              -- - tokyonight-night
-              -- - tokyonight-storm
-              -- - rose-pine
-              -- - rose-pine-moon
-              -- - rose-pine-dawn
-              backgroundColor = nil,
-              -- buffer-scoped options
-              -- Note: any `vim.bo` options will work here
-              bo = {
-                  filetype = "no-neck-pain",
-                  buftype = "nofile",
-                  bufhidden = "hide",
-                  modifiable = false,
-                  buflisted = false,
-                  swapfile = false,
-              },
-              -- window-scoped options
-              -- Note: any `vim.wo` options will work here
-              wo = {
-                  cursorline = false,
-                  cursorcolumn = false,
-                  number = false,
-                  relativenumber = false,
-                  foldenable = false,
-                  list = false,
-              },
-          },
-          right = {
-              -- When `false` the buffer won't be created.
-              enabled = true,
-              -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-              -- popular theme are supported by their name:
-              -- - catppuccin-frappe
-              -- - catppuccin-latte
-              -- - catppuccin-macchiato
-              -- - catppuccin-mocha
-              -- - tokyonight-day
-              -- - tokyonight-moon
-              -- - tokyonight-night
-              -- - tokyonight-storm
-              -- - rose-pine
-              -- - rose-pine-moon
-              -- - rose-pine-dawn
-              backgroundColor = nil,
-              bo = {
-                  -- buffer-scoped options
-                  -- Note: any `vim.bo` options will work here
-                  filetype = "no-neck-pain",
-                  buftype = "nofile",
-                  bufhidden = "hide",
-                  modifiable = false,
-                  buflisted = false,
-                  swapfile = false,
-              },
-              wo = {
-                  -- window-scoped options
-                  -- Note: any `vim.wo` options will work here
-                  cursorline = false,
-                  cursorcolumn = false,
-                  number = false,
-                  relativenumber = false,
-                  foldenable = false,
-                  list = false,
-              },
-          },
+          -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
+          setNames = false,
+          -- Common options are set to both buffers, for option scoped to the `left` and/or `right` buffer, see `buffers.left` and `buffers.right`.
+          common = NoNeckPain.bufferOptions,
+          --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
+          --- When `nil`, the buffer won't be created.
+          left = NoNeckPain.bufferOptions,
+          --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
+          --- When `nil`, the buffer won't be created.
+          right = NoNeckPain.bufferOptions,
       },
       -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
       integrations = {

--- a/doc/tags
+++ b/doc/tags
@@ -1,3 +1,4 @@
+NoNeckPain.bufferOptions	no-neck-pain.txt	/*NoNeckPain.bufferOptions*
 NoNeckPain.disable()	no-neck-pain.txt	/*NoNeckPain.disable()*
 NoNeckPain.enable()	no-neck-pain.txt	/*NoNeckPain.enable()*
 NoNeckPain.options	no-neck-pain.txt	/*NoNeckPain.options*

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -21,9 +21,21 @@ NoNeckPain.options = {
     setBufferNames = false,
     buffers = {
         left = {
+            -- When `false` the buffer won't be created.
             enabled = true,
-            -- Hex color for setting the background color of the NNP buffer as well as some other
-            -- highlight groups to make it look clean
+            -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+            -- popular theme are supported by their name:
+            -- - catppuccin-frappe
+            -- - catppuccin-latte
+            -- - catppuccin-macchiato
+            -- - catppuccin-mocha
+            -- - tokyonight-day
+            -- - tokyonight-moon
+            -- - tokyonight-night
+            -- - tokyonight-storm
+            -- - rose-pine
+            -- - rose-pine-moon
+            -- - rose-pine-dawn
             backgroundColor = nil,
             -- buffer-scoped options
             -- Note: any `vim.bo` options will work here
@@ -47,10 +59,22 @@ NoNeckPain.options = {
             }
         },
         right = {
+            -- When `false` the buffer won't be created.
             enabled = true,
-            -- Hex color for setting the background color of the NNP buffer as well as some other
-            -- highlight groups to make it look clean
-            color = nil,
+            -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+            -- popular theme are supported by their name:
+            -- - catppuccin-frappe
+            -- - catppuccin-latte
+            -- - catppuccin-macchiato
+            -- - catppuccin-mocha
+            -- - tokyonight-day
+            -- - tokyonight-moon
+            -- - tokyonight-night
+            -- - tokyonight-storm
+            -- - rose-pine
+            -- - rose-pine-moon
+            -- - rose-pine-dawn
+            backgroundColor = nil,
             bo = {
                 -- buffer-scoped options
                 -- Note: any `vim.bo` options will work here

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -25,9 +25,9 @@ NoNeckPain.options = {
             -- Hex color for setting the background color of the NNP buffer as well as some other
             -- highlight groups to make it look clean
             backgroundColor = nil,
+            -- buffer-scoped options
+            -- Note: any `vim.bo` options will work here
             bo = {
-                -- buffer-scoped options
-                -- Note: any `vim.bo` options will work here
                 filetype = "no-neck-pain",
                 buftype = "nofile",
                 bufhidden = "hide",

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -17,52 +17,62 @@ NoNeckPain.options = {
     -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
     killAllBuffersOnDisable = false,
     -- Options related to the side buffers.
+    -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
+    showBufferNames = false,
     buffers = {
-        -- The background options of the side buffer(s).
-        background = {
-            -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-            -- popular theme are supported by their name:
-            -- - catppuccin-frappe
-            -- - catppuccin-latte
-            -- - catppuccin-macchiato
-            -- - catppuccin-mocha
-            -- - tokyonight-day
-            -- - tokyonight-moon
-            -- - tokyonight-night
-            -- - tokyonight-storm
-            -- - rose-pine
-            -- - rose-pine-moon
-            -- - rose-pine-dawn
-            colorCode = nil,
-        },
-        -- When `false`, the `left` padding buffer won't be created.
-        left = true,
-        -- When `false`, the `right` padding buffer won't be created.
-        right = true,
-        -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
-        showName = false,
-        -- The buffer options when creating the buffer.
-        options = {
-            -- Buffer-scoped options, below are the default values, but any `vim.bo` options are valid and will be forwarded to the buffer creation.
+        left = {
+            enabled = true,
+            -- Hex color for setting the background color of the NNP buffer as well as some other
+            -- highlight groups to make it look clean
+            color = nil,
             bo = {
+                -- buffer-scoped options
+                -- Note: any `vim.bo` options will work here
                 filetype = "no-neck-pain",
                 buftype = "nofile",
                 bufhidden = "hide",
                 modifiable = false,
                 buflisted = false,
-                swapfile = false,
+                swapfile = false
             },
-            -- Window-scoped options, below are the default values, but any `vim.wo` options are valid and will be forwarded to the buffer creation.
             wo = {
+                -- window-scoped options
+                -- Note: any `vim.wo` options will work here
                 cursorline = false,
                 cursorcolumn = false,
                 number = false,
                 relativenumber = false,
                 foldenable = false,
-                list = false,
-            },
+                list = false
+            }
         },
-    },
+        right = {
+            enabled = true,
+            -- Hex color for setting the background color of the NNP buffer as well as some other
+            -- highlight groups to make it look clean
+            color = nil,
+            bo = {
+                -- buffer-scoped options
+                -- Note: any `vim.bo` options will work here
+                filetype = "no-neck-pain",
+                buftype = "nofile",
+                bufhidden = "hide",
+                modifiable = false,
+                buflisted = false,
+                swapfile = false
+            },
+            wo = {
+                -- window-scoped options
+                -- Note: any `vim.wo` options will work here
+                cursorline = false,
+                cursorcolumn = false,
+                number = false,
+                relativenumber = false,
+                foldenable = false,
+                list = false
+            }
+        }
+    }
 }
 
 --- Define your no-neck-pain setup.
@@ -72,8 +82,12 @@ NoNeckPain.options = {
 ---@usage `require("no-neck-pain").setup()` (add `{}` with your |NoNeckPain.options| table)
 function NoNeckPain.setup(options)
     NoNeckPain.options = vim.tbl_deep_extend("keep", options or {}, NoNeckPain.options)
-    NoNeckPain.options.buffers.background.colorCode =
-        C.matchIntegrationToHexCode(NoNeckPain.options.buffers.background.colorCode)
+
+    NoNeckPain.options.buffers.left.color =
+        C.matchIntegrationToHexCode(NoNeckPain.options.buffers.left.color)
+
+    NoNeckPain.options.buffers.right.color =
+        C.matchIntegrationToHexCode(NoNeckPain.options.buffers.right.color)
 
     return NoNeckPain.options
 end

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -18,7 +18,7 @@ NoNeckPain.options = {
     killAllBuffersOnDisable = false,
     -- Options related to the side buffers.
     -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
-    showBufferNames = false,
+    setBufferNames = false,
     buffers = {
         left = {
             enabled = true,

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -24,7 +24,7 @@ NoNeckPain.options = {
             enabled = true,
             -- Hex color for setting the background color of the NNP buffer as well as some other
             -- highlight groups to make it look clean
-            color = nil,
+            backgroundColor = nil,
             bo = {
                 -- buffer-scoped options
                 -- Note: any `vim.bo` options will work here

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -35,9 +35,9 @@ NoNeckPain.options = {
                 buflisted = false,
                 swapfile = false
             },
+            -- window-scoped options
+            -- Note: any `vim.wo` options will work here
             wo = {
-                -- window-scoped options
-                -- Note: any `vim.wo` options will work here
                 cursorline = false,
                 cursorcolumn = false,
                 number = false,

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -45,7 +45,7 @@ NoNeckPain.options = {
                 bufhidden = "hide",
                 modifiable = false,
                 buflisted = false,
-                swapfile = false
+                swapfile = false,
             },
             -- window-scoped options
             -- Note: any `vim.wo` options will work here
@@ -55,8 +55,8 @@ NoNeckPain.options = {
                 number = false,
                 relativenumber = false,
                 foldenable = false,
-                list = false
-            }
+                list = false,
+            },
         },
         right = {
             -- When `false` the buffer won't be created.
@@ -83,7 +83,7 @@ NoNeckPain.options = {
                 bufhidden = "hide",
                 modifiable = false,
                 buflisted = false,
-                swapfile = false
+                swapfile = false,
             },
             wo = {
                 -- window-scoped options
@@ -93,10 +93,10 @@ NoNeckPain.options = {
                 number = false,
                 relativenumber = false,
                 foldenable = false,
-                list = false
-            }
-        }
-    }
+                list = false,
+            },
+        },
+    },
 }
 
 --- Define your no-neck-pain setup.

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -59,7 +59,7 @@ local function createBuf(name, cmd, padding, moveTo)
 
     vim.api.nvim_win_set_width(0, padding)
 
-    if _G.NoNeckPain.config.buffers.showName then
+    if _G.NoNeckPain.config.showBufferNames then
         vim.api.nvim_buf_set_name(0, "no-neck-pain-" .. name)
     end
 
@@ -108,11 +108,11 @@ local function createWin(action)
             curr = vim.api.nvim_get_current_win(),
         }
 
-        if _G.NoNeckPain.config.buffers.left then
+        if _G.NoNeckPain.config.buffers.left.enabled then
             NoNeckPain.state.win.left = createBuf("left", "leftabove vnew", padding, "wincmd l")
         end
 
-        if _G.NoNeckPain.config.buffers.right then
+        if _G.NoNeckPain.config.buffers.right.enabled then
             NoNeckPain.state.win.right = createBuf("right", "vnew", padding, "wincmd h")
         end
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -63,8 +63,6 @@ local function createBuf(name, cmd, padding, moveTo)
         vim.api.nvim_buf_set_name(0, "no-neck-pain-" .. name)
     end
 
-    -- there is probably a cleaner way to do this but it's kind of annoying
-    -- since the tables contain multiple different kinds of values
     for opt, val in pairs(_G.NoNeckPain.config.buffers[name].bo) do
         vim.bo[opt] = val
     end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -40,7 +40,7 @@ function NoNeckPain.toggle()
 end
 
 -- Creates a buffer for the given "padding" (width), at the given `moveTo` direction.
--- Options from `_G.NoNeckPain.config.buffer.options` are applied to the created buffer.
+-- Options are applied to the created buffer, `_G.NoNeckPain.config.buffer.left` and `_G.NoNeckPain.config.buffer.right` will override the common option `_G.NoNeckPain.config.buffer.options` when defined.
 --
 --@param name string: the name of the buffer, `no-neck-pain-` will be prepended.
 --@param cmd string: the command to execute when creating the buffer
@@ -57,7 +57,7 @@ local function createBuf(name, cmd, padding, moveTo)
 
     vim.api.nvim_win_set_width(0, padding)
 
-    if _G.NoNeckPain.config.showBufferNames then
+    if _G.NoNeckPain.config.buffers.setNames then
         vim.api.nvim_buf_set_name(0, "no-neck-pain-" .. name)
     end
 
@@ -71,7 +71,7 @@ local function createBuf(name, cmd, padding, moveTo)
 
     vim.cmd(moveTo)
 
-    C.init(id, _G.NoNeckPain.config.buffers[name].color)
+    C.init(id, _G.NoNeckPain.config.buffers[name].backgroundColor)
 
     return id
 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -73,8 +73,7 @@ local function createBuf(name, cmd, padding, moveTo)
 
     vim.cmd(moveTo)
 
-    C.init(id, _G.NoNeckPain.config.buffers.left.color)
-    C.init(id, _G.NoNeckPain.config.buffers.right.color)
+    C.init(id, _G.NoNeckPain.config.buffers[name].color)
 
     return id
 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -65,19 +65,11 @@ local function createBuf(name, cmd, padding, moveTo)
 
     -- there is probably a cleaner way to do this but it's kind of annoying
     -- since the tables contain multiple different kinds of values
-    for opt, val in pairs(_G.NoNeckPain.config.buffers.left.bo) do
+    for opt, val in pairs(_G.NoNeckPain.config.buffers[name].bo) do
         vim.bo[opt] = val
     end
 
-    for opt, val in pairs(_G.NoNeckPain.config.buffers.left.wo) do
-        vim.wo[opt] = val
-    end
-
-    for opt, val in pairs(_G.NoNeckPain.config.buffers.right.bo) do
-        vim.bo[opt] = val
-    end
-
-    for opt, val in pairs(_G.NoNeckPain.config.buffers.right.wo) do
+    for opt, val in pairs(_G.NoNeckPain.config.buffers[name].wo) do
         vim.wo[opt] = val
     end
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -63,19 +63,31 @@ local function createBuf(name, cmd, padding, moveTo)
         vim.api.nvim_buf_set_name(0, "no-neck-pain-" .. name)
     end
 
-    for scope, _ in pairs(_G.NoNeckPain.config.buffers.options) do
-        for key, value in pairs(_G.NoNeckPain.config.buffers.options[scope]) do
-            vim[scope][key] = value
-        end
+    -- there is probably a cleaner way to do this but it's kind of annoying
+    -- since the tables contain multiple different kinds of values
+    for opt, val in pairs(_G.NoNeckPain.config.buffers.left.bo) do
+        vim.bo[opt] = val
+    end
+
+    for opt, val in pairs(_G.NoNeckPain.config.buffers.left.wo) do
+        vim.wo[opt] = val
+    end
+
+    for opt, val in pairs(_G.NoNeckPain.config.buffers.right.bo) do
+        vim.bo[opt] = val
+    end
+
+    for opt, val in pairs(_G.NoNeckPain.config.buffers.right.wo) do
+        vim.wo[opt] = val
     end
 
     vim.cmd(moveTo)
 
-    if _G.NoNeckPain.config.buffers.background.colorCode ~= nil then
-        D.print("CreateWin: setting `colorCode` for buffer " .. id)
+    D.print(string.format("CreateWin: setting color `%s` for left buffer (`%s`)", _G.NoNeckPain.config.buffers.left.color, id))
+    C.init(id, _G.NoNeckPain.config.buffers.left.color)
 
-        C.init(id, _G.NoNeckPain.config.buffers.background.colorCode)
-    end
+    D.print(string.format("CreateWin: setting color `%s` for right buffer (`%s`)", _G.NoNeckPain.config.buffers.right.color, id))
+    C.init(id, _G.NoNeckPain.config.buffers.right.color)
 
     return id
 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -75,10 +75,7 @@ local function createBuf(name, cmd, padding, moveTo)
 
     vim.cmd(moveTo)
 
-    D.print(string.format("CreateWin: setting color `%s` for left buffer (`%s`)", _G.NoNeckPain.config.buffers.left.color, id))
     C.init(id, _G.NoNeckPain.config.buffers.left.color)
-
-    D.print(string.format("CreateWin: setting color `%s` for right buffer (`%s`)", _G.NoNeckPain.config.buffers.right.color, id))
     C.init(id, _G.NoNeckPain.config.buffers.right.color)
 
     return id

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -30,18 +30,35 @@ function C.matchIntegrationToHexCode(colorCode)
     return colorCode
 end
 
--- creates an highlight group `NoNeckPain` with the given `colorCode` and assign it to the side buffer of the given `id`.
+-- creates an highlight group `NNPBuffers` with the given `color` and assign it to the side buffer of the given `id`.
 -- `cmd` is used instead of native commands for backward compatibility with Neovim 0.7
-function C.init(win, colorCode)
-    local groupName = "nnpcolorname"
+function C.init(win, color)
+    local groupName = "NNPBuffers"
+
+    local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
+
+    -- check if the user has a transparent background or not
+    if defaultBackground == nil then
+        defaultBackground = "NONE"
+    else
+        -- if it's not transparent, get the user's current background color
+        defaultBackground = string.format("#%06X", defaultBackground)
+    end
+
+    color = color or defaultBackground
 
     D.print(
-        "Color.init: initializing background mode with groupname "
-            .. groupName
-            .. " for win "
-            .. win
-            .. " with color "
-            .. colorCode
+        string.format(
+        	[[
+Color.init: initializing colors:
+- groupName: `%s`
+- window: `%s`
+- color: `%s`
+            ]],
+            groupName,
+            win,
+            color
+        )
     )
 
     vim.cmd(string.format([[highlight! clear %s NONE]], groupName))
@@ -49,12 +66,11 @@ function C.init(win, colorCode)
         string.format(
             [[highlight! %s guifg=%s guibg=%s]],
             groupName,
-            colorCode,
-            colorCode,
-            colorCode,
-            colorCode
+            color,
+            color
         )
     )
+
     vim.api.nvim_win_set_option(
         win,
         "winhl",

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -30,10 +30,10 @@ function C.matchIntegrationToHexCode(colorCode)
     return colorCode
 end
 
--- creates an highlight group `NNPBuffers` with the given `color` and assign it to the side buffer of the given `id`.
+-- creates an highlight group `NNPBuffers` with the given `backgroundColor` and assign it to the side buffer of the given `id`.
 -- `cmd` is used instead of native commands for backward compatibility with Neovim 0.7
-function C.init(win, color)
-    D.print(string.format("CreateWin: setting color `%s` for right buffer (`%s`)", color, win))
+function C.init(win, backgroundColor)
+    D.print(string.format("CreateWin: setting color `%s` for buffer `%s`", backgroundColor, win))
 
     local groupName = "NNPBuffers"
 
@@ -47,7 +47,7 @@ function C.init(win, color)
         defaultBackground = string.format("#%06X", defaultBackground)
     end
 
-    color = color or defaultBackground
+    backgroundColor = backgroundColor or defaultBackground
 
     D.print(
         string.format(
@@ -55,11 +55,11 @@ function C.init(win, color)
 Color.init: initializing colors:
 - groupName: `%s`
 - window: `%s`
-- color: `%s`
+- backgroundColor: `%s`
             ]],
             groupName,
             win,
-            color
+            backgroundColor
         )
     )
 
@@ -68,8 +68,8 @@ Color.init: initializing colors:
         string.format(
             [[highlight! %s guifg=%s guibg=%s]],
             groupName,
-            color,
-            color
+            backgroundColor,
+            backgroundColor
         )
     )
 

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -33,6 +33,8 @@ end
 -- creates an highlight group `NNPBuffers` with the given `color` and assign it to the side buffer of the given `id`.
 -- `cmd` is used instead of native commands for backward compatibility with Neovim 0.7
 function C.init(win, color)
+    D.print(string.format("CreateWin: setting color `%s` for right buffer (`%s`)", color, win))
+
     local groupName = "NNPBuffers"
 
     local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -33,10 +33,7 @@ end
 -- creates an highlight group `NNPBuffers` with the given `backgroundColor` and assign it to the side buffer of the given `id`.
 -- `cmd` is used instead of native commands for backward compatibility with Neovim 0.7
 function C.init(win, backgroundColor)
-    D.print(string.format("CreateWin: setting color `%s` for buffer `%s`", backgroundColor, win))
-
     local groupName = "NNPBuffers"
-
     local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
 
     -- check if the user has a transparent background or not
@@ -49,22 +46,19 @@ function C.init(win, backgroundColor)
 
     backgroundColor = backgroundColor or defaultBackground
 
-    D.print(string.format(
-        [[
-Color.init: initializing colors:
-- groupName: `%s`
-- window: `%s`
-- backgroundColor: `%s`
-            ]],
-        groupName,
-        win,
-        backgroundColor
-    ))
+    D.print(
+        string.format(
+            "Color.init: groupName `%s` - window `%s` - backgroundColor `%s`",
+            groupName,
+            win,
+            backgroundColor
+        )
+    )
 
-    vim.cmd(string.format([[highlight! clear %s NONE]], groupName))
+    vim.cmd(string.format("highlight! clear %s NONE", groupName))
     vim.cmd(
         string.format(
-            [[highlight! %s guifg=%s guibg=%s]],
+            "highlight! %s guifg=%s guibg=%s",
             groupName,
             backgroundColor,
             backgroundColor

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -34,17 +34,17 @@ end
 -- `cmd` is used instead of native commands for backward compatibility with Neovim 0.7
 function C.init(win, backgroundColor)
     local groupName = "NNPBuffers"
-    local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
-
-    -- check if the user has a transparent background or not
-    if defaultBackground == nil then
-        defaultBackground = "NONE"
-    else
-        -- if it's not transparent, get the user's current background color
-        defaultBackground = string.format("#%06X", defaultBackground)
-    end
-
-    backgroundColor = backgroundColor or defaultBackground
+    -- local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
+    --
+    -- -- check if the user has a transparent background or not
+    -- if defaultBackground == nil then
+    --     defaultBackground = "NONE"
+    -- else
+    --     -- if it's not transparent, get the user's current background color
+    --     defaultBackground = string.format("#%06X", defaultBackground)
+    -- end
+    --
+    -- backgroundColor = backgroundColor or defaultBackground
 
     D.print(
         string.format(

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -34,17 +34,17 @@ end
 -- `cmd` is used instead of native commands for backward compatibility with Neovim 0.7
 function C.init(win, backgroundColor)
     local groupName = "NNPBuffers"
-    -- local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
-    --
-    -- -- check if the user has a transparent background or not
-    -- if defaultBackground == nil then
-    --     defaultBackground = "NONE"
-    -- else
-    --     -- if it's not transparent, get the user's current background color
-    --     defaultBackground = string.format("#%06X", defaultBackground)
-    -- end
-    --
-    -- backgroundColor = backgroundColor or defaultBackground
+    local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
+
+    -- check if the user has a transparent background or not
+    if defaultBackground == nil then
+        defaultBackground = "NONE"
+    else
+        -- if it's not transparent, get the user's current background color
+        defaultBackground = string.format("#%06X", defaultBackground)
+    end
+
+    backgroundColor = backgroundColor or defaultBackground
 
     D.print(
         string.format(
@@ -69,7 +69,7 @@ function C.init(win, backgroundColor)
         win,
         "winhl",
         string.format(
-            "Normal:%s,NormalNC:%s,CursorColumn:%s,CursorColumnNr:%s,NonText:%s,SignColumn:%s,Cursor:%s,LineNr:%s,EndOfBuffer:%s,WinSeparator:%s,VertSplit:%s",
+            "Normal:%s,NormalNC:%s,CursorColumn:%s,CursorLineNr:%s,NonText:%s,SignColumn:%s,Cursor:%s,LineNr:%s,EndOfBuffer:%s,WinSeparator:%s,VertSplit:%s",
             groupName,
             groupName,
             groupName,

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -49,19 +49,17 @@ function C.init(win, backgroundColor)
 
     backgroundColor = backgroundColor or defaultBackground
 
-    D.print(
-        string.format(
-        	[[
+    D.print(string.format(
+        [[
 Color.init: initializing colors:
 - groupName: `%s`
 - window: `%s`
 - backgroundColor: `%s`
             ]],
-            groupName,
-            win,
-            backgroundColor
-        )
-    )
+        groupName,
+        win,
+        backgroundColor
+    ))
 
     vim.cmd(string.format([[highlight! clear %s NONE]], groupName))
     vim.cmd(

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -20,6 +20,8 @@ local T = MiniTest.new_set({
     },
 })
 
+local SCOPES = { "common", "left", "right" }
+
 T["install"] = MiniTest.new_set()
 
 T["install"]["sets global loaded variable and provide toggle command"] = function()
@@ -45,38 +47,39 @@ T["setup()"]["sets exposed methods and default options value"] = function()
     eq_type_global(child, "_G.NoNeckPain.enable", "function")
     eq_type_global(child, "_G.NoNeckPain.setup", "function")
 
-    -- options
+    -- config
     eq_type_global(child, "_G.NoNeckPain.config", "table")
-
     eq_type_option(child, "buffers", "table")
-    eq_type_option(child, "buffers.background", "table")
-    eq_type_option(child, "buffers.options", "table")
-    eq_type_option(child, "buffers.options.bo", "table")
-    eq_type_option(child, "buffers.options.wo", "table")
 
     eq_option(child, "width", 100)
     eq_option(child, "debug", false)
     eq_option(child, "disableOnLastBuffer", false)
     eq_option(child, "killAllBuffersOnDisable", false)
-    eq_option(child, "buffers.left", true)
-    eq_option(child, "buffers.right", true)
-    eq_option(child, "buffers.showName", false)
 
-    eq_option(child, "buffers.background.colorCode", vim.NIL)
+    -- buffers
+    eq_option(child, "buffers.setNames", false)
 
-    eq_option(child, "buffers.options.bo.filetype", "no-neck-pain")
-    eq_option(child, "buffers.options.bo.buftype", "nofile")
-    eq_option(child, "buffers.options.bo.bufhidden", "hide")
-    eq_option(child, "buffers.options.bo.modifiable", false)
-    eq_option(child, "buffers.options.bo.buflisted", false)
-    eq_option(child, "buffers.options.bo.swapfile", false)
+    for _, scope in pairs(SCOPES) do
+        eq_type_option(child, "buffers." .. scope, "table")
+        eq_type_option(child, "buffers." .. scope .. ".bo", "table")
+        eq_type_option(child, "buffers." .. scope .. ".wo", "table")
 
-    eq_option(child, "buffers.options.wo.cursorline", false)
-    eq_option(child, "buffers.options.wo.cursorcolumn", false)
-    eq_option(child, "buffers.options.wo.number", false)
-    eq_option(child, "buffers.options.wo.relativenumber", false)
-    eq_option(child, "buffers.options.wo.foldenable", false)
-    eq_option(child, "buffers.options.wo.list", false)
+        eq_option(child, "buffers." .. scope .. ".backgroundColor", vim.NIL)
+
+        eq_option(child, "buffers." .. scope .. ".bo.filetype", "no-neck-pain")
+        eq_option(child, "buffers." .. scope .. ".bo.buftype", "nofile")
+        eq_option(child, "buffers." .. scope .. ".bo.bufhidden", "hide")
+        eq_option(child, "buffers." .. scope .. ".bo.modifiable", false)
+        eq_option(child, "buffers." .. scope .. ".bo.buflisted", false)
+        eq_option(child, "buffers." .. scope .. ".bo.swapfile", false)
+
+        eq_option(child, "buffers." .. scope .. ".wo.cursorline", false)
+        eq_option(child, "buffers." .. scope .. ".wo.cursorcolumn", false)
+        eq_option(child, "buffers." .. scope .. ".wo.number", false)
+        eq_option(child, "buffers." .. scope .. ".wo.relativenumber", false)
+        eq_option(child, "buffers." .. scope .. ".wo.foldenable", false)
+        eq_option(child, "buffers." .. scope .. ".wo.list", false)
+    end
 end
 
 T["setup()"]["overrides default values"] = function()
@@ -86,13 +89,47 @@ T["setup()"]["overrides default values"] = function()
         disableOnLastBuffer = true,
         killAllBuffersOnDisable = true,
         buffers = {
-            background = {
-                colorCode = "#2E1E2E"
+            setNames = true,
+            common = {
+                backgroundColor = "catppuccin-frappe",
+                bo = {
+                    filetype = "my-file-type",
+                    buftype = "help",
+                    bufhidden = "",
+                    modifiable = true,
+                    buflisted = true,
+                    swapfile = true,
+                },
+                wo = {
+                    cursorline = true,
+                    cursorcolumn = true,
+                    number = true,
+                    relativenumber = true,
+                    foldenable = true,
+                    list = true,
+                },
             },
-            left = false,
-            right = false,
-            showName = true,
-            options = {
+            left = {
+                backgroundColor = "catppuccin-frappe",
+                bo = {
+                    filetype = "my-file-type",
+                    buftype = "help",
+                    bufhidden = "",
+                    modifiable = true,
+                    buflisted = true,
+                    swapfile = true,
+                },
+                wo = {
+                    cursorline = true,
+                    cursorcolumn = true,
+                    number = true,
+                    relativenumber = true,
+                    foldenable = true,
+                    list = true,
+                },
+            },
+            right = {
+                backgroundColor = "catppuccin-frappe",
                 bo = {
                     filetype = "my-file-type",
                     buftype = "help",
@@ -113,29 +150,33 @@ T["setup()"]["overrides default values"] = function()
         },
     })]])
 
+    -- config
     eq_option(child, "width", 42)
     eq_option(child, "debug", true)
     eq_option(child, "disableOnLastBuffer", true)
     eq_option(child, "killAllBuffersOnDisable", true)
-    eq_option(child, "buffers.left", false)
-    eq_option(child, "buffers.right", false)
-    eq_option(child, "buffers.showName", true)
 
-    eq_option(child, "buffers.background.colorCode", "#2E1E2E")
+    -- buffers
+    eq_option(child, "buffers.setNames", true)
 
-    eq_option(child, "buffers.options.bo.filetype", "my-file-type")
-    eq_option(child, "buffers.options.bo.buftype", "help")
-    eq_option(child, "buffers.options.bo.bufhidden", "")
-    eq_option(child, "buffers.options.bo.modifiable", true)
-    eq_option(child, "buffers.options.bo.buflisted", true)
-    eq_option(child, "buffers.options.bo.swapfile", true)
+    -- common
+    for _, scope in pairs(SCOPES) do
+        eq_option(child, "buffers." .. scope .. ".backgroundColor", "#292C3C")
 
-    eq_option(child, "buffers.options.wo.cursorline", true)
-    eq_option(child, "buffers.options.wo.cursorcolumn", true)
-    eq_option(child, "buffers.options.wo.number", true)
-    eq_option(child, "buffers.options.wo.relativenumber", true)
-    eq_option(child, "buffers.options.wo.foldenable", true)
-    eq_option(child, "buffers.options.wo.list", true)
+        eq_option(child, "buffers." .. scope .. ".bo.filetype", "my-file-type")
+        eq_option(child, "buffers." .. scope .. ".bo.buftype", "help")
+        eq_option(child, "buffers." .. scope .. ".bo.bufhidden", "")
+        eq_option(child, "buffers." .. scope .. ".bo.modifiable", true)
+        eq_option(child, "buffers." .. scope .. ".bo.buflisted", true)
+        eq_option(child, "buffers." .. scope .. ".bo.swapfile", true)
+
+        eq_option(child, "buffers." .. scope .. ".wo.cursorline", true)
+        eq_option(child, "buffers." .. scope .. ".wo.cursorcolumn", true)
+        eq_option(child, "buffers." .. scope .. ".wo.number", true)
+        eq_option(child, "buffers." .. scope .. ".wo.relativenumber", true)
+        eq_option(child, "buffers." .. scope .. ".wo.foldenable", true)
+        eq_option(child, "buffers." .. scope .. ".wo.list", true)
+    end
 end
 
 T["setup()"]["colorCode: map integration name to a value"] = function()
@@ -157,14 +198,18 @@ T["setup()"]["colorCode: map integration name to a value"] = function()
         child.lua(string.format(
             [[require('no-neck-pain').setup({
                 buffers = {
-                    background = {
-                        colorCode = "%s"
-                    },
+                    common = { backgroundColor = "%s" },
+                    left = { backgroundColor = "%s" },
+                    right = { backgroundColor = "%s" },
                 },
             })]],
+            integration[1],
+            integration[1],
             integration[1]
         ))
-        eq_option(child, "buffers.background.colorCode", integration[2])
+        for _, scope in pairs(SCOPES) do
+            eq_option(child, "buffers." .. scope .. ".backgroundColor", integration[2])
+        end
     end
 end
 

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -32,7 +32,7 @@ end
 
 T["side buffers"]["only creates a `left` buffer when `right` is `false`"] = function()
     child.lua([[
-        require('no-neck-pain').setup({width=50,buffers={right=false}})
+        require('no-neck-pain').setup({width=50,buffers={right={enabled=false}}})
         require('no-neck-pain').enable()
     ]])
 
@@ -44,7 +44,7 @@ end
 
 T["side buffers"]["only creates a `right` buffer when `left` is `false`"] = function()
     child.lua([[
-        require('no-neck-pain').setup({width=50,buffers={left=false}})
+        require('no-neck-pain').setup({width=50,buffers={left={enabled=false}}})
         require('no-neck-pain').enable()
     ]])
 


### PR DESCRIPTION
## 📃 Summary

As discussed in #76, the exposed options have been refactored to allow more customization of the side buffers. We now provide:
- `common`: defines options common to both buffers
- `left`/`right`: defines options for the side buffer directly
