### PR TITLE
feat: prevent split closing side buffers

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -232,13 +232,10 @@ function NoNeckPain.enable()
                 end
 
                 if total > threshold then
-                    return D.log(
-                        p.event,
-                        "more than one buffer left (%s > %s), no killed split to handle",
-                        total,
-                        threshold
-                    )
+                    return
                 end
+
+                D.log(p.event, "%s < %s, killing split", total, threshold)
 
                 if vim.api.nvim_win_is_valid(S.win.main.split) then
                     S.win.main.curr = S.win.main.split

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -351,6 +351,7 @@ T["enable()"]["sets state and internal methods"] = function()
     eq_state(child, "win.main.left", 1001)
     eq_state(child, "win.main.right", 1002)
     eq_state(child, "win.main.split", vim.NIL)
+    eq_state(child, "vsplit", false)
 
     eq_type_state(child, "win.external.tree", "table")
     eq_state(child, "win.external.tree.id", vim.NIL)
@@ -376,6 +377,7 @@ T["disable()"]["resets state and remove internal methods"] = function()
     eq_state(child, "win.main.left", vim.NIL)
     eq_state(child, "win.main.right", vim.NIL)
     eq_state(child, "win.main.split", vim.NIL)
+    eq_state(child, "vsplit", false)
 
     eq_type_state(child, "win.external.tree", "table")
     eq_state(child, "win.external.tree.id", vim.NIL)
@@ -410,6 +412,7 @@ T["toggle()"]["sets state and internal methods and resets everything when toggle
         eq_state(child, "win.main.left", 1001)
         eq_state(child, "win.main.right", 1002)
         eq_state(child, "win.main.split", vim.NIL)
+        eq_state(child, "vsplit", false)
 
         eq_type_state(child, "win.external.tree", "table")
         eq_state(child, "win.external.tree.id", vim.NIL)
@@ -432,6 +435,7 @@ T["toggle()"]["sets state and internal methods and resets everything when toggle
         eq_state(child, "win.main.left", vim.NIL)
         eq_state(child, "win.main.right", vim.NIL)
         eq_state(child, "win.main.split", vim.NIL)
+        eq_state(child, "vsplit", false)
 
         eq_type_state(child, "win.external.tree", "table")
         eq_state(child, "win.external.tree.id", vim.NIL)


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/81

a normal split won't disable NNP during the split anymore, which wasn't an expected behavior. This prevents big UI shift when opening splits.

Vsplits are unchanged.

## 📸 Preview

`vsplit`:

<img width="1280" alt="Screenshot 2022-12-22 at 01 15 34" src="https://user-images.githubusercontent.com/20689156/209027684-7bd1ee02-583e-45ec-8dde-832763c7ef52.png">

`split`:

<img width="1280" alt="Screenshot 2022-12-22 at 01 16 01" src="https://user-images.githubusercontent.com/20689156/209027712-fcd0f3a5-11f1-4079-97cf-b22cd7153ba4.png">


`split` and `vsplit`:

<img width="1280" alt="Screenshot 2022-12-22 at 01 16 16" src="https://user-images.githubusercontent.com/20689156/209027750-e49b896d-b09b-4e50-87b3-59c52a85c840.png">
