### PR TITLE
feat: add `enableOnVimEnter` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ No configuration/setup steps needed! Sit back, relax and call `:NoNeckPain`.
 require("no-neck-pain").setup({
     -- Prints useful logs about what event are triggered, and reasons actions are executed.
     debug = false,
+    -- When `true`, enables the plugin when your start Neovim.
+    enableOnVimEnter = false,
     -- The width of the focused buffer when enabling NNP.
     -- If the available window size is less than `width`, the buffer will take the whole screen.
     width = 100,

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -63,6 +63,8 @@ Default values:
   NoNeckPain.options = {
       -- Prints useful logs about what event are triggered, and reasons actions are executed.
       debug = false,
+      -- When `true`, enables the plugin when your start Neovim.
+      enableOnVimEnter = false,
       -- The width of the focused buffer when enabling NNP.
       -- If the available window size is less than `width`, the buffer will take the whole screen.
       width = 100,

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -58,6 +58,8 @@ NoNeckPain.bufferOptions = {
 NoNeckPain.options = {
     -- Prints useful logs about what event are triggered, and reasons actions are executed.
     debug = false,
+    -- When `true`, enables the plugin when your start Neovim.
+    enableOnVimEnter = false,
     -- The width of the focused buffer when enabling NNP.
     -- If the available window size is less than `width`, the buffer will take the whole screen.
     width = 100,

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -50,6 +50,19 @@ end
 -- setup NNP options and merge them with user provided ones.
 function NNP.setup(opts)
     NNP.config = require("no-neck-pain.config").setup(opts)
+
+    if NNP.config.enableOnVimEnter then
+        vim.api.nvim_create_augroup("NoNeckPainVimEnter", { clear = true })
+        vim.api.nvim_create_autocmd({ "VimEnter" }, {
+            group = "NoNeckPainVimEnter",
+            pattern = "*",
+            callback = function()
+                vim.schedule(function()
+                    NNP.enable()
+                end)
+            end,
+        })
+    end
 end
 
 _G.NoNeckPain = NNP

--- a/scripts/test_auto_open.lua
+++ b/scripts/test_auto_open.lua
@@ -1,0 +1,11 @@
+vim.cmd([[let &rtp.=','.getcwd()]])
+vim.cmd("set rtp+=deps/mini.nvim")
+
+-- Auto open enabled for the test
+require("no-neck-pain").setup({ width = 50, enableOnVimEnter = true })
+
+-- Set up 'mini.test'
+require("mini.test").setup()
+
+-- Set up 'mini.doc'
+require("mini.doc").setup()

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -52,6 +52,7 @@ T["setup()"]["sets exposed methods and default options value"] = function()
     eq_type_config(child, "buffers", "table")
 
     eq_config(child, "width", 100)
+    eq_config(child, "enableOnVimEnter", false)
     eq_config(child, "toggleMapping", "<Leader>np")
     eq_config(child, "debug", false)
     eq_config(child, "disableOnLastBuffer", false)
@@ -130,6 +131,7 @@ end
 T["setup()"]["overrides default values"] = function()
     child.lua([[require('no-neck-pain').setup({
         width = 42,
+        enableOnVimEnter = true,
         toggleMapping = "<Leader>kz",
         debug = true,
         disableOnLastBuffer = true,
@@ -202,6 +204,7 @@ T["setup()"]["overrides default values"] = function()
 
     -- config
     eq_config(child, "width", 42)
+    eq_config(child, "enableOnVimEnter", true)
     eq_config(child, "toggleMapping", "<Leader>kz")
     eq_config(child, "debug", true)
     eq_config(child, "disableOnLastBuffer", true)


### PR DESCRIPTION
## 📃 Summary

The `enableOnVimEnter` creates an autocmd, when calling the `setup` method, which will enable the plugin when entering Neovim.

The end option should accept `true | false | callback` so the user can control whether or not it should be enable (e.g. when opening a dashboard, or nvim-tree)