### PR TITLE
feat: add built-in nvim-tree and dashboard support

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,3 +1,5 @@
+local E = require("no-neck-pain.util.event")
+
 local NNP = {}
 
 -- toggles NNP switch between enabled/disable state.
@@ -52,15 +54,21 @@ function NNP.setup(opts)
     NNP.config = require("no-neck-pain.config").setup(opts)
 
     if NNP.config.enableOnVimEnter then
-        vim.api.nvim_create_augroup("NoNeckPainVimEnter", { clear = true })
-        vim.api.nvim_create_autocmd({ "VimEnter" }, {
-            group = "NoNeckPainVimEnter",
+        vim.api.nvim_create_augroup("NoNeckPainBufWinEnter", { clear = true })
+        vim.api.nvim_create_autocmd({ "BufWinEnter" }, {
+            group = "NoNeckPainBufWinEnter",
             pattern = "*",
-            callback = function()
+            callback = function(p)
                 vim.schedule(function()
+                    if E.abortEnable(NNP.state, vim.bo.filetype) then
+                        return
+                    end
+
                     NNP.enable()
+                    vim.api.nvim_del_autocmd(p.id)
                 end)
             end,
+            desc = "Triggers until it find the correct moment/buffer to enable the plugin.",
         })
     end
 end

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -3,6 +3,24 @@ local W = require("no-neck-pain.util.win")
 
 local E = {}
 
+-- abortEnable ensure we don't proceed the `enable` method
+-- in the `enableOnVimEnter` hooks. It exists to prevent
+-- conflicts with other plugins:
+-- netrw: it works
+-- dashboard: we skip until we open an other buffer
+-- nvim-tree: we skip until we open an other buffer
+function E.abortEnable(state, filetype)
+    if state ~= nil and state.enabled == true then
+        return true
+    end
+
+    if filetype == "dashboard" or filetype == "NvimTree" then
+        return true
+    end
+
+    return false
+end
+
 -- determines if we should skip the event.
 function E.skip(scope, enabled, split)
     if not enabled then


### PR DESCRIPTION
## 📃 Summary

Now that we have an Enter hook to automatically enable the plugin, we can introduce plugin-related behaviors to prevent conflicting with others.
