### PR TITLE
feat: handle side tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ test:
 		-c "lua require('mini.test').setup()" \
 		-c "lua MiniTest.run({ execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 1 }) } })"
 
-deps/mini.nvim:
+deps:
 	@mkdir -p deps
-	git clone --depth 1 https://github.com/echasnovski/mini.nvim $@
+	git clone --depth 1 https://github.com/echasnovski/mini.nvim deps/mini.nvim
 
-test-ci: deps/mini.nvim
+test-ci: deps
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua require('mini.test').setup()" \
 		-c "lua MiniTest.run()"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ require("no-neck-pain").setup({
             },
         },
     },
+    -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
+    integrations = {
+        -- https://github.com/nvim-tree/nvim-tree.lua
+        nvimTree = {
+            -- the position of the tree, can be `left` or `right``
+            position = "left",
+        },
+    },
 })
 ```
 

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -63,6 +63,14 @@ Default values:
               },
           },
       },
+      -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
+      integrations = {
+          -- https://github.com/nvim-tree/nvim-tree.lua
+          nvimTree = {
+              -- the position of the tree, can be `left` or `right``
+              position = "left",
+          },
+      },
   }
 
 <

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -63,6 +63,14 @@ NoNeckPain.options = {
             },
         },
     },
+    -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
+    integrations = {
+        -- https://github.com/nvim-tree/nvim-tree.lua
+        nvimTree = {
+            -- the position of the tree, can be `left` or `right``
+            position = "left",
+        },
+    },
 }
 
 --- Define your no-neck-pain setup.

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -7,11 +7,11 @@ function NNP.toggle()
     end
     local main = require("no-neck-pain.main")
 
-    if main.toggle() then
+    if main[1].toggle() then
         NNP.internal = {
-            toggle = main.toggle,
-            enable = main.enable,
-            disable = main.disable,
+            toggle = main[1].toggle,
+            enable = main[1].enable,
+            disable = main[1].disable,
         }
     else
         NNP.internal = {
@@ -21,20 +21,20 @@ function NNP.toggle()
         }
     end
 
-    NNP.state = main.state
+    NNP.state = main[2]
 end
 
 -- starts NNP and set internal functions and state.
 function NNP.enable()
     local main = require("no-neck-pain.main")
 
-    main.enable()
+    main[1].enable()
 
-    NNP.state = main.state
+    NNP.state = main[2]
     NNP.internal = {
-        toggle = main.toggle,
-        enable = main.enable,
-        disable = main.disable,
+        toggle = main[1].toggle,
+        enable = main[1].enable,
+        disable = main[1].disable,
     }
 end
 
@@ -42,9 +42,9 @@ end
 function NNP.disable()
     local main = require("no-neck-pain.main")
 
-    main.disable()
+    main[1].disable()
 
-    NNP.state = main.state
+    NNP.state = main[2]
 end
 
 -- setup NNP options and merge them with user provided ones.

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -2,24 +2,33 @@ local C = require("no-neck-pain.util.color")
 local D = require("no-neck-pain.util.debug")
 local M = require("no-neck-pain.util.map")
 local W = require("no-neck-pain.util.win")
-local SIDES = { "left", "right" }
 
