### PR TITLE
feat(config): cleanup fields and unused code

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,52 @@ require("no-neck-pain").setup({
     disableOnLastBuffer = false,
     -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
     killAllBuffersOnDisable = false,
-    --- Options related to the side buffers. See |NoNeckPain.bufferOptions|.
+    --- Common options that are set to both buffers, for option scoped to the `left` and/or `right` buffer, see `buffers.left` and `buffers.right`.
+    --- See |NoNeckPain.bufferOptions|.
     buffers = {
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         setNames = false,
-        -- Common options are set to both buffers, for option scoped to the `left` and/or `right` buffer, see `buffers.left` and `buffers.right`.
-        common = NoNeckPain.bufferOptions,
-        --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
-        --- When `nil`, the buffer won't be created.
+        -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+        -- popular theme are supported by their name:
+        -- - catppuccin-frappe
+        -- - catppuccin-frappe-dark
+        -- - catppuccin-latte
+        -- - catppuccin-latte-dark
+        -- - catppuccin-macchiato
+        -- - catppuccin-macchiato-dark
+        -- - catppuccin-mocha
+        -- - catppuccin-mocha-dark
+        -- - tokyonight-day
+        -- - tokyonight-moon
+        -- - tokyonight-night
+        -- - tokyonight-storm
+        -- - rose-pine
+        -- - rose-pine-moon
+        -- - rose-pine-dawn
+        backgroundColor = nil,
+        -- buffer-scoped options: any `vim.bo` options is accepted here.
+        bo = {
+            filetype = "no-neck-pain",
+            buftype = "nofile",
+            bufhidden = "hide",
+            modifiable = false,
+            buflisted = false,
+            swapfile = false,
+        },
+        -- window-scoped options: any `vim.wo` options is accepted here.
+        wo = {
+            cursorline = false,
+            cursorcolumn = false,
+            number = false,
+            relativenumber = false,
+            foldenable = false,
+            list = false,
+        },
+        --- Options applied to the `left` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+        --- See |NoNeckPain.bufferOptions|.
         left = NoNeckPain.bufferOptions,
-        --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
-        --- When `nil`, the buffer won't be created.
+        --- Options applied to the `right` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+        --- See |NoNeckPain.bufferOptions|.
         right = NoNeckPain.bufferOptions,
     },
     -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -66,17 +66,52 @@ Default values:
       disableOnLastBuffer = false,
       -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
       killAllBuffersOnDisable = false,
-      --- Options related to the side buffers. See |NoNeckPain.bufferOptions|.
+      --- Common options that are set to both buffers, for option scoped to the `left` and/or `right` buffer, see `buffers.left` and `buffers.right`.
+      --- See |NoNeckPain.bufferOptions|.
       buffers = {
           -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
           setNames = false,
-          -- Common options are set to both buffers, for option scoped to the `left` and/or `right` buffer, see `buffers.left` and `buffers.right`.
-          common = NoNeckPain.bufferOptions,
-          --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
-          --- When `nil`, the buffer won't be created.
+          -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+          -- popular theme are supported by their name:
+          -- - catppuccin-frappe
+          -- - catppuccin-frappe-dark
+          -- - catppuccin-latte
+          -- - catppuccin-latte-dark
+          -- - catppuccin-macchiato
+          -- - catppuccin-macchiato-dark
+          -- - catppuccin-mocha
+          -- - catppuccin-mocha-dark
+          -- - tokyonight-day
+          -- - tokyonight-moon
+          -- - tokyonight-night
+          -- - tokyonight-storm
+          -- - rose-pine
+          -- - rose-pine-moon
+          -- - rose-pine-dawn
+          backgroundColor = nil,
+          -- buffer-scoped options: any `vim.bo` options is accepted here.
+          bo = {
+              filetype = "no-neck-pain",
+              buftype = "nofile",
+              bufhidden = "hide",
+              modifiable = false,
+              buflisted = false,
+              swapfile = false,
+          },
+          -- window-scoped options: any `vim.wo` options is accepted here.
+          wo = {
+              cursorline = false,
+              cursorcolumn = false,
+              number = false,
+              relativenumber = false,
+              foldenable = false,
+              list = false,
+          },
+          --- Options applied to the `left` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+          --- See |NoNeckPain.bufferOptions|.
           left = NoNeckPain.bufferOptions,
-          --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
-          --- When `nil`, the buffer won't be created.
+          --- Options applied to the `right` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+          --- See |NoNeckPain.bufferOptions|.
           right = NoNeckPain.bufferOptions,
       },
       -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
@@ -116,7 +151,7 @@ Initializes NNP and sets event listeners.
 
 ------------------------------------------------------------------------------
                                                           *NoNeckPain.disable()*
-                             `NoNeckPain.disable`()
+                         `NoNeckPain.disable`({scope})
 Disable NNP and reset windows, leaving the `curr` focused window as focused.
 
 

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -61,17 +61,52 @@ NoNeckPain.options = {
     disableOnLastBuffer = false,
     -- When `true`, disabling NNP kills every split/vsplit buffers except the main NNP buffer.
     killAllBuffersOnDisable = false,
-    --- Options related to the side buffers. See |NoNeckPain.bufferOptions|.
+    --- Common options that are set to both buffers, for option scoped to the `left` and/or `right` buffer, see `buffers.left` and `buffers.right`.
+    --- See |NoNeckPain.bufferOptions|.
     buffers = {
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         setNames = false,
-        -- Common options are set to both buffers, for option scoped to the `left` and/or `right` buffer, see `buffers.left` and `buffers.right`.
-        common = NoNeckPain.bufferOptions,
-        --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
-        --- When `nil`, the buffer won't be created.
+        -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+        -- popular theme are supported by their name:
+        -- - catppuccin-frappe
+        -- - catppuccin-frappe-dark
+        -- - catppuccin-latte
+        -- - catppuccin-latte-dark
+        -- - catppuccin-macchiato
+        -- - catppuccin-macchiato-dark
+        -- - catppuccin-mocha
+        -- - catppuccin-mocha-dark
+        -- - tokyonight-day
+        -- - tokyonight-moon
+        -- - tokyonight-night
+        -- - tokyonight-storm
+        -- - rose-pine
+        -- - rose-pine-moon
+        -- - rose-pine-dawn
+        backgroundColor = nil,
+        -- buffer-scoped options: any `vim.bo` options is accepted here.
+        bo = {
+            filetype = "no-neck-pain",
+            buftype = "nofile",
+            bufhidden = "hide",
+            modifiable = false,
+            buflisted = false,
+            swapfile = false,
+        },
+        -- window-scoped options: any `vim.wo` options is accepted here.
+        wo = {
+            cursorline = false,
+            cursorcolumn = false,
+            number = false,
+            relativenumber = false,
+            foldenable = false,
+            list = false,
+        },
+        --- Options applied to the `left` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+        --- See |NoNeckPain.bufferOptions|.
         left = NoNeckPain.bufferOptions,
-        --- Options applied to the `left` buffer, the options defined here overrides the `common` ones.
-        --- When `nil`, the buffer won't be created.
+        --- Options applied to the `right` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+        --- See |NoNeckPain.bufferOptions|.
         right = NoNeckPain.bufferOptions,
     },
     -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
@@ -92,28 +127,26 @@ NoNeckPain.options = {
 function NoNeckPain.setup(options)
     options = options or {}
     options.buffers = options.buffers or {}
-    options.buffers.common =
-        vim.tbl_deep_extend("keep", options.buffers.common or {}, NoNeckPain.options.buffers.common)
-    options.buffers.left = vim.tbl_deep_extend(
+    NoNeckPain.options = vim.tbl_deep_extend("keep", options, NoNeckPain.options)
+    NoNeckPain.options.buffers.left = vim.tbl_deep_extend(
         "keep",
-        options.buffers.left or options.buffers.common,
+        options.buffers.left or NoNeckPain.options.buffers,
         NoNeckPain.options.buffers.left
     )
-    options.buffers.right = vim.tbl_deep_extend(
+    NoNeckPain.options.buffers.right = vim.tbl_deep_extend(
         "keep",
-        options.buffers.right or options.buffers.common,
+        options.buffers.right or NoNeckPain.options.buffers,
         NoNeckPain.options.buffers.right
     )
-    NoNeckPain.options = vim.tbl_deep_extend("keep", options or {}, NoNeckPain.options)
 
-    NoNeckPain.options.buffers.common.backgroundColor =
-        C.matchIntegrationToHexCode(NoNeckPain.options.buffers.common.backgroundColor)
+    NoNeckPain.options.buffers.backgroundColor =
+        C.matchIntegrationToHexCode(NoNeckPain.options.buffers.backgroundColor)
     NoNeckPain.options.buffers.left.backgroundColor = C.matchIntegrationToHexCode(
         NoNeckPain.options.buffers.left.backgroundColor
-    ) or NoNeckPain.options.buffers.common.backgroundColor
+    ) or NoNeckPain.options.buffers.backgroundColor
     NoNeckPain.options.buffers.right.backgroundColor = C.matchIntegrationToHexCode(
         NoNeckPain.options.buffers.right.backgroundColor
-    ) or NoNeckPain.options.buffers.common.backgroundColor
+    ) or NoNeckPain.options.buffers.backgroundColor
 
     return NoNeckPain.options
 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -85,7 +85,7 @@ end
 --- Initializes NNP and sets event listeners.
 function NoNeckPain.enable()
     if S.enabled then
-        return D.log("NoNeckPain.enable()", "tried to enable already enabled NNP")
+        return
     end
 
     S.augroup = vim.api.nvim_create_augroup("NoNeckPain", {
@@ -111,22 +111,15 @@ function NoNeckPain.enable()
                         _G.NoNeckPain.config.width
                     )
 
+                    -- we create everything if side buffers are missing
                     if S.win.main.left == nil and S.win.main.right == nil then
-                        D.log(p.event, "no side buffer found, creating...")
-
                         return init()
                     end
-
-                    D.log(p.event, "buffers are here, resizing...")
 
                     return resize(p.event)
                 end
 
-                D.log(
-                    p.event,
-                    "window's width is below the `width` option, closing opened buffers..."
-                )
-
+                -- window width below `options.width`
                 close(p.event)
             end)
         end,
@@ -231,7 +224,7 @@ function NoNeckPain.enable()
 
                 -- skip if the newly focused window is a side buffer
                 if focusedWin == S.win.main.left or focusedWin == S.win.main.right then
-                    return D.log(p.event, "focus on side buffer, skipped resize")
+                    return
                 end
 
                 -- when opening a new buffer as current, store its padding and resize everything (e.g. side tree)

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -6,13 +6,11 @@ local E = {}
 -- determines if we should skip the event.
 function E.skip(scope, enabled, split)
     if not enabled then
-        D.log(scope, "event received but NNP is disabled")
-
         return true
     end
 
     if split ~= nil or W.isRelativeWindow() then
-        D.log(scope, "already in split view or float window detected, nothing more to do")
+        D.log(scope, "already in split view or float window detected, skipped")
 
         return true
     end

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -195,7 +195,6 @@ T["setup()"]["overrides default values"] = function()
     eq_option(child, "buffers.wo.foldenable", true)
     eq_option(child, "buffers.wo.list", true)
 
-    -- common
     for _, scope in pairs(SCOPES) do
         eq_option(child, "buffers." .. scope .. ".backgroundColor", "#303446")
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -20,7 +20,7 @@ local T = MiniTest.new_set({
     },
 })
 
-local SCOPES = { "common", "left", "right" }
+local SCOPES = { "left", "right" }
 
 T["install"] = MiniTest.new_set()
 
@@ -57,7 +57,26 @@ T["setup()"]["sets exposed methods and default options value"] = function()
     eq_option(child, "killAllBuffersOnDisable", false)
 
     -- buffers
+    eq_type_option(child, "buffers", "table")
+    eq_type_option(child, "buffers.bo", "table")
+    eq_type_option(child, "buffers.wo", "table")
+
     eq_option(child, "buffers.setNames", false)
+    eq_option(child, "buffers.backgroundColor", vim.NIL)
+
+    eq_option(child, "buffers.bo.filetype", "no-neck-pain")
+    eq_option(child, "buffers.bo.buftype", "nofile")
+    eq_option(child, "buffers.bo.bufhidden", "hide")
+    eq_option(child, "buffers.bo.modifiable", false)
+    eq_option(child, "buffers.bo.buflisted", false)
+    eq_option(child, "buffers.bo.swapfile", false)
+
+    eq_option(child, "buffers.wo.cursorline", false)
+    eq_option(child, "buffers.wo.cursorcolumn", false)
+    eq_option(child, "buffers.wo.number", false)
+    eq_option(child, "buffers.wo.relativenumber", false)
+    eq_option(child, "buffers.wo.foldenable", false)
+    eq_option(child, "buffers.wo.list", false)
 
     for _, scope in pairs(SCOPES) do
         eq_type_option(child, "buffers." .. scope, "table")
@@ -90,24 +109,22 @@ T["setup()"]["overrides default values"] = function()
         killAllBuffersOnDisable = true,
         buffers = {
             setNames = true,
-            common = {
-                backgroundColor = "catppuccin-frappe",
-                bo = {
-                    filetype = "my-file-type",
-                    buftype = "help",
-                    bufhidden = "",
-                    modifiable = true,
-                    buflisted = true,
-                    swapfile = true,
-                },
-                wo = {
-                    cursorline = true,
-                    cursorcolumn = true,
-                    number = true,
-                    relativenumber = true,
-                    foldenable = true,
-                    list = true,
-                },
+            backgroundColor = "catppuccin-frappe",
+            bo = {
+                filetype = "my-file-type",
+                buftype = "help",
+                bufhidden = "",
+                modifiable = true,
+                buflisted = true,
+                swapfile = true,
+            },
+            wo = {
+                cursorline = true,
+                cursorcolumn = true,
+                number = true,
+                relativenumber = true,
+                foldenable = true,
+                list = true,
             },
             left = {
                 backgroundColor = "catppuccin-frappe",
@@ -157,7 +174,26 @@ T["setup()"]["overrides default values"] = function()
     eq_option(child, "killAllBuffersOnDisable", true)
 
     -- buffers
+    eq_type_option(child, "buffers", "table")
+    eq_type_option(child, "buffers.bo", "table")
+    eq_type_option(child, "buffers.wo", "table")
+
     eq_option(child, "buffers.setNames", true)
+    eq_option(child, "buffers.backgroundColor", "#303446")
+
+    eq_option(child, "buffers.bo.filetype", "my-file-type")
+    eq_option(child, "buffers.bo.buftype", "help")
+    eq_option(child, "buffers.bo.bufhidden", "")
+    eq_option(child, "buffers.bo.modifiable", true)
+    eq_option(child, "buffers.bo.buflisted", true)
+    eq_option(child, "buffers.bo.swapfile", true)
+
+    eq_option(child, "buffers.wo.cursorline", true)
+    eq_option(child, "buffers.wo.cursorcolumn", true)
+    eq_option(child, "buffers.wo.number", true)
+    eq_option(child, "buffers.wo.relativenumber", true)
+    eq_option(child, "buffers.wo.foldenable", true)
+    eq_option(child, "buffers.wo.list", true)
 
     -- common
     for _, scope in pairs(SCOPES) do
@@ -182,14 +218,12 @@ end
 T["setup()"]["`left` or `right` buffer options overrides `common` ones"] = function()
     child.lua([[require('no-neck-pain').setup({
         buffers = {
-            common = {
-                backgroundColor = "catppuccin-frappe",
-                bo = {
-                    filetype = "TEST",
-                },
-                wo = {
-                    cursorline = false,
-                },
+            backgroundColor = "catppuccin-frappe",
+            bo = {
+                filetype = "TEST",
+            },
+            wo = {
+                cursorline = false,
             },
             left = {
                 backgroundColor = "catppuccin-frappe-dark",
@@ -212,15 +246,16 @@ T["setup()"]["`left` or `right` buffer options overrides `common` ones"] = funct
         },
     })]])
 
-    eq_option(child, "buffers.common.backgroundColor", "#303446")
+    eq_option(child, "buffers.backgroundColor", "#303446")
+    eq_option(child, "buffers.bo.filetype", "TEST")
+    eq_option(child, "buffers.wo.cursorline", false)
+
     eq_option(child, "buffers.left.backgroundColor", "#292C3C")
     eq_option(child, "buffers.right.backgroundColor", "#EFF1F5")
 
-    eq_option(child, "buffers.common.bo.filetype", "TEST")
     eq_option(child, "buffers.left.bo.filetype", "TEST-left")
     eq_option(child, "buffers.right.bo.filetype", "TEST-right")
 
-    eq_option(child, "buffers.common.wo.cursorline", false)
     eq_option(child, "buffers.left.wo.cursorline", true)
     eq_option(child, "buffers.right.wo.number", true)
 end
@@ -228,29 +263,28 @@ end
 T["setup()"]["`common` options spreads it to `left` and `right` buffers"] = function()
     child.lua([[require('no-neck-pain').setup({
         buffers = {
-            common = {
-                backgroundColor = "catppuccin-frappe",
-                bo = {
-                    filetype = "TEST",
-                },
-                wo = {
-                    number = true,
-                },
+            backgroundColor = "catppuccin-frappe",
+            bo = {
+                filetype = "TEST",
+            },
+            wo = {
+                number = true,
             },
         },
     })]])
 
-    eq_option(child, "buffers.common.backgroundColor", "#303446")
+    eq_option(child, "buffers.backgroundColor", "#303446")
+    eq_option(child, "buffers.bo.filetype", "TEST")
+    eq_option(child, "buffers.wo.number", true)
+
     eq_option(child, "buffers.left.backgroundColor", "#303446")
     eq_option(child, "buffers.right.backgroundColor", "#303446")
 
-    eq_option(child, "buffers.common.bo.filetype", "TEST")
-    eq_option(child, "buffers.left.bo.filetype", "TEST")
-    eq_option(child, "buffers.right.bo.filetype", "TEST")
-
-    eq_option(child, "buffers.common.wo.number", true)
     eq_option(child, "buffers.left.wo.number", true)
     eq_option(child, "buffers.right.wo.number", true)
+
+    eq_option(child, "buffers.left.bo.filetype", "TEST")
+    eq_option(child, "buffers.right.bo.filetype", "TEST")
 end
 
 T["setup()"]["colorCode: map integration name to a value"] = function()
@@ -276,7 +310,7 @@ T["setup()"]["colorCode: map integration name to a value"] = function()
         child.lua(string.format(
             [[require('no-neck-pain').setup({
                 buffers = {
-                    common = { backgroundColor = "%s" },
+                    backgroundColor = "%s",
                     left = { backgroundColor = "%s" },
                     right = { backgroundColor = "%s" },
                 },


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/90
follow up of https://github.com/shortcuts/no-neck-pain.nvim/pull/78

I was bothered by the fact that the next breaking change of the API would introduce a `common` field instead of being at the root of the `buffers`. The goal is to make it even easy to use and configure the plugin.