### PR TITLE
fix: prevent `setup` wrong overrides

### DIFF
--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -90,36 +90,30 @@ NoNeckPain.options = {
 ---
 ---@usage `require("no-neck-pain").setup()` (add `{}` with your |NoNeckPain.options| table)
 function NoNeckPain.setup(options)
+    options = options or {}
+    options.buffers = options.buffers or {}
+    options.buffers.common =
+        vim.tbl_deep_extend("keep", options.buffers.common or {}, NoNeckPain.options.buffers.common)
+    options.buffers.left = vim.tbl_deep_extend(
+        "keep",
+        options.buffers.left or options.buffers.common,
+        NoNeckPain.options.buffers.left
+    )
+    options.buffers.right = vim.tbl_deep_extend(
+        "keep",
+        options.buffers.right or options.buffers.common,
+        NoNeckPain.options.buffers.right
+    )
     NoNeckPain.options = vim.tbl_deep_extend("keep", options or {}, NoNeckPain.options)
+
     NoNeckPain.options.buffers.common.backgroundColor =
         C.matchIntegrationToHexCode(NoNeckPain.options.buffers.common.backgroundColor)
-
-    -- to prevent having to do the left|right > common check internally everytime, we do the merge here so we can rely on the side directly
-    NoNeckPain.options.buffers.left.bo = vim.tbl_deep_extend(
-        "keep",
-        NoNeckPain.options.buffers.left.bo,
-        NoNeckPain.options.buffers.common.bo
-    )
-    NoNeckPain.options.buffers.left.wo = vim.tbl_deep_extend(
-        "keep",
-        NoNeckPain.options.buffers.left.wo,
-        NoNeckPain.options.buffers.common.wo
-    )
-    NoNeckPain.options.buffers.left.backgroundColor =
-        C.matchIntegrationToHexCode(NoNeckPain.options.buffers.left.backgroundColor)
-
-    NoNeckPain.options.buffers.right.bo = vim.tbl_deep_extend(
-        "keep",
-        NoNeckPain.options.buffers.right.bo,
-        NoNeckPain.options.buffers.common.bo
-    )
-    NoNeckPain.options.buffers.right.wo = vim.tbl_deep_extend(
-        "keep",
-        NoNeckPain.options.buffers.right.wo,
-        NoNeckPain.options.buffers.common.wo
-    )
-    NoNeckPain.options.buffers.right.backgroundColor =
-        C.matchIntegrationToHexCode(NoNeckPain.options.buffers.right.backgroundColor)
+    NoNeckPain.options.buffers.left.backgroundColor = C.matchIntegrationToHexCode(
+        NoNeckPain.options.buffers.left.backgroundColor
+    ) or NoNeckPain.options.buffers.common.backgroundColor
+    NoNeckPain.options.buffers.right.backgroundColor = C.matchIntegrationToHexCode(
+        NoNeckPain.options.buffers.right.backgroundColor
+    ) or NoNeckPain.options.buffers.common.backgroundColor
 
     return NoNeckPain.options
 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -77,7 +77,7 @@ end
 
 -- Resizes both of the NNP buffers.
 local function resize(scope)
-    D.print(scope)
+    D.print(scope, "resizing NNP buffers")
 
     W.resize("createWin", S.win.main.left, W.getPadding("left", S.win.external.tree.width))
     W.resize("createWin", S.win.main.right, W.getPadding("right", S.win.external.tree.width))
@@ -85,7 +85,7 @@ end
 
 -- Creates NNP buffers.
 local function init(scope)
-    D.print(scope)
+    D.print(scope, "intializing NNP")
 
     local splitbelow, splitright = vim.o.splitbelow, vim.o.splitright
     vim.o.splitbelow, vim.o.splitright = true, true

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -38,10 +38,10 @@ function C.matchIntegrationToHexCode(colorCode)
     return colorCode
 end
 
--- creates an highlight group `NNPBuffers` with the given `backgroundColor` and assign it to the side buffer of the given `id`.
+-- creates an highlight group for a given buffer named `NNPBuffers_$NAME` with the given `backgroundColor` and assign it to the side buffer of the given `id`.
 -- `cmd` is used instead of native commands for backward compatibility with Neovim 0.7
-function C.init(win, backgroundColor)
-    local groupName = "NNPBuffers"
+function C.init(win, name, backgroundColor)
+    local groupName = "NNPBuffers_" .. name
     local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
 
     -- check if the user has a transparent background or not

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -1,0 +1,28 @@
+local D = require("no-neck-pain.util.debug")
+local W = require("no-neck-pain.util.win")
+
+local E = {}
+
+-- determines if we should skip the event.
+function E.skip(scope, enabled, split)
+    if not enabled then
+        D.print(string.format("%s: event received but NNP is disabled", scope))
+
+        return true
+    end
+
+    if split ~= nil or W.isRelativeWindow(scope) then
+        D.print(
+            string.format(
+                "%s: already in split view or float window detected, nothing more to do",
+                scope
+            )
+        )
+
+        return true
+    end
+
+    return false
+end
+
+return E

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -98,7 +98,13 @@ end
 --
 -- @param paddingToSubstract number: a value to be substracted to the `width` of the screen.
 function W.getPadding(side, paddingToSubstract)
-    local width = vim.api.nvim_list_uis()[1].width
+    local wins = vim.api.nvim_list_uis()
+
+    if wins[1] == nil then
+        return D.print("getPadding: attempted to get the padding of a non-existing window.")
+    end
+
+    local width = wins[1].width
 
     if _G.NoNeckPain.config.width >= width then
         return 1

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -1,6 +1,43 @@
+local C = require("no-neck-pain.util.color")
 local D = require("no-neck-pain.util.debug")
 local M = require("no-neck-pain.util.map")
 local W = {}
+
+-- Creates a buffer for the given "padding" (width), at the given `moveTo` direction.
+--
+--@param name string: the name of the buffer, `no-neck-pain-` will be prepended.
+--@param cmd string: the command to execute when creating the buffer
+--@param padding number: the "padding" (width) of the buffer
+--@param moveTo string: the command to execute to place the buffer at the correct spot.
+function W.createBuf(name, cmd, padding, moveTo)
+    if vim.api.nvim_list_uis()[1].width < _G.NoNeckPain.config.width then
+        return D.print("createBuf: not enough space to create side buffer " .. name)
+    end
+
+    vim.cmd(cmd)
+
+    local id = vim.api.nvim_get_current_win()
+
+    vim.api.nvim_win_set_width(0, padding)
+
+    if _G.NoNeckPain.config.buffers.setNames then
+        vim.api.nvim_buf_set_name(0, "no-neck-pain-" .. name)
+    end
+
+    for opt, val in pairs(_G.NoNeckPain.config.buffers[name].bo) do
+        vim.api.nvim_buf_set_option(0, opt, val)
+    end
+
+    for opt, val in pairs(_G.NoNeckPain.config.buffers[name].wo) do
+        vim.api.nvim_win_set_option(id, opt, val)
+    end
+
+    vim.cmd(moveTo)
+
+    C.init(id, name, _G.NoNeckPain.config.buffers[name].backgroundColor)
+
+    return id
+end
 
 -- returns the buffers without the NNP ones, and their number.
 function W.bufferListWithoutNNP(scope, list)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -179,6 +179,80 @@ T["setup()"]["overrides default values"] = function()
     end
 end
 
+T["setup()"]["`left` or `right` buffer options overrides `common` ones"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        buffers = {
+            common = {
+                backgroundColor = "catppuccin-frappe",
+                bo = {
+                    filetype = "TEST",
+                },
+                wo = {
+                    cursorline = false,
+                },
+            },
+            left = {
+                backgroundColor = "catppuccin-frappe-dark",
+                bo = {
+                    filetype = "TEST-left",
+                },
+                wo = {
+                    cursorline = true,
+                },
+            },
+            right = {
+                backgroundColor = "catppuccin-latte",
+                bo = {
+                    filetype = "TEST-right",
+                },
+                wo = {
+                    number = true,
+                },
+            },
+        },
+    })]])
+
+    eq_option(child, "buffers.common.backgroundColor", "#303446")
+    eq_option(child, "buffers.left.backgroundColor", "#292C3C")
+    eq_option(child, "buffers.right.backgroundColor", "#EFF1F5")
+
+    eq_option(child, "buffers.common.bo.filetype", "TEST")
+    eq_option(child, "buffers.left.bo.filetype", "TEST-left")
+    eq_option(child, "buffers.right.bo.filetype", "TEST-right")
+
+    eq_option(child, "buffers.common.wo.cursorline", false)
+    eq_option(child, "buffers.left.wo.cursorline", true)
+    eq_option(child, "buffers.right.wo.number", true)
+end
+
+T["setup()"]["`common` options spreads it to `left` and `right` buffers"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        buffers = {
+            common = {
+                backgroundColor = "catppuccin-frappe",
+                bo = {
+                    filetype = "TEST",
+                },
+                wo = {
+                    number = true,
+                },
+            },
+        },
+    })]])
+
+    eq_option(child, "buffers.common.backgroundColor", "#303446")
+    eq_option(child, "buffers.left.backgroundColor", "#303446")
+    eq_option(child, "buffers.right.backgroundColor", "#303446")
+
+    eq_option(child, "buffers.common.bo.filetype", "TEST")
+    eq_option(child, "buffers.left.bo.filetype", "TEST")
+    eq_option(child, "buffers.right.bo.filetype", "TEST")
+
+    eq_option(child, "buffers.common.wo.number", true)
+    eq_option(child, "buffers.left.wo.number", true)
+    eq_option(child, "buffers.right.wo.number", true)
+end
+
 T["setup()"]["colorCode: map integration name to a value"] = function()
     local integrationsMapping = {
         { "catppuccin-frappe", "#303446" },


### PR DESCRIPTION
## 📃 Summary

We were not correctly spreading the common table in the `left` or `right` ones, which led to non-forwarded options.