### PR TITLE
fix: weird layout when enabling the plugin with vsplit(s) opened

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -43,9 +43,6 @@ end
 
 -- Creates side buffers and set the internal state considering potential external trees.
 local function init()
-    local splitbelow, splitright = vim.o.splitbelow, vim.o.splitright
-    vim.o.splitbelow, vim.o.splitright = true, true
-
     S.win.main.curr = vim.api.nvim_get_current_win()
 
     if vim.api.nvim_list_uis()[1].width < _G.NoNeckPain.config.width then
@@ -56,7 +53,6 @@ local function init()
     S.win.external.trees = W.getSideTrees()
     S.win.main.left, S.win.main.right = W.createSideBuffers(S.win)
 
-    vim.o.splitbelow, vim.o.splitright = splitbelow, splitright
     vim.fn.win_gotoid(S.win.main.curr)
 end
 
@@ -75,7 +71,7 @@ function N.enable()
     vim.api.nvim_create_autocmd({ "VimResized" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(p.event, S.enabled, nil) then
+                if E.skip(S.enabled, nil) then
                     return
                 end
 
@@ -108,7 +104,7 @@ function N.enable()
     vim.api.nvim_create_autocmd({ "WinEnter" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(p.event, S.enabled, nil) then
+                if E.skip(S.enabled, nil) then
                     return
                 end
 
@@ -159,7 +155,7 @@ function N.enable()
     vim.api.nvim_create_autocmd({ "QuitPre", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(p.event, S.enabled, nil) then
+                if E.skip(S.enabled, nil) then
                     return
                 end
 
@@ -203,7 +199,7 @@ function N.enable()
     vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(p.event, S.enabled, nil) or S.win.main.split == nil then
+                if E.skip(S.enabled, nil) or S.win.main.split == nil then
                     return
                 end
 
@@ -258,7 +254,7 @@ function N.enable()
     vim.api.nvim_create_autocmd({ "WinEnter", "WinClosed" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(p.event, S.enabled, S.win.split) then
+                if E.skip(S.enabled, S.win.split) then
                     return
                 end
 

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -137,15 +137,6 @@ function C.init(win, name, backgroundColor, textColor)
 
     backgroundColor = backgroundColor or defaultBackground
 
-    D.log(
-        "Color.init",
-        "`%s` with bg `%s` | `%s` with fg `%s`",
-        backgroundGroup,
-        backgroundColor,
-        textGroup,
-        textColor
-    )
-
     -- clear groups
     vim.cmd(string.format("highlight! clear %s NONE", backgroundGroup))
     vim.cmd(string.format("highlight! clear %s NONE", textGroup))

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -22,14 +22,12 @@ function E.abortEnable(state, filetype)
 end
 
 -- determines if we should skip the event.
-function E.skip(scope, enabled, split)
+function E.skip(enabled, split)
     if not enabled then
         return true
     end
 
     if split ~= nil or W.isRelativeWindow() then
-        D.log(scope, "already in split view or float window detected, skipped")
-
         return true
     end
 

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -13,13 +13,11 @@ function W.createSideBuffers(wins)
     -- id: the id stored in the internal state
     local config = {
         left = {
-            cmd = "leftabove vnew",
-            moveTo = "wincmd l",
+            cmd = "topleft vnew",
             id = wins.main.left,
         },
         right = {
-            cmd = "vnew",
-            moveTo = "wincmd h",
+            cmd = "botright vnew",
             id = wins.main.right,
         },
     }
@@ -45,8 +43,6 @@ function W.createSideBuffers(wins)
             for opt, val in pairs(_G.NoNeckPain.config.buffers[side].wo) do
                 vim.api.nvim_win_set_option(id, opt, val)
             end
-
-            vim.cmd(config[side].moveTo)
 
             C.init(
                 id,

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -129,6 +129,19 @@ T["side buffers"]["closing the `right` buffer disables NNP"] = function()
     eq_state(child, "enabled", false)
 end
 
+T["side buffers"]["are correctly positionned on enable the plugin with vsplits open"] = function()
+    child.cmd("vsplit")
+
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000 })
+
+    child.lua([[
+        require('no-neck-pain').setup({width=50})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1002, 1001, 1000, 1003 })
+end
+
 T["auto command"] = new_set()
 
 T["auto command"]["does not create side buffers window's width < options.width"] = function()


### PR DESCRIPTION
## 📃 Summary

discovered in https://github.com/shortcuts/no-neck-pain.nvim/pull/113, closes https://github.com/shortcuts/no-neck-pain.nvim/issues/125

we now use the proper command to open side buffers at the left/right most of the screen.

## 📸 Preview

**Before**

<img width="1280" alt="Screenshot 2023-01-05 at 22 19 47" src="https://user-images.githubusercontent.com/20689156/210882038-af850de4-5bbf-41b8-ab1f-d92d014a8b21.png">

**After**

<img width="1280" alt="Screenshot 2023-01-05 at 22 20 13" src="https://user-images.githubusercontent.com/20689156/210882100-3b2202a4-ade0-4913-a6dc-59e5e5f46b6d.png">
