### PR TITLE
fix: adjust catppuccin colors to the correct values

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ require("no-neck-pain").setup({
             position = "left",
         },
     },
-
 })
 
 NoNeckPain.bufferOptions = {
@@ -178,7 +177,6 @@ NoNeckPain.bufferOptions = {
         foldenable = false,
         list = false,
     },
-
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,13 @@ require("no-neck-pain").setup({
             -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
             -- popular theme are supported by their name:
             -- - catppuccin-frappe
+            -- - catppuccin-frappe-dark
             -- - catppuccin-latte
+            -- - catppuccin-latte-dark
             -- - catppuccin-macchiato
+            -- - catppuccin-macchiato-dark
             -- - catppuccin-mocha
+            -- - catppuccin-mocha-dark
             -- - tokyonight-day
             -- - tokyonight-moon
             -- - tokyonight-night

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -23,9 +23,13 @@ Default values:
               -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
               -- popular theme are supported by their name:
               -- - catppuccin-frappe
+              -- - catppuccin-frappe-dark
               -- - catppuccin-latte
+              -- - catppuccin-latte-dark
               -- - catppuccin-macchiato
+              -- - catppuccin-macchiato-dark
               -- - catppuccin-mocha
+              -- - catppuccin-mocha-dark
               -- - tokyonight-day
               -- - tokyonight-moon
               -- - tokyonight-night

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -12,9 +12,13 @@ Default values:
       -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
       -- popular theme are supported by their name:
       -- - catppuccin-frappe
+      -- - catppuccin-frappe-dark
       -- - catppuccin-latte
+      -- - catppuccin-latte-dark
       -- - catppuccin-macchiato
+      -- - catppuccin-macchiato-dark
       -- - catppuccin-mocha
+      -- - catppuccin-mocha-dark
       -- - tokyonight-day
       -- - tokyonight-moon
       -- - tokyonight-night
@@ -64,34 +68,6 @@ Default values:
       killAllBuffersOnDisable = false,
       --- Options related to the side buffers. See |NoNeckPain.bufferOptions|.
       buffers = {
-<<<<<<< HEAD
-          -- The background options of the side buffer(s).
-          background = {
-              -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-              -- popular theme are supported by their name:
-              -- - catppuccin-frappe
-              -- - catppuccin-frappe-dark
-              -- - catppuccin-latte
-              -- - catppuccin-latte-dark
-              -- - catppuccin-macchiato
-              -- - catppuccin-macchiato-dark
-              -- - catppuccin-mocha
-              -- - catppuccin-mocha-dark
-              -- - tokyonight-day
-              -- - tokyonight-moon
-              -- - tokyonight-night
-              -- - tokyonight-storm
-              -- - rose-pine
-              -- - rose-pine-moon
-              -- - rose-pine-dawn
-              colorCode = nil,
-          },
-          -- When `false`, the `left` padding buffer won't be created.
-          left = true,
-          -- When `false`, the `right` padding buffer won't be created.
-          right = true,
-=======
->>>>>>> main
           -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
           setNames = false,
           -- Common options are set to both buffers, for option scoped to the `left` and/or `right` buffer, see `buffers.left` and `buffers.right`.

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -23,9 +23,13 @@ NoNeckPain.options = {
             -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
             -- popular theme are supported by their name:
             -- - catppuccin-frappe
+            -- - catppuccin-frappe-dark
             -- - catppuccin-latte
+            -- - catppuccin-latte-dark
             -- - catppuccin-macchiato
+            -- - catppuccin-macchiato-dark
             -- - catppuccin-mocha
+            -- - catppuccin-mocha-dark
             -- - tokyonight-day
             -- - tokyonight-moon
             -- - tokyonight-night

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -4,13 +4,13 @@ local C = {}
 -- tries to match the provided `colorCode` to an integration name, defaults to the provided string if not successful.
 function C.matchIntegrationToHexCode(colorCode)
     if colorCode == "catppuccin-frappe" then
-        colorCode = "#292C3C"
+        colorCode = "#303446"
     elseif colorCode == "catppuccin-latte" then
-        colorCode = "#E6E9EF"
+        colorCode = "#EFF1F5"
     elseif colorCode == "catppuccin-macchiato" then
-        colorCode = "#1E2030"
+        colorCode = "#24273A"
     elseif colorCode == "catppuccin-mocha" then
-        colorCode = "#181825"
+        colorCode = "#1E1E2E"
     elseif colorCode == "tokyonight-day" then
         colorCode = "#16161e"
     elseif colorCode == "tokyonight-moon" then

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -5,12 +5,20 @@ local C = {}
 function C.matchIntegrationToHexCode(colorCode)
     if colorCode == "catppuccin-frappe" then
         colorCode = "#303446"
+    elseif colorCode == "catppuccin-frappe-dark" then
+        colorCode = "#292C3C"
     elseif colorCode == "catppuccin-latte" then
         colorCode = "#EFF1F5"
+    elseif colorCode == "catppuccin-latte-dark" then
+        colorCode = "#E6E9EF"
     elseif colorCode == "catppuccin-macchiato" then
         colorCode = "#24273A"
+    elseif colorCode == "catppuccin-macchiato-dark" then
+        colorCode = "#1E2030"
     elseif colorCode == "catppuccin-mocha" then
         colorCode = "#1E1E2E"
+    elseif colorCode == "catppuccin-mocha-dark" then
+        colorCode = "#181825"
     elseif colorCode == "tokyonight-day" then
         colorCode = "#16161e"
     elseif colorCode == "tokyonight-moon" then

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -140,10 +140,10 @@ end
 
 T["setup()"]["colorCode: map integration name to a value"] = function()
     local integrationsMapping = {
-        { "catppuccin-frappe", "#292C3C" },
-        { "catppuccin-latte", "#E6E9EF" },
-        { "catppuccin-macchiato", "#1E2030" },
-        { "catppuccin-mocha", "#181825" },
+        { "catppuccin-frappe", "#303446" },
+        { "catppuccin-latte", "#EFF1F5" },
+        { "catppuccin-macchiato", "#24273A" },
+        { "catppuccin-mocha", "#1E1E2E" },
         { "tokyonight-day", "#16161e" },
         { "tokyonight-moon", "#1e2030" },
         { "tokyonight-storm", "#1f2335" },

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -141,9 +141,13 @@ end
 T["setup()"]["colorCode: map integration name to a value"] = function()
     local integrationsMapping = {
         { "catppuccin-frappe", "#303446" },
+        { "catppuccin-frappe-dark", "#292C3C" },
         { "catppuccin-latte", "#EFF1F5" },
+        { "catppuccin-latte-dark", "#E6E9EF" },
         { "catppuccin-macchiato", "#24273A" },
+        { "catppuccin-macchiato-dark", "#1E2030" },
         { "catppuccin-mocha", "#1E1E2E" },
+        { "catppuccin-mocha-dark", "#181825" },
         { "tokyonight-day", "#16161e" },
         { "tokyonight-moon", "#1e2030" },
         { "tokyonight-storm", "#1f2335" },


### PR DESCRIPTION
## 📃 Summary

The editor background uses the `base` color of the palette, as defined [here](https://github.com/catppuccin/nvim/blob/55f43a952856bc0029e6cef066297c6cfab3451d/lua/catppuccin/groups/editor.lua#L32). Currently the `crust` values are being used, making the side buffers darker than the main window.

We now provide both color themes.

- [Frappe](https://github.com/catppuccin/nvim/blob/55f43a952856bc0029e6cef066297c6cfab3451d/lua/catppuccin/palettes/frappe.lua#L32)
- [Latte](https://github.com/catppuccin/nvim/blob/55f43a952856bc0029e6cef066297c6cfab3451d/lua/catppuccin/palettes/latte.lua#L32)
- [Macchiato](https://github.com/catppuccin/nvim/blob/55f43a952856bc0029e6cef066297c6cfab3451d/lua/catppuccin/palettes/macchiato.lua#L32)
- [Mocha](https://github.com/catppuccin/nvim/blob/55f43a952856bc0029e6cef066297c6cfab3451d/lua/catppuccin/palettes/mocha.lua#L32)