### PR TITLE
feat: reduce number of resize event

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -184,7 +184,7 @@ function NoNeckPain.enable()
         desc = "WinEnter covers the split/vsplit management",
     })
 
-    vim.api.nvim_create_autocmd({ "BufDelete", "WinClosed" }, {
+    vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
                 if E.skip(p.event, S.enabled, nil) then

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -321,8 +321,10 @@ function NoNeckPain.disable(scope)
     end
 
     S.enabled = false
-    vim.cmd("highlight! clear NNPBuffers_left NONE")
-    vim.cmd("highlight! clear NNPBuffers_right NONE")
+    vim.cmd("highlight! clear NNPBuffers_Background_left NONE")
+    vim.cmd("highlight! clear NNPBuffers_Text_left NONE")
+    vim.cmd("highlight! clear NNPBuffers_Background_Right NONE")
+    vim.cmd("highlight! clear NNPBuffers_Text_Right NONE")
     vim.api.nvim_del_augroup_by_id(S.augroup)
 
     -- shutdowns gracefully by focusing the stored `curr` buffer

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -184,7 +184,7 @@ function NoNeckPain.enable()
         desc = "WinEnter covers the split/vsplit management",
     })
 
-    vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
+    vim.api.nvim_create_autocmd({ "QuitPre", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
                 if E.skip(p.event, S.enabled, nil) then
@@ -221,11 +221,20 @@ function NoNeckPain.enable()
                         return NoNeckPain.disable()
                     end
                 end
+            end)
+        end,
+        group = "NoNeckPain",
+        desc = "Handles the closure of main NNP windows and restoring the state correctly",
+    })
 
