### PR TITLE
feat: default text color

### DIFF
--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -36,6 +36,9 @@ Default values:
       -- - catppuccin-macchiato-dark
       -- - catppuccin-mocha
       -- - catppuccin-mocha-dark
+      -- - github-nvim-theme-dark
+      -- - github-nvim-theme-dimmed
+      -- - github-nvim-theme-light
       -- - tokyonight-day
       -- - tokyonight-moon
       -- - tokyonight-night
@@ -108,6 +111,9 @@ Default values:
           -- - catppuccin-macchiato-dark
           -- - catppuccin-mocha
           -- - catppuccin-mocha-dark
+          -- - github-nvim-theme-dark
+          -- - github-nvim-theme-dimmed
+          -- - github-nvim-theme-light
           -- - tokyonight-day
           -- - tokyonight-moon
           -- - tokyonight-night

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -154,20 +154,25 @@ function NoNeckPain.setup(options)
     options = options or {}
     options.buffers = options.buffers or {}
     NoNeckPain.options = vim.tbl_deep_extend("keep", options, NoNeckPain.options)
-    NoNeckPain.options.buffers.left = vim.tbl_deep_extend(
-        "keep",
-        options.buffers.left or NoNeckPain.options.buffers,
-        NoNeckPain.options.buffers.left
-    )
-    NoNeckPain.options.buffers.right = vim.tbl_deep_extend(
-        "keep",
-        options.buffers.right or NoNeckPain.options.buffers,
-        NoNeckPain.options.buffers.right
-    )
+
+    assert(NoNeckPain.options.width > 0, "`width` must be greater than 0.")
+
+    for _, side in pairs({ "left", "right" }) do
+        NoNeckPain.options.buffers[side] = vim.tbl_deep_extend(
+            "keep",
+            options.buffers[side] or NoNeckPain.options.buffers,
+            NoNeckPain.options.buffers[side]
+        )
+    end
 
     NoNeckPain.options.buffers = C.parseColors(NoNeckPain.options.buffers)
 
     if NoNeckPain.options.toggleMapping ~= false then
+        assert(
+            type(NoNeckPain.options.toggleMapping) == "string",
+            "`toggleMapping` must be a string"
+        )
+
         vim.api.nvim_set_keymap("n", NoNeckPain.options.toggleMapping, ":NoNeckPain<CR>", {
             silent = true,
         })

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -78,13 +78,6 @@ function N.enable()
                 local width = vim.api.nvim_list_uis()[1].width
 
                 if width > _G.NoNeckPain.config.width then
-                    D.log(
-                        p.event,
-                        "window's width %s is above the given `width` option %s",
-                        width,
-                        _G.NoNeckPain.config.width
-                    )
-
                     -- we create everything if side buffers are missing
                     if S.win.main.left == nil and S.win.main.right == nil then
                         return init()

--- a/lua/no-neck-pain/util/color.lua
+++ b/lua/no-neck-pain/util/color.lua
@@ -92,22 +92,19 @@ end
 
 function C.parseColors(buffers)
     buffers.backgroundColor = matchAndBlend(buffers.backgroundColor, buffers.blend)
-    buffers.left.backgroundColor = matchAndBlend(
-        buffers.left.backgroundColor,
-        buffers.left.blend or buffers.blend
-    ) or buffers.backgroundColor
-    buffers.right.backgroundColor = matchAndBlend(
-        buffers.right.backgroundColor,
-        buffers.right.blend or buffers.blend
-    ) or buffers.backgroundColor
+
+    for _, side in pairs({ "left", "right" }) do
+        buffers[side].backgroundColor = matchAndBlend(
+            buffers[side].backgroundColor,
+            buffers[side].blend or buffers.blend
+        ) or buffers.backgroundColor
+
+        buffers[side].textColor = buffers[side].textColor
+            or buffers.textColor
+            or matchAndBlend(buffers[side].backgroundColor, 0.5)
+    end
 
     buffers.textColor = buffers.textColor or buffers.backgroundColor
-    buffers.left.textColor = buffers.left.textColor
-        or buffers.textColor
-        or buffers.left.backgroundColor
-    buffers.right.textColor = buffers.right.textColor
-        or buffers.textColor
-        or buffers.right.backgroundColor
 
     return buffers
 end

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -1,4 +1,3 @@
-local D = require("no-neck-pain.util.debug")
 local W = require("no-neck-pain.util.win")
 
 local E = {}


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/73

we can default the text color to the background one, plus some blending, to ease the usage of those features.

We default to blend +0.5 which should work in most cases.

## 📸 Preview


<img width="1280" alt="Screenshot 2023-01-09 at 22 51 32" src="https://user-images.githubusercontent.com/20689156/211415594-1cf42665-6b1d-461a-9b43-10b3ad2a5c16.png">