-local NoNeckPain = {
-    state = {
-        enabled = false,
-        augroup = nil,
-        win = {
+-- internal methods
+local NoNeckPain = {}
+
+-- state
+local S = {
+    enabled = false,
+    augroup = nil,
+    win = {
+        main = {
             curr = nil,
             left = nil,
             right = nil,
             split = nil,
+        },
+        external = {
+            tree = {
+                id = nil,
+                width = 0,
+            },
         },
     },
 }
 
 --- Toggle the plugin by calling the `enable`/`disable` methods respectively.
 function NoNeckPain.toggle()
-    if NoNeckPain.state.enabled then
+    if S.enabled then
         NoNeckPain.disable()
 
         return false
@@ -31,14 +40,17 @@ function NoNeckPain.toggle()
 end
 
 -- Determine the "padding" (width) of the buffer based on the `_G.NoNeckPain.config.width` parameter.
-local function getPadding()
+--
+-- @param paddingToSubstract number: a value to be substracted to the `width` of the screen
+local function getPadding(paddingToSubstract)
+    paddingToSubstract = paddingToSubstract or 0
     local width = vim.api.nvim_list_uis()[1].width
 
     if _G.NoNeckPain.config.width >= width then
         return 1
     end
 
-    return math.floor((width - _G.NoNeckPain.config.width) / 2)
+    return math.floor((width - paddingToSubstract - _G.NoNeckPain.config.width) / 2)
 end
 
 -- Creates a buffer for the given "padding" (width), at the given `moveTo` direction.
@@ -92,16 +104,14 @@ local function createWin(action)
         local splitbelow, splitright = vim.o.splitbelow, vim.o.splitright
         vim.o.splitbelow, vim.o.splitright = true, true
 
-        NoNeckPain.state.win = {
-            curr = vim.api.nvim_get_current_win(),
-        }
+        S.win.main.curr = vim.api.nvim_get_current_win()
 
         if _G.NoNeckPain.config.buffers.left then
-            NoNeckPain.state.win.left = createBuf("left", "leftabove vnew", padding, "wincmd l")
+            S.win.main.left = createBuf("left", "leftabove vnew", padding, "wincmd l")
         end
 
         if _G.NoNeckPain.config.buffers.right then
-            NoNeckPain.state.win.right = createBuf("right", "vnew", padding, "wincmd h")
+            S.win.main.right = createBuf("right", "vnew", padding, "wincmd h")
         end
 
         vim.o.splitbelow, vim.o.splitright = splitbelow, splitright
@@ -109,26 +119,19 @@ local function createWin(action)
         return
     end
 
-    -- resize
-    for _, side in ipairs(SIDES) do
-        if
-            NoNeckPain.state.win[side] ~= nil
-            and vim.api.nvim_win_is_valid(NoNeckPain.state.win[side])
-        then
-            vim.api.nvim_win_set_width(NoNeckPain.state.win[side], padding)
-        end
-    end
+    W.resize("createWin", S.win.main.left, getPadding(S.win.external.tree.width * 2))
+    W.resize("createWin", S.win.main.right, getPadding())
 end
 
 --- Initializes NNP and sets event listeners.
 function NoNeckPain.enable()
-    if NoNeckPain.state.enabled then
+    if S.enabled then
         return D.print("Enable: tried to enable already enabled NNP")
     end
 
     D.print("enabling NNP")
 
-    NoNeckPain.state.augroup = vim.api.nvim_create_augroup("NoNeckPain", {
+    S.augroup = vim.api.nvim_create_augroup("NoNeckPain", {
         clear = true,
     })
 
@@ -137,12 +140,12 @@ function NoNeckPain.enable()
     vim.api.nvim_create_autocmd({ "VimResized" }, {
         callback = function()
             vim.schedule(function()
-                if not NoNeckPain.state.enabled then
+                if not S.enabled then
                     return D.print("VimResized: event received but NNP is disabled")
                 end
 
                 if
-                    NoNeckPain.state.win.split ~= nil
+                    S.win.main.split ~= nil
                     -- we don't want close action on float window to impact NNP
                     or W.isRelativeWindow("VimEnter")
                 then
@@ -156,7 +159,7 @@ function NoNeckPain.enable()
                 if width > _G.NoNeckPain.config.width then
                     D.print("VimResized: window's width is above the `width` option")
 
-                    if NoNeckPain.state.win.left == nil and NoNeckPain.state.win.right == nil then
+                    if S.win.main.left == nil and S.win.main.right == nil then
                         D.print("VimResized: no side buffer found, creating...")
 
                         return createWin("init")
@@ -171,14 +174,14 @@ function NoNeckPain.enable()
                     "VimResized: window's width is below the `width` option, closing opened buffers..."
                 )
 
-                local ok = W.close("VimResized", NoNeckPain.state.win.left)
+                local ok = W.close("VimResized", S.win.main.left)
                 if ok then
-                    NoNeckPain.state.win.left = nil
+                    S.win.main.left = nil
                 end
 
-                ok = W.close("VimResized", NoNeckPain.state.win.right)
+                ok = W.close("VimResized", S.win.main.right)
                 if ok then
-                    NoNeckPain.state.win.right = nil
+                    S.win.main.right = nil
                 end
             end)
         end,
@@ -189,12 +192,12 @@ function NoNeckPain.enable()
     vim.api.nvim_create_autocmd({ "WinEnter" }, {
         callback = function()
             vim.schedule(function()
-                if not NoNeckPain.state.enabled then
+                if not S.enabled then
                     return D.print("WinEnter: event received but NNP is disabled")
                 end
 
                 if
-                    NoNeckPain.state.win.split ~= nil
+                    S.win.main.split ~= nil
                     -- we don't want close action on float window to impact NNP
                     or W.isRelativeWindow("WinEnter")
                 then
@@ -203,7 +206,7 @@ function NoNeckPain.enable()
                     )
                 end
 
-                local buffers, total = W.bufferListWithoutNNP("WinEnter")
+                local buffers, total = W.bufferListWithoutNNP("WinEnter", S.win.main)
                 local focusedWin = vim.api.nvim_get_current_win()
 
                 if total == 0 or not M.contains(buffers, focusedWin) then
@@ -212,17 +215,23 @@ function NoNeckPain.enable()
 
                 D.print("WinEnter: found ", total, " remaining valid buffers")
 
-                -- start by saving the split, because steps below will trigger `WinClosed`
-                NoNeckPain.state.win.split = focusedWin
+                -- below we will check for plugins that opens windows as splits (e.g. tree)
+                -- and early return while storing its NoNeckPain.
+                if vim.api.nvim_buf_get_option(0, "filetype") == "NvimTree" then
+                    S.win.external.tree.id = focusedWin
 
-                local ok = W.close("WinEnter", NoNeckPain.state.win.left)
-                if ok then
-                    NoNeckPain.state.win.left = nil
+                    return D.print("WinEnter: encoutered an NvimTree split")
                 end
 
-                ok = W.close("WinEnter", NoNeckPain.state.win.right)
-                if ok then
-                    NoNeckPain.state.win.right = nil
+                -- start by saving the split, because steps below will trigger `WinClosed`
+                S.win.main.split = focusedWin
+
+                if W.close("WinEnter", S.win.main.left) then
+                    S.win.main.left = nil
+                end
+
+                if W.close("WinEnter", S.win.main.right) then
+                    S.win.main.right = nil
                 end
             end)
         end,
@@ -233,7 +242,7 @@ function NoNeckPain.enable()
     vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
         callback = function()
             vim.schedule(function()
-                if not NoNeckPain.state.enabled then
+                if not S.enabled then
                     return D.print("WinClose, BufDelete: event received but NNP is disabled")
                 end
 
@@ -246,10 +255,7 @@ function NoNeckPain.enable()
 
                 -- if we are not in split view, we check if we killed one of the main buffers (curr, left, right) to disable NNP
                 -- TODO: make killed side buffer decision configurable, we can re-create it
-                if
-                    NoNeckPain.state.win.split == nil
-                    and not M.every(buffers, NoNeckPain.state.win)
-                then
+                if S.win.main.split == nil and not M.every(buffers, S.win.main) then
                     D.print(
                         "WinClosed, BufDelete: one of the NNP main buffers have been closed, disabling..."
                     )
@@ -257,7 +263,12 @@ function NoNeckPain.enable()
                     return NoNeckPain.disable()
                 end
 
-                local _, total = W.bufferListWithoutNNP("WinClosed, BufDelete")
+                local _, total = W.bufferListWithoutNNP("WinClosed, BufDelete", {
+                    S.win.main.curr,
+                    S.win.main.left,
+                    S.win.main.right,
+                    S.win.external.tree.id,
+                })
 
                 if
                     _G.NoNeckPain.config.disableOnLastBuffer
@@ -275,11 +286,11 @@ function NoNeckPain.enable()
                     )
                 end
 
-                NoNeckPain.state.win.curr = buffers[0]
-                NoNeckPain.state.win.split = nil
+                S.win.main.curr = buffers[0]
+                S.win.main.split = nil
 
                 -- focus curr
-                vim.fn.win_gotoid(NoNeckPain.state.win.curr)
+                vim.fn.win_gotoid(S.win.main.curr)
 
                 -- recreate everything
                 createWin("init")
@@ -292,95 +303,96 @@ function NoNeckPain.enable()
     vim.api.nvim_create_autocmd({ "WinEnter", "WinClosed" }, {
         callback = function()
             vim.schedule(function()
-                if not NoNeckPain.state.enabled then
+                if not S.enabled then
                     return D.print("WinEnter, WinClosed: event received but NNP is disabled")
                 end
 
-                if NoNeckPain.state.win.split ~= nil or W.isRelativeWindow("WinEnter") then
+                if S.win.main.split ~= nil or W.isRelativeWindow("WinEnter") then
                     return D.print("WinEnter: stop because of split view or float window")
                 end
 
                 local focusedWin = vim.api.nvim_get_current_win()
 
                 -- skip if the newly focused window is a side buffer
-                if
-                    focusedWin == NoNeckPain.state.win.left
-                    or focusedWin == NoNeckPain.state.win.right
-                then
+                if focusedWin == S.win.main.left or focusedWin == S.win.main.right then
                     return D.print("WinEnter, WinClosed: focus on side buffer, skipped resize")
                 end
 
-                local padding = 0
-
                 -- when opening a new buffer as current, store its padding and resize everything (e.g. side tree)
-                if focusedWin ~= NoNeckPain.state.win.curr then
+                if focusedWin ~= S.win.main.curr then
+                    S.win.external.tree.width = vim.api.nvim_win_get_width(focusedWin)
+
                     D.print(
-                        "WinEnter, WinClosed: new current buffer found",
-                        focusedWin,
-                        "resizing:",
-                        padding
+                        "WinEnter, WinClosed: new current buffer with width:",
+                        S.win.external.tree.width
                     )
-
-                    padding = vim.api.nvim_win_get_width(focusedWin)
                 end
 
-                local width = vim.api.nvim_list_uis()[1].width
-                local totalSideSizes = (width - padding) - _G.NoNeckPain.config.width
-
-                D.print("WinEnter, WinClosed: resizing side buffers")
-                for _, side in ipairs(SIDES) do
-                    if NoNeckPain.state.win[side] ~= nil then
-                        if vim.api.nvim_win_is_valid(NoNeckPain.state.win[side]) then
-                            vim.api.nvim_win_set_width(
-                                NoNeckPain.state.win[side],
-                                math.floor(totalSideSizes / 2)
-                            )
-                        end
-                    end
+                if not M.contains(vim.api.nvim_list_wins(), S.win.external.tree.id) then
+                    S.win.external.tree = {
+                        id = nil,
+                        width = 0,
+                    }
                 end
+
+                -- TODO: Make this configurable, here we assume the tree is on the left of the screen.
+                W.resize(
+                    "WinEnter, WinClosed",
+                    S.win.main.left,
+                    getPadding(S.win.external.tree.width * 2)
+                )
+                W.resize("WinEnter, WinClosed", S.win.main.right, getPadding())
             end)
         end,
         group = "NoNeckPain",
         desc = "Resize to apply on WinEnter/Closed",
     })
 
-    NoNeckPain.state.enabled = true
+    S.enabled = true
 end
 
 --- Disable NNP and reset windows, leaving the `curr` focused window as focused.
 function NoNeckPain.disable()
-    if not NoNeckPain.state.enabled then
+    if not S.enabled then
         return D.print("Disable: tried to disable non-enabled NNP")
     end
 
     D.print("disabling NNP")
 
-    NoNeckPain.state.enabled = false
-    vim.api.nvim_del_augroup_by_id(NoNeckPain.state.augroup)
+    S.enabled = false
+    vim.api.nvim_del_augroup_by_id(S.augroup)
 
-    W.close("Disable left", NoNeckPain.state.win.left)
-    W.close("Disable right", NoNeckPain.state.win.right)
+    W.close("Disable left", S.win.main.left)
+    W.close("Disable right", S.win.main.right)
 
     -- shutdowns gracefully by focusing the stored `curr` buffer, if possible
     if
-        NoNeckPain.state.win.curr ~= nil
-        and vim.api.nvim_win_is_valid(NoNeckPain.state.win.curr)
-        and NoNeckPain.state.win.curr ~= vim.api.nvim_get_current_win()
+        S.win.main.curr ~= nil
+        and vim.api.nvim_win_is_valid(S.win.main.curr)
+        and S.win.main.curr ~= vim.api.nvim_get_current_win()
     then
-        vim.fn.win_gotoid(NoNeckPain.state.win.curr)
+        vim.fn.win_gotoid(S.win.main.curr)
     end
 
     if _G.NoNeckPain.config.killAllBuffersOnDisable then
         vim.cmd("only")
     end
 
-    NoNeckPain.state.augroup = nil
-    NoNeckPain.state.win = {
-        curr = nil,
-        left = nil,
-        right = nil,
-        split = nil,
+    S.augroup = nil
+    S.win = {
+        main = {
+            curr = nil,
+            left = nil,
+            right = nil,
+            split = nil,
+        },
+        external = {
+            tree = {
+                id = nil,
+                width = 0,
+            },
+        },
     }
 end
 
-return NoNeckPain
+return { NoNeckPain, S }

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -69,11 +69,49 @@ function W.resize(scope, win, padding)
         return
     end
 
-    if vim.api.nvim_win_is_valid(win) then
-        D.print(scope, "resizing", win, padding)
+    D.print(scope .. ": resizing window " .. win .. " with padding", padding)
 
+    if vim.api.nvim_win_is_valid(win) then
         vim.api.nvim_win_set_width(win, padding)
     end
+end
+
+function W.getSideTree()
+    local wins = vim.api.nvim_list_wins()
+
+    for _, win in pairs(wins) do
+        if vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(win), "filetype") == "NvimTree" then
+            return {
+                id = win,
+                width = vim.api.nvim_win_get_width(win) * 2,
+            }
+        end
+    end
+
+    return {
+        id = nil,
+        width = 0,
+    }
+end
+
+-- Determine the "padding" (width) of the buffer based on the `_G.NoNeckPain.config.width`, the width of the screen, and it a side tree is currently open.
+--
+-- @param paddingToSubstract number: a value to be substracted to the `width` of the screen
+function W.getPadding(side, paddingToSubstract)
+    local width = vim.api.nvim_list_uis()[1].width
+
+    if _G.NoNeckPain.config.width >= width then
+        return 1
+    end
+
+    paddingToSubstract = paddingToSubstract or 0
+
+    -- if the side we are resizing is not the same as the tree position, we set it to 0
+    if side ~= _G.NoNeckPain.config.integrations.nvimTree.position then
+        paddingToSubstract = 0
+    end
+
+    return math.floor((width - paddingToSubstract - _G.NoNeckPain.config.width) / 2)
 end
 
 return W

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -3,18 +3,13 @@ local M = require("no-neck-pain.util.map")
 local W = {}
 
 -- returns the buffers without the NNP ones, and their number.
-function W.bufferListWithoutNNP(scope)
+function W.bufferListWithoutNNP(scope, list)
     local buffers = vim.api.nvim_list_wins()
     local validBuffers = {}
     local size = 0
 
     for _, buffer in pairs(buffers) do
-        if
-            buffer ~= _G.NoNeckPain.state.win.curr
-            and buffer ~= _G.NoNeckPain.state.win.left
-            and buffer ~= _G.NoNeckPain.state.win.right
-            and not W.isRelativeWindow(scope, buffer)
-        then
+        if not M.contains(list, buffer) and not W.isRelativeWindow(scope, buffer) then
             table.insert(validBuffers, buffer)
             size = size + 1
         end
@@ -66,6 +61,19 @@ function W.close(scope, win)
     end
 
     return true
+end
+
+-- resizes a given `win` for the given `padding`
+function W.resize(scope, win, padding)
+    if win == nil then
+        return
+    end
+
+    if vim.api.nvim_win_is_valid(win) then
+        D.print(scope, "resizing", win, padding)
+
+        vim.api.nvim_win_set_width(win, padding)
+    end
 end
 
 return W

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -94,9 +94,9 @@ function W.getSideTree()
     }
 end
 
--- Determine the "padding" (width) of the buffer based on the `_G.NoNeckPain.config.width`, the width of the screen, and it a side tree is currently open.
+-- Determine the "padding" (width) of the buffer based on the `_G.NoNeckPain.config.width` and the width of the screen.
 --
--- @param paddingToSubstract number: a value to be substracted to the `width` of the screen
+-- @param paddingToSubstract number: a value to be substracted to the `width` of the screen.
 function W.getPadding(side, paddingToSubstract)
     local width = vim.api.nvim_list_uis()[1].width
 

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -10,6 +10,6 @@ if #vim.api.nvim_list_uis() == 0 then
     -- Set up 'mini.test'
     require("mini.test").setup()
 
-    -- Set up 'mini.test'
+    -- Set up 'mini.doc'
     require("mini.doc").setup()
 end

--- a/scripts/minitest.lua
+++ b/scripts/minitest.lua
@@ -1,6 +1,0 @@
-local minitest = require("mini.test")
-
-if _G.MiniTest == nil then
-    minitest.setup()
-end
-minitest.run()

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -188,11 +188,17 @@ T["enable()"]["sets state and internal methods"] = function()
     eq_state(child, "augroup", 15)
 
     eq_type_state(child, "win", "table")
+    eq_type_state(child, "win.main", "table")
+    eq_type_state(child, "win.external", "table")
 
-    eq_state(child, "win.curr", 1000)
-    eq_state(child, "win.left", 1001)
-    eq_state(child, "win.right", 1002)
-    eq_state(child, "win.split", vim.NIL)
+    eq_state(child, "win.main.curr", 1000)
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", 1002)
+    eq_state(child, "win.main.split", vim.NIL)
+
+    eq_type_state(child, "win.external.tree", "table")
+    eq_state(child, "win.external.tree.id", vim.NIL)
+    eq_state(child, "win.external.tree.width", 0)
 end
 
 T["disable()"] = MiniTest.new_set()
@@ -207,11 +213,17 @@ T["disable()"]["resets state and remove internal methods"] = function()
     eq_state(child, "augroup", vim.NIL)
 
     eq_type_state(child, "win", "table")
+    eq_type_state(child, "win.main", "table")
+    eq_type_state(child, "win.external", "table")
 
-    eq_state(child, "win.curr", vim.NIL)
-    eq_state(child, "win.left", vim.NIL)
-    eq_state(child, "win.right", vim.NIL)
-    eq_state(child, "win.split", vim.NIL)
+    eq_state(child, "win.main.curr", vim.NIL)
+    eq_state(child, "win.main.left", vim.NIL)
+    eq_state(child, "win.main.right", vim.NIL)
+    eq_state(child, "win.main.split", vim.NIL)
+
+    eq_type_state(child, "win.external.tree", "table")
+    eq_state(child, "win.external.tree.id", vim.NIL)
+    eq_state(child, "win.external.tree.width", 0)
 end
 
 T["toggle()"] = MiniTest.new_set()
@@ -235,11 +247,17 @@ T["toggle()"]["sets state and internal methods and resets everything when toggle
         eq_state(child, "augroup", 15)
 
         eq_type_state(child, "win", "table")
+        eq_type_state(child, "win.main", "table")
+        eq_type_state(child, "win.external", "table")
 
-        eq_state(child, "win.curr", 1000)
-        eq_state(child, "win.left", 1001)
-        eq_state(child, "win.right", 1002)
-        eq_state(child, "win.split", vim.NIL)
+        eq_state(child, "win.main.curr", 1000)
+        eq_state(child, "win.main.left", 1001)
+        eq_state(child, "win.main.right", 1002)
+        eq_state(child, "win.main.split", vim.NIL)
+
+        eq_type_state(child, "win.external.tree", "table")
+        eq_state(child, "win.external.tree.id", vim.NIL)
+        eq_state(child, "win.external.tree.width", 0)
 
         -- disable
         child.lua([[require('no-neck-pain').toggle()]])
@@ -251,11 +269,17 @@ T["toggle()"]["sets state and internal methods and resets everything when toggle
         eq_state(child, "augroup", vim.NIL)
 
         eq_type_state(child, "win", "table")
+        eq_type_state(child, "win.main", "table")
+        eq_type_state(child, "win.external", "table")
 
-        eq_state(child, "win.curr", vim.NIL)
-        eq_state(child, "win.left", vim.NIL)
-        eq_state(child, "win.right", vim.NIL)
-        eq_state(child, "win.split", vim.NIL)
+        eq_state(child, "win.main.curr", vim.NIL)
+        eq_state(child, "win.main.left", vim.NIL)
+        eq_state(child, "win.main.right", vim.NIL)
+        eq_state(child, "win.main.split", vim.NIL)
+
+        eq_type_state(child, "win.external.tree", "table")
+        eq_state(child, "win.external.tree.id", vim.NIL)
+        eq_state(child, "win.external.tree.width", 0)
     end
 
 return T

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -26,8 +26,8 @@ T["side buffers"]["have the same width"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq_buf_width(child, "left", 15)
-    eq_buf_width(child, "right", 15)
+    eq_buf_width(child, "main.left", 15)
+    eq_buf_width(child, "main.right", 15)
 end
 
 T["side buffers"]["only creates a `left` buffer when `right` is `false`"] = function()
@@ -36,10 +36,10 @@ T["side buffers"]["only creates a `left` buffer when `right` is `false`"] = func
         require('no-neck-pain').enable()
     ]])
 
-    eq_state(child, "win.left", 1001)
-    eq_state(child, "win.right", vim.NIL)
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", vim.NIL)
 
-    eq_buf_width(child, "left", 15)
+    eq_buf_width(child, "main.left", 15)
 end
 
 T["side buffers"]["only creates a `right` buffer when `left` is `false`"] = function()
@@ -48,10 +48,10 @@ T["side buffers"]["only creates a `right` buffer when `left` is `false`"] = func
         require('no-neck-pain').enable()
     ]])
 
-    eq_state(child, "win.left", vim.NIL)
-    eq_state(child, "win.right", 1001)
+    eq_state(child, "win.main.left", vim.NIL)
+    eq_state(child, "win.main.right", 1001)
 
-    eq_buf_width(child, "right", 15)
+    eq_buf_width(child, "main.right", 15)
 end
 
 T["side buffers"]["closing the `left` buffer kills the `right one"] = function()
@@ -61,8 +61,8 @@ T["side buffers"]["closing the `left` buffer kills the `right one"] = function()
     ]])
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
-    eq_state(child, "win.left", 1001)
-    eq_state(child, "win.right", 1002)
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", 1002)
 
     child.lua("vim.api.nvim_win_close(1002, false)")
 
