### PR TITLE
feat: support undotree

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,12 @@ require("no-neck-pain").setup({
     -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
     integrations = {
         -- https://github.com/nvim-tree/nvim-tree.lua
-        nvimTree = {
+        NvimTree = {
+            -- the position of the tree, can be `left` or `right``
+            position = "left",
+        },
+        -- https://github.com/mbbill/undotree
+        undotree = {
             -- the position of the tree, can be `left` or `right``
             position = "left",
         },

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -121,7 +121,7 @@ Default values:
       -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
       integrations = {
           -- https://github.com/nvim-tree/nvim-tree.lua
-          nvimTree = {
+          NvimTree = {
               -- the position of the tree, can be `left` or `right``
               position = "left",
           },

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -125,6 +125,11 @@ Default values:
               -- the position of the tree, can be `left` or `right``
               position = "left",
           },
+          -- https://github.com/mbbill/undotree
+          undotree = {
+              -- the position of the tree, can be `left` or `right``
+              position = "left",
+          },
       },
   }
 

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -120,6 +120,11 @@ NoNeckPain.options = {
             -- the position of the tree, can be `left` or `right``
             position = "left",
         },
+        -- https://github.com/mbbill/undotree
+        undotree = {
+            -- the position of the tree, can be `left` or `right``
+            position = "left",
+        },
     },
 }
 

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -116,7 +116,7 @@ NoNeckPain.options = {
     -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
     integrations = {
         -- https://github.com/nvim-tree/nvim-tree.lua
-        nvimTree = {
+        NvimTree = {
             -- the position of the tree, can be `left` or `right``
             position = "left",
         },

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -19,7 +19,7 @@ local S = {
         },
         external = {
             trees = {
-                nvimTree = {
+                NvimTree = {
                     id = nil,
                     width = 0,
                 },
@@ -207,7 +207,7 @@ function NoNeckPain.enable()
                         S.win.main.left,
                         S.win.main.right,
                         S.win.main.split,
-                        S.win.external.trees.nvimTree.id,
+                        S.win.external.trees.NvimTree.id,
                         S.win.external.trees.undotree.id,
                     })
 
@@ -287,7 +287,7 @@ function NoNeckPain.enable()
                 local wins = vim.api.nvim_list_wins()
                 local trees = W.getSideTree()
 
-                -- we cycle ever trees supported to see which got closed or open
+                -- we cycle over supported integrations to see which got closed or open
                 for name, tree in pairs(S.win.external.trees) do
                     -- if there was a tree[name] but not anymore, we resize
                     if tree.id ~= nil and not M.contains(wins, tree.id) then

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -141,7 +141,7 @@ end
 function W.getSideTree()
     local wins = vim.api.nvim_list_wins()
     local trees = {
-        nvimTree = {
+        NvimTree = {
             id = nil,
             width = 0,
         },
@@ -183,8 +183,6 @@ function W.getPadding(side, trees)
     local paddingToSubstract = 0
 
     for name, tree in pairs(trees) do
-        D.log(side, name)
-        D.tprint(tree)
         if side == _G.NoNeckPain.config.integrations[name].position and tree.id ~= nil then
             paddingToSubstract = paddingToSubstract + tree.width
         end

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -140,26 +140,34 @@ end
 
 function W.getSideTree()
     local wins = vim.api.nvim_list_wins()
+    local trees = {
+        nvimTree = {
+            id = nil,
+            width = 0,
+        },
+        undotree = {
+            id = nil,
+            width = 0,
+        },
+    }
 
     for _, win in pairs(wins) do
-        if vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(win), "filetype") == "NvimTree" then
-            return {
+        local fileType = vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(win), "filetype")
+        if fileType == "NvimTree" or fileType == "undotree" then
+            trees[fileType] = {
                 id = win,
                 width = vim.api.nvim_win_get_width(win) * 2,
             }
         end
     end
 
-    return {
-        id = nil,
-        width = 0,
-    }
+    return trees
 end
 
 -- Determine the "padding" (width) of the buffer based on the `_G.NoNeckPain.config.width` and the width of the screen.
 --
--- @param paddingToSubstract number: a value to be substracted to the `width` of the screen.
-function W.getPadding(side, paddingToSubstract)
+-- @param trees list: the external trees supported with their `width` and `id`.
+function W.getPadding(side, trees)
     local wins = vim.api.nvim_list_uis()
 
     if wins[1] == nil then
@@ -172,11 +180,14 @@ function W.getPadding(side, paddingToSubstract)
         return 1
     end
 
-    paddingToSubstract = paddingToSubstract or 0
+    local paddingToSubstract = 0
 
-    -- if the side we are resizing is not the same as the tree position, we set it to 0
-    if side ~= _G.NoNeckPain.config.integrations.nvimTree.position then
-        paddingToSubstract = 0
+    for name, tree in pairs(trees) do
+        D.log(side, name)
+        D.tprint(tree)
+        if side == _G.NoNeckPain.config.integrations[name].position and tree.id ~= nil then
+            paddingToSubstract = paddingToSubstract + tree.width
+        end
     end
 
     return math.floor((width - paddingToSubstract - _G.NoNeckPain.config.width) / 2)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -370,9 +370,13 @@ T["enable()"]["sets state and internal methods"] = function()
     eq_state(child, "win.main.split", vim.NIL)
     eq_state(child, "vsplit", false)
 
-    eq_type_state(child, "win.external.tree", "table")
-    eq_state(child, "win.external.tree.id", vim.NIL)
-    eq_state(child, "win.external.tree.width", 0)
+    eq_type_state(child, "win.external.trees", "table")
+
+    local integrations = { "nvimTree", "undotree" }
+    for _, integration in pairs(integrations) do
+        eq_state(child, "win.external.trees." .. integration .. ".id", vim.NIL)
+        eq_state(child, "win.external.trees." .. integration .. ".width", 0)
+    end
 end
 
 T["disable()"] = MiniTest.new_set()
@@ -396,9 +400,13 @@ T["disable()"]["resets state and remove internal methods"] = function()
     eq_state(child, "win.main.split", vim.NIL)
     eq_state(child, "vsplit", false)
 
-    eq_type_state(child, "win.external.tree", "table")
-    eq_state(child, "win.external.tree.id", vim.NIL)
-    eq_state(child, "win.external.tree.width", 0)
+    eq_type_state(child, "win.external.trees", "table")
+
+    local integrations = { "nvimTree", "undotree" }
+    for _, integration in pairs(integrations) do
+        eq_state(child, "win.external.trees." .. integration .. ".id", vim.NIL)
+        eq_state(child, "win.external.trees." .. integration .. ".width", 0)
+    end
 end
 
 T["toggle()"] = MiniTest.new_set()
@@ -431,9 +439,13 @@ T["toggle()"]["sets state and internal methods and resets everything when toggle
         eq_state(child, "win.main.split", vim.NIL)
         eq_state(child, "vsplit", false)
 
-        eq_type_state(child, "win.external.tree", "table")
-        eq_state(child, "win.external.tree.id", vim.NIL)
-        eq_state(child, "win.external.tree.width", 0)
+        eq_type_state(child, "win.external.trees", "table")
+
+        local integrations = { "nvimTree", "undotree" }
+        for _, integration in pairs(integrations) do
+            eq_state(child, "win.external.trees." .. integration .. ".id", vim.NIL)
+            eq_state(child, "win.external.trees." .. integration .. ".width", 0)
+        end
 
         -- disable
         child.lua([[require('no-neck-pain').toggle()]])

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -372,7 +372,7 @@ T["enable()"]["sets state and internal methods"] = function()
 
     eq_type_state(child, "win.external.trees", "table")
 
-    local integrations = { "nvimTree", "undotree" }
+    local integrations = { "NvimTree", "undotree" }
     for _, integration in pairs(integrations) do
         eq_state(child, "win.external.trees." .. integration .. ".id", vim.NIL)
         eq_state(child, "win.external.trees." .. integration .. ".width", 0)
@@ -402,7 +402,7 @@ T["disable()"]["resets state and remove internal methods"] = function()
 
     eq_type_state(child, "win.external.trees", "table")
 
-    local integrations = { "nvimTree", "undotree" }
+    local integrations = { "NvimTree", "undotree" }
     for _, integration in pairs(integrations) do
         eq_state(child, "win.external.trees." .. integration .. ".id", vim.NIL)
         eq_state(child, "win.external.trees." .. integration .. ".width", 0)
@@ -441,7 +441,7 @@ T["toggle()"]["sets state and internal methods and resets everything when toggle
 
         eq_type_state(child, "win.external.trees", "table")
 
-        local integrations = { "nvimTree", "undotree" }
+        local integrations = { "NvimTree", "undotree" }
         for _, integration in pairs(integrations) do
             eq_state(child, "win.external.trees." .. integration .. ".id", vim.NIL)
             eq_state(child, "win.external.trees." .. integration .. ".width", 0)


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/94

This PR adds support for undotree, to prevent UI shifts. It also makes the internal state API much more extensible, for next integration support.

## 📸 Preview

Undotree

<img width="1280" alt="Screenshot 2022-12-27 at 22 34 22" src="https://user-images.githubusercontent.com/20689156/209724501-b83e9bf8-94d8-4e8b-805b-90d8673ed91d.png">

NvimTree

<img width="1280" alt="Screenshot 2022-12-27 at 22 39 20" src="https://user-images.githubusercontent.com/20689156/209724768-9bc4e284-6b9a-4510-810f-50484cea75f6.png">
