### PR TITLE
fix: split/vsplit computing

### DIFF
--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -10,10 +10,6 @@ local W = {}
 --@param padding number: the "padding" (width) of the buffer
 --@param moveTo string: the command to execute to place the buffer at the correct spot.
 function W.createBuf(name, cmd, padding, moveTo)
-    if vim.api.nvim_list_uis()[1].width < _G.NoNeckPain.config.width then
-        return D.log("W.createBuf", "not enough space to create side buffer %s", name)
-    end
-
     vim.cmd(cmd)
 
     local id = vim.api.nvim_get_current_win()


### PR DESCRIPTION
## 📃 Summary

https://github.com/shortcuts/no-neck-pain.nvim/pull/92 introduced an error which impacted the opening of vsplit windows, due to wrong computation, windows like Packer were overlapping.

This is now much more reliable since we now consider side buffers.

## 📸 Preview

### Normal vsplit

<img width="1280" alt="Screenshot 2022-12-24 at 11 26 31" src="https://user-images.githubusercontent.com/20689156/209431912-9db9f620-42f7-4b5c-ab7f-565db29b076e.png">

### split

<img width="1280" alt="Screenshot 2022-12-24 at 11 26 24" src="https://user-images.githubusercontent.com/20689156/209431915-fb45d545-6053-43ee-939e-e589cadfa803.png">

### Packer vsplit

<img width="1280" alt="Screenshot 2022-12-24 at 11 26 17" src="https://user-images.githubusercontent.com/20689156/209431917-e989d0d4-2c54-4f87-8ebc-53ecd3c1469b.png">