@@ -76,8 +76,8 @@ T["side buffers"]["closing the `right` buffer kills the `left` one"] = function(
     ]])
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
-    eq_state(child, "win.left", 1001)
-    eq_state(child, "win.right", 1002)
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", 1002)
 
     child.lua("vim.api.nvim_win_close(1001, false)")
 
@@ -92,7 +92,7 @@ T["curr buffer"]["have the default width from the config"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq_buf_width(child, "curr", 48)
+    eq_buf_width(child, "main.curr", 48)
 end
 
 T["curr buffer"]["closing `curr` buffer without any other window open closes Neovim"] = function()
@@ -102,7 +102,7 @@ T["curr buffer"]["closing `curr` buffer without any other window open closes Neo
     ]])
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
-    eq_state(child, "win.curr", 1000)
+    eq_state(child, "win.main.curr", 1000)
 
     child.lua("vim.api.nvim_win_close(1000, false)")
 
@@ -121,9 +121,9 @@ T["auto command"]["does not create side buffers window's width < options.width"]
         ]])
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
-    eq_state(child, "win.curr", 1000)
-    eq_state(child, "win.left", vim.NIL)
-    eq_state(child, "win.right", vim.NIL)
+    eq_state(child, "win.main.curr", 1000)
+    eq_state(child, "win.main.left", vim.NIL)
+    eq_state(child, "win.main.right", vim.NIL)
 end
 
 T["auto command"]["closing `curr` makes `split` the new `curr`"] = function()