-                if S.win.main.split == nil then
+    vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
+        callback = function(p)
+            vim.schedule(function()
+                if E.skip(p.event, S.enabled, nil) or S.win.main.split == nil then
                     return
                 end
 
+                local wins = vim.api.nvim_list_wins()
                 local total = M.tsize(wins)
 
                 -- `total` needs to be compared with the number of active wins,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -234,12 +234,12 @@ function NoNeckPain.enable()
                     return
                 end
 
-                local wins = vim.api.nvim_list_wins()
-                local total = M.tsize(wins)
-
                 if S.win.main.split == nil then
                     return
                 end
+
+                local wins = vim.api.nvim_list_wins()
+                local total = M.tsize(wins)
 
                 -- `total` needs to be compared with the number of active wins,
                 -- in the NNP context. This threshold holds the count.
@@ -293,19 +293,16 @@ function NoNeckPain.enable()
 
                 S.win.external.tree = W.getSideTree()
                 if S.win.external.tree.id ~= nil then
+                    if not M.contains(vim.api.nvim_list_wins(), S.win.external.tree.id) then
+                        S.win.external.tree = {
+                            id = nil,
+                            width = 0,
+                        }
+
+                        return resize(p.event)
+                    end
+
                     D.log(p.event, "side tree found, resizing")
-
-                    return resize(p.event)
-                end
-
-                if
-                    S.win.external.tree.id ~= nil
-                    and not M.contains(vim.api.nvim_list_wins(), S.win.external.tree.id)
-                then
-                    S.win.external.tree = {
-                        id = nil,
-                        width = 0,
-                    }
 
                     return resize(p.event)
                 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -278,17 +278,20 @@ function NoNeckPain.enable()
                     return
                 end
 
+                if
+                    S.win.external.tree.id ~= nil
+                    and not M.contains(vim.api.nvim_list_wins(), S.win.external.tree.id)
+                then
+                    S.win.external.tree = {
+                        id = nil,
+                        width = 0,
+                    }
+
+                    return resize(p.event)
+                end
+
                 S.win.external.tree = W.getSideTree()
                 if S.win.external.tree.id ~= nil then
-                    if not M.contains(vim.api.nvim_list_wins(), S.win.external.tree.id) then
-                        S.win.external.tree = {
-                            id = nil,
-                            width = 0,
-                        }
-
-                        return resize(p.event)
-                    end
-
                     D.log(p.event, "side tree found, resizing")
 
                     return resize(p.event)

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -221,24 +221,11 @@ function NoNeckPain.enable()
                         return NoNeckPain.disable()
                     end
                 end
-            end)
-        end,
-        group = "NoNeckPain",
-        desc = "Covers the cases where closing should disable NNP",
-    })
-
-    vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
-        callback = function(p)
-            vim.schedule(function()
-                if E.skip(p.event, S.enabled, nil) then
-                    return
-                end
 
                 if S.win.main.split == nil then
                     return
                 end
 
-                local wins = vim.api.nvim_list_wins()
                 local total = M.tsize(wins)
 
                 -- `total` needs to be compared with the number of active wins,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -149,9 +149,7 @@ function NoNeckPain.enable()
 
                 local fileType = vim.api.nvim_buf_get_option(0, "filetype")
                 if fileType == "NvimTree" then
-                    S.win.external.tree = W.getSideTree()
-
-                    return D.log(p.event, "encoutered an external window")
+                    return D.log(p.event, "encountered an external window")
                 end
 
                 -- start by saving the split, because steps below will trigger `WinClosed`
@@ -279,11 +277,7 @@ function NoNeckPain.enable()
     vim.api.nvim_create_autocmd({ "WinEnter", "WinClosed" }, {
         callback = function(p)
             vim.schedule(function()
-                local focusedWin = vim.api.nvim_get_current_win()
-
-                if
-                    E.skip(p.event, S.enabled, S.win.split) or M.contains(S.win.main, focusedWin)
-                then
+                if E.skip(p.event, S.enabled, S.win.split) then
                     return
                 end
 
@@ -301,14 +295,12 @@ function NoNeckPain.enable()
 
                 S.win.external.tree = W.getSideTree()
                 if S.win.external.tree.id ~= nil then
-                    D.log(p.event, "side tree found, resizing")
-
                     return resize(p.event)
                 end
             end)
         end,
         group = "NoNeckPain",
-        desc = "Resize to apply on WinEnter/Closed",
+        desc = "Resize to apply on WinEnter/Closed of external windows",
     })
 
     S.enabled = true

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -59,10 +59,8 @@ function C.init(win, name, backgroundColor, textColor)
         "Color.init",
         "`%s` with bg `%s` | `%s` with fg `%s`",
         backgroundGroup,
-        win,
         backgroundColor,
         textGroup,
-        win,
         textColor
     )
 

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -57,7 +57,7 @@ function C.init(win, name, backgroundColor, textColor)
 
     D.log(
         "Color.init",
-        "groupName `%s` - window `%s` - backgroundColor `%s`\ngroupName `%s` - window `%s` - textColor `%s`",
+        "`%s` with bg `%s` | `%s` with fg `%s`",
         backgroundGroup,
         win,
         backgroundColor,

--- a/lua/no-neck-pain/util/debug.lua
+++ b/lua/no-neck-pain/util/debug.lua
@@ -10,7 +10,7 @@ function D.log(scope, str, ...)
     local line = ""
 
     if info then
-        line = " L" .. info.currentline
+        line = "L" .. info.currentline
     end
 
     print(

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -68,20 +68,53 @@ function W.listWinsExcept(list)
     return validWins, size
 end
 
+-- returns the available buffers and their total number, without the `list` ones.
+function W.listBufsExcept(list)
+    local bufs = vim.api.nvim_list_bufs()
+    local validBufs = {}
+    local size = 0
+
+    for _, buf in pairs(bufs) do
+        if not M.contains(list, buf) then
+            table.insert(validBufs, buf)
+            size = size + 1
+        end
+    end
+
+    return validBufs, size
+end
+
+-- gets the bufs of the given `wins` list, if win are valid.
+function W.winsGetBufs(wins)
+    local bufs = {}
+
+    for _, win in pairs(wins) do
+        if win ~= nil and vim.api.nvim_win_is_valid(win) then
+            table.insert(bufs, vim.api.nvim_win_get_buf(win))
+        end
+    end
+
+    return bufs
+end
+
 -- closes a given `win`. quits Neovim if its the last window open.
 function W.close(scope, win)
     if win == nil then
         return nil
     end
 
-    local wins = vim.api.nvim_list_wins()
+    local wins, wsize = W.listWinsExcept({ win })
 
-    if M.tsize(wins) == 1 and wins[1] == win then
-        D.log(scope, "trying to kill the last available win %s", win)
+    -- if we are closing the last window, we might just quit Nvim
+    if wsize == 0 then
+        local _, bsize = W.listBufsExcept(W.winsGetBufs(wins))
 
-        vim.cmd([[quit!]])
+        -- if it's the last buffer in the list, we definitely want to quit it
+        if scope == "WinClosed" and bsize == 0 then
+            return vim.cmd("quit!")
+        end
 
-        return nil
+        vim.cmd("new")
     end
 
     D.log(scope, "killing window %s", win)

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -121,6 +121,8 @@ function W.close(scope, win)
     if vim.api.nvim_win_is_valid(win) then
         vim.api.nvim_win_close(win, false)
     end
+
+    return nil
 end
 
 -- resizes a given `win` for the given `padding`

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -103,27 +103,24 @@ function W.close(scope, win)
         return nil
     end
 
-    local wins, wsize = W.listWinsExcept({ win })
+    local _, wsize = W.listWinsExcept({ win })
 
-    -- if we are closing the last window, we might just quit Nvim
+    -- we don't have any window left if we close this one
     if wsize == 0 then
-        local _, bsize = W.listBufsExcept(W.winsGetBufs(wins))
-
-        -- if it's the last buffer in the list, we definitely want to quit it
-        if scope == "WinClosed" and bsize == 0 then
+        -- either triggered by a :wq or quit event, we can just quit
+        if scope == "QuitPre" then
             return vim.cmd("quit!")
         end
 
+        -- mostly triggered by :bd or similar
+        -- we will create a new window and close the other
         vim.cmd("new")
     end
 
-    D.log(scope, "killing window %s", win)
-
+    -- when we have more than 1 window left, we can just close it
     if vim.api.nvim_win_is_valid(win) then
         vim.api.nvim_win_close(win, false)
     end
-
-    return nil
 end
 
 -- resizes a given `win` for the given `padding`

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -40,23 +40,7 @@ T["curr buffer"]["have the width from the config"] = function()
     eq_buf_width(child, "main.curr", 48)
 end
 
-T["curr buffer"]["bdelete doesn't close Neovim"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
-
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
-
-    child.cmd("bd")
-
-    -- neovim is not closed, otherwise it would throw an error
-    helpers.expect.no_error(function()
-        child.lua_get("vim.api.nvim_list_wins()")
-    end)
-end
-
-T["curr buffer"]["closing `curr` buffer without any other window creates a new window"] = function()
+T["curr buffer"]["closing `curr` window without any other window quits Neovim"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
@@ -65,14 +49,12 @@ T["curr buffer"]["closing `curr` buffer without any other window creates a new w
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
     eq_state(child, "win.main.curr", 1000)
 
-    child.lua("vim.api.nvim_win_close(1000, false)")
+    child.cmd("q")
 
-    eq_state(child, "enabled", false)
-    eq_state(child, "win.main.curr", vim.NIL)
-    eq_state(child, "win.main.left", vim.NIL)
-    eq_state(child, "win.main.right", vim.NIL)
-
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1003 })
+    -- neovim is closed, so it errors
+    helpers.expect.error(function()
+        child.lua_get("vim.api.nvim_list_wins()")
+    end)
 end
 
 T["side buffers"] = new_set()
@@ -111,7 +93,7 @@ T["side buffers"]["only creates a `right` buffer when `left.enabled` is `false`"
     eq_buf_width(child, "main.right", 15)
 end
 
-T["side buffers"]["closing the `left` buffer kills the `right` one"] = function()
+T["side buffers"]["closing the `left` buffer disables NNP"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
@@ -121,12 +103,15 @@ T["side buffers"]["closing the `left` buffer kills the `right` one"] = function(
     eq_state(child, "win.main.left", 1001)
     eq_state(child, "win.main.right", 1002)
 
-    child.lua("vim.api.nvim_win_close(1002, false)")
+    child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.win.main.left)")
+    child.cmd("q")
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+
+    eq_state(child, "enabled", false)
 end
 
-T["side buffers"]["closing the `right` buffer kills the `left` one"] = function()
+T["side buffers"]["closing the `right` buffer disables NNP"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
@@ -136,9 +121,12 @@ T["side buffers"]["closing the `right` buffer kills the `left` one"] = function(
     eq_state(child, "win.main.left", 1001)
     eq_state(child, "win.main.right", 1002)
 
-    child.lua("vim.api.nvim_win_close(1001, false)")
+    child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.win.main.right)")
+    child.cmd("q")
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+
+    eq_state(child, "enabled", false)
 end
 
 T["auto command"] = new_set()
@@ -171,7 +159,8 @@ T["auto command"]["(split) closing `curr` makes `split` the new `curr`"] = funct
     eq_state(child, "win.main.curr", 1000)
     eq_state(child, "vsplit", false)
 
-    child.lua("vim.api.nvim_win_close(1000, true)")
+    child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.win.main.curr)")
+    child.cmd("q")
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1003, 1002 })
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
@@ -192,7 +181,8 @@ T["auto command"]["(vsplit) closing `curr` makes `split` the new `curr`"] = func
     eq_state(child, "win.main.curr", 1000)
     eq_state(child, "vsplit", true)
 
-    child.lua("vim.api.nvim_win_close(1000, false)")
+    child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.win.main.curr)")
+    child.cmd("q")
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1003, 1005 })
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
@@ -213,7 +203,8 @@ T["auto command"]["split keeps side buffers"] = function()
     eq_state(child, "win.main.split", 1003)
     eq_state(child, "vsplit", false)
 
-    child.lua("vim.api.nvim_win_close(1003, false)")
+    child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.win.main.split)")
+    child.cmd("q")
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
 
@@ -235,7 +226,8 @@ T["auto command"]["hides side buffers after vsplit"] = function()
     eq_state(child, "win.main.split", 1003)
     eq_state(child, "vsplit", true)
 
-    child.lua("vim.api.nvim_win_close(1003, false)")
+    child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.win.main.split)")
+    child.cmd("q")
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1000, 1005 })
     eq_state(child, "win.main.left", 1004)
@@ -268,7 +260,8 @@ T["auto command"]["does not shift using when opening/closing float window"] = fu
     eq_buf_width(child, "main.right", 15)
 
     -- Close float window keeps the buffer here with the same width
-    child.lua("vim.api.nvim_win_close(1003, false)")
+    child.lua("vim.fn.win_gotoid(1003)")
+    child.cmd("q")
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
     eq_state(child, "win.main.left", 1001)


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/82
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/99

The goal is to split hooks responsibilities to prevent unwanted behaviors. This PR also covers wrong interpretation of a `BufDelete` event.
