### PR TITLE
fix: prevent help split disabling nnp

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -238,6 +238,12 @@ function NoNeckPain.enable()
                 local wins = vim.api.nvim_list_wins()
                 local total = M.tsize(wins)
 
+                -- if all the main buffers are still present,
+                -- it means we have nothing to do here
+                if M.every(wins, S.win.main) then
+                    return
+                end
+
                 -- `total` needs to be compared with the number of active wins,
                 -- in the NNP context. This threshold holds the count.
                 -- 1 = split && curr && !left && !right

--- a/lua/no-neck-pain/util/map.lua
+++ b/lua/no-neck-pain/util/map.lua
@@ -12,12 +12,12 @@ function M.contains(map, element)
 end
 
 -- returns true if the given `map` contains every `elements`.
-function M.every(map, ...)
-    local nbElements = M.tsize(...)
+function M.every(map, elements)
+    local nbElements = M.tsize(elements)
     local count = 0
 
     for _, v in pairs(map) do
-        for _, el in pairs(...) do
+        for _, el in pairs(elements) do
             if v == el then
                 count = count + 1
                 break

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -143,6 +143,28 @@ T["auto command"]["does not create side buffers window's width < options.width"]
     eq_state(child, "win.main.right", vim.NIL)
 end
 
+T["auto command"]["(split) with only one side buffer, closing help doesn't close NNP"] = function()
+    child.set_size(500, 500)
+    child.lua([[
+        require('no-neck-pain').setup({width=50, buffers={right={enabled=false}}})
+        require('no-neck-pain').enable()
+    ]])
+
+    child.cmd("h")
+
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1002, 1000 })
+    eq_state(child, "win.main.left", 1001)
+    eq_state(child, "win.main.right", vim.NIL)
+    eq_state(child, "win.main.split", 1002)
+    eq_state(child, "win.main.curr", 1000)
+    eq_state(child, "vsplit", false)
+
+    child.cmd("q")
+
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000 })
+    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
+end
+
 T["auto command"]["(split) closing `curr` makes `split` the new `curr`"] = function()
     child.set_size(200, 200)
     child.lua([[


### PR DESCRIPTION
## 📃 Summary

Seems like the Close/Delete hook is triggered when entering a help window. To prevent this, we ensure at least one NNP win is missing from the win list before entering the split/vsplit closing logic.

Someone, this happened only when having a single side buffer.