@@ -133,21 +133,21 @@ T["auto command"]["closing `curr` makes `split` the new `curr`"] = function()
         ]])
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
-    eq_state(child, "win.split", vim.NIL)
+    eq_state(child, "win.main.split", vim.NIL)
 
     child.cmd("split")
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1003, 1000 })
-    eq_state(child, "win.left", vim.NIL)
-    eq_state(child, "win.right", vim.NIL)
-    eq_state(child, "win.split", 1003)
+    eq_state(child, "win.main.left", vim.NIL)
+    eq_state(child, "win.main.right", vim.NIL)
+    eq_state(child, "win.main.split", 1003)
 
     child.lua("vim.api.nvim_win_close(1000, false)")
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1003, 1005 })
-    eq_state(child, "win.curr", 1003)
-    eq_state(child, "win.left", 1004)
-    eq_state(child, "win.right", 1005)
-    eq_state(child, "win.split", vim.NIL)
+    eq_state(child, "win.main.curr", 1003)
+    eq_state(child, "win.main.left", 1004)
+    eq_state(child, "win.main.right", 1005)
+    eq_state(child, "win.main.split", vim.NIL)
 end
 
 T["auto command"]["hides side buffers after split"] = function()
@@ -158,32 +158,32 @@ T["auto command"]["hides side buffers after split"] = function()
 
     -- At start 1 win automatically sorrounded with side buffers
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
-    eq_state(child, "win.left", 1001)
-    eq_state(child, "win.right", 1002)
-    eq_state(child, "win.split", vim.NIL)
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", 1002)
+    eq_state(child, "win.main.split", vim.NIL)
 
-    eq_buf_width(child, "left", 15)
-    eq_buf_width(child, "right", 15)
+    eq_buf_width(child, "main.left", 15)
+    eq_buf_width(child, "main.right", 15)
 
     -- Opening split hides side buffers
     child.cmd("split")
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1003, 1000 })
-    eq_state(child, "win.left", vim.NIL)
-    eq_state(child, "win.right", vim.NIL)
-    eq_state(child, "win.split", 1003)
+    eq_state(child, "win.main.left", vim.NIL)
+    eq_state(child, "win.main.right", vim.NIL)
+    eq_state(child, "win.main.split", 1003)
 
-    eq_buf_width(child, "split", 80)
-    eq_buf_width(child, "curr", 80)
+    eq_buf_width(child, "main.split", 80)
+    eq_buf_width(child, "main.curr", 80)
 
     -- Closing split and returning to last window opens side buffers again
     child.cmd("close")
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1000, 1005 })
-    eq_state(child, "win.left", 1004)
-    eq_state(child, "win.right", 1005)
-    eq_state(child, "win.split", vim.NIL)
+    eq_state(child, "win.main.left", 1004)
+    eq_state(child, "win.main.right", 1005)
+    eq_state(child, "win.main.split", vim.NIL)
 
-    eq_buf_width(child, "left", 15)
-    eq_buf_width(child, "right", 15)
+    eq_buf_width(child, "main.left", 15)
+    eq_buf_width(child, "main.right", 15)
 end
 
 T["auto command"]["hides side buffers after vsplit"] = function()
@@ -194,32 +194,32 @@ T["auto command"]["hides side buffers after vsplit"] = function()
 
     -- At start 1 win automatically sorrounded with side buffers
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
-    eq_state(child, "win.left", 1001)
-    eq_state(child, "win.right", 1002)
-    eq_state(child, "win.split", vim.NIL)
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", 1002)
+    eq_state(child, "win.main.split", vim.NIL)
 
-    eq_buf_width(child, "left", 15)
-    eq_buf_width(child, "right", 15)
+    eq_buf_width(child, "main.left", 15)
+    eq_buf_width(child, "main.right", 15)
 
     -- Opening vsplit hides side buffers
     child.cmd("vsplit")
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1003, 1000 })
-    eq_state(child, "win.left", vim.NIL)
-    eq_state(child, "win.right", vim.NIL)
-    eq_state(child, "win.split", 1003)
+    eq_state(child, "win.main.left", vim.NIL)
+    eq_state(child, "win.main.right", vim.NIL)
+    eq_state(child, "win.main.split", 1003)
 
-    eq_buf_width(child, "split", 40)
-    eq_buf_width(child, "curr", 39)
+    eq_buf_width(child, "main.split", 40)
+    eq_buf_width(child, "main.curr", 39)
 
     -- Closing vsplit and returning to last window opens side buffers again
     child.cmd("close")
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1000, 1005 })
-    eq_state(child, "win.left", 1004)
-    eq_state(child, "win.right", 1005)
-    eq_state(child, "win.split", vim.NIL)
+    eq_state(child, "win.main.left", 1004)
+    eq_state(child, "win.main.right", 1005)
+    eq_state(child, "win.main.split", vim.NIL)
 
-    eq_buf_width(child, "left", 15)
-    eq_buf_width(child, "right", 15)
+    eq_buf_width(child, "main.left", 15)
+    eq_buf_width(child, "main.right", 15)
 end
 
 T["auto command"]["does not shift using when opening/closing float window"] = function()
@@ -230,11 +230,11 @@ T["auto command"]["does not shift using when opening/closing float window"] = fu
 
     -- At start 1 win automatically sorrounded with side buffers
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
-    eq_state(child, "win.left", 1001)
-    eq_state(child, "win.right", 1002)
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", 1002)
 
-    eq_buf_width(child, "left", 15)
-    eq_buf_width(child, "right", 15)
+    eq_buf_width(child, "main.left", 15)
+    eq_buf_width(child, "main.right", 15)
 
     -- Opening float window keeps the buffer here with the same width
     child.lua(
@@ -242,21 +242,21 @@ T["auto command"]["does not shift using when opening/closing float window"] = fu
     )
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002, 1003 })
-    eq_state(child, "win.left", 1001)
-    eq_state(child, "win.right", 1002)
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", 1002)
 
-    eq_buf_width(child, "left", 15)
-    eq_buf_width(child, "right", 15)
+    eq_buf_width(child, "main.left", 15)
+    eq_buf_width(child, "main.right", 15)
 
     -- Close float window keeps the buffer here with the same width
     child.lua("vim.api.nvim_win_close(1003, false)")
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
-    eq_state(child, "win.left", 1001)
-    eq_state(child, "win.right", 1002)
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", 1002)
 
-    eq_buf_width(child, "left", 15)
-    eq_buf_width(child, "right", 15)
+    eq_buf_width(child, "main.left", 15)
+    eq_buf_width(child, "main.right", 15)
 end
 
 return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/77

This update aims at making NNP correctly resize its side buffers when there's a side tree that opens, or is already opened.

- [x] provide an option to configure the tree position (`left` or `right`)
- [x] correctly positions NNP when enabling it with the tree open
- [ ] https://github.com/simrat39/symbols-outline.nvim is supported: **not yet**

## Other changes

The internal state API have been rewrote to store `external` window values (e.g. tree). it doesn't change how NNP works at all, but should be less verbose.

## 📸 Preview

### With overflow right

<img width="1280" alt="Screenshot 2022-12-19 at 22 42 25" src="https://user-images.githubusercontent.com/20689156/208529715-1a00a306-9f4a-4264-ae1d-549e1cbb85fe.png">

### With both side buffers

<img width="1280" alt="Screenshot 2022-12-19 at 22 43 18" src="https://user-images.githubusercontent.com/20689156/208529885-9cd89e1d-2b43-48b2-93dd-b79e63eebf7f.png">

