### PR TITLE
fix: prevent unwanted event trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ require("no-neck-pain").setup({
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         setNames = false,
         -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-        -- popular theme are supported by their name:
+        -- See |NoNeckPain.bufferOptions| for more details.
         backgroundColor = nil,
         -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
         blend = 0,
@@ -185,7 +185,7 @@ NoNeckPain.bufferOptions = {
     -- When `false`, the buffer won't be created.
     enabled = true,
     -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-    -- popular theme are supported by their name:
+    -- See |NoNeckPain.bufferOptions| for more details.
     backgroundColor = nil,
     -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
     blend = 0,

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ require("no-neck-pain").setup({
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         setNames = false,
         -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-        -- See |NoNeckPain.bufferOptions| for more details.
+        -- popular theme are supported by their name:
         backgroundColor = nil,
         -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
         blend = 0,
         -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
         textColor = nil,
-        -- vim buffer-scoped options: any `vim.bo` options is accepted here.
+        -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
         bo = {
             filetype = "no-neck-pain",
             buftype = "nofile",
@@ -148,7 +148,7 @@ require("no-neck-pain").setup({
             buflisted = false,
             swapfile = false,
         },
-        -- vim window-scoped options: any `vim.wo` options is accepted here.
+        -- Vim window-scoped options: any `vim.wo` options is accepted here.
         wo = {
             cursorline = false,
             cursorcolumn = false,
@@ -166,7 +166,7 @@ require("no-neck-pain").setup({
         --- See |NoNeckPain.bufferOptions|.
         right = NoNeckPain.bufferOptions,
     },
-    -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
+    -- Supported integrations that might clash with `no-neck-pain.nvim`'s behavior.
     integrations = {
         -- https://github.com/nvim-tree/nvim-tree.lua
         NvimTree = {
@@ -185,13 +185,13 @@ NoNeckPain.bufferOptions = {
     -- When `false`, the buffer won't be created.
     enabled = true,
     -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-    -- See |NoNeckPain.bufferOptions| for more details.
+    -- popular theme are supported by their name:
     backgroundColor = nil,
     -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
     blend = 0,
     -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
     textColor = nil,
-    -- vim buffer-scoped options: any `vim.bo` options is accepted here.
+    -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
     bo = {
         filetype = "no-neck-pain",
         buftype = "nofile",
@@ -199,7 +199,7 @@ NoNeckPain.bufferOptions = {
         buflisted = false,
         swapfile = false,
     },
-    -- vim window-scoped options: any `vim.wo` options is accepted here.
+    -- Vim window-scoped options: any `vim.wo` options is accepted here.
     wo = {
         cursorline = false,
         cursorcolumn = false,

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -51,7 +51,7 @@ Default values:
       blend = 0,
       -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
       textColor = nil,
-      -- vim buffer-scoped options: any `vim.bo` options is accepted here.
+      -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
       bo = {
           filetype = "no-neck-pain",
           buftype = "nofile",
@@ -59,7 +59,7 @@ Default values:
           buflisted = false,
           swapfile = false,
       },
-      -- vim window-scoped options: any `vim.wo` options is accepted here.
+      -- Vim window-scoped options: any `vim.wo` options is accepted here.
       wo = {
           cursorline = false,
           cursorcolumn = false,
@@ -126,7 +126,7 @@ Default values:
           blend = 0,
           -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
           textColor = nil,
-          -- vim buffer-scoped options: any `vim.bo` options is accepted here.
+          -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
           bo = {
               filetype = "no-neck-pain",
               buftype = "nofile",
@@ -134,7 +134,7 @@ Default values:
               buflisted = false,
               swapfile = false,
           },
-          -- vim window-scoped options: any `vim.wo` options is accepted here.
+          -- Vim window-scoped options: any `vim.wo` options is accepted here.
           wo = {
               cursorline = false,
               cursorcolumn = false,
@@ -152,7 +152,7 @@ Default values:
           --- See |NoNeckPain.bufferOptions|.
           right = NoNeckPain.bufferOptions,
       },
-      -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
+      -- Supported integrations that might clash with `no-neck-pain.nvim`'s behavior.
       integrations = {
           -- https://github.com/nvim-tree/nvim-tree.lua
           NvimTree = {

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -34,7 +34,7 @@ NoNeckPain.bufferOptions = {
     blend = 0,
     -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
     textColor = nil,
-    -- vim buffer-scoped options: any `vim.bo` options is accepted here.
+    -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
     bo = {
         filetype = "no-neck-pain",
         buftype = "nofile",
@@ -42,7 +42,7 @@ NoNeckPain.bufferOptions = {
         buflisted = false,
         swapfile = false,
     },
-    -- vim window-scoped options: any `vim.wo` options is accepted here.
+    -- Vim window-scoped options: any `vim.wo` options is accepted here.
     wo = {
         cursorline = false,
         cursorcolumn = false,
@@ -104,7 +104,7 @@ NoNeckPain.options = {
         blend = 0,
         -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
         textColor = nil,
-        -- vim buffer-scoped options: any `vim.bo` options is accepted here.
+        -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
         bo = {
             filetype = "no-neck-pain",
             buftype = "nofile",
@@ -112,7 +112,7 @@ NoNeckPain.options = {
             buflisted = false,
             swapfile = false,
         },
-        -- vim window-scoped options: any `vim.wo` options is accepted here.
+        -- Vim window-scoped options: any `vim.wo` options is accepted here.
         wo = {
             cursorline = false,
             cursorcolumn = false,
@@ -130,7 +130,7 @@ NoNeckPain.options = {
         --- See |NoNeckPain.bufferOptions|.
         right = NoNeckPain.bufferOptions,
     },
-    -- lists supported integrations that might clash with `no-neck-pain.nvim`'s behavior
+    -- Supported integrations that might clash with `no-neck-pain.nvim`'s behavior.
     integrations = {
         -- https://github.com/nvim-tree/nvim-tree.lua
         NvimTree = {

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -2,6 +2,7 @@ local D = require("no-neck-pain.util.debug")
 local E = require("no-neck-pain.util.event")
 local M = require("no-neck-pain.util.map")
 local W = require("no-neck-pain.util.win")
+local T = require("no-neck-pain.util.trees")
 
 local N = {}
 
@@ -50,7 +51,7 @@ local function init()
     end
 
     -- before creating side buffers, we determine if we should consider externals
-    S.win.external.trees = W.getSideTrees()
+    S.win.external.trees = T.getSideTrees()
     S.win.main.left, S.win.main.right = W.createSideBuffers(S.win)
 
     vim.fn.win_gotoid(S.win.main.curr)
@@ -110,7 +111,7 @@ function N.enable()
 
                 -- we skip side trees etc. as they are not part of the split manager.
                 local fileType = vim.api.nvim_buf_get_option(0, "filetype")
-                if W.isSideTree(fileType) then
+                if T.isSideTree(fileType) then
                     return D.log(p.event, "encountered an external window")
                 end
 
@@ -257,7 +258,7 @@ function N.enable()
                 end
 
                 local wins = vim.api.nvim_list_wins()
-                local trees = W.getSideTrees()
+                local trees = T.getSideTrees()
 
                 -- we cycle over supported integrations to see which got closed or opened
                 for name, tree in pairs(S.win.external.trees) do

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -21,13 +21,21 @@ function E.abortEnable(state, filetype)
 end
 
 -- determines if we should skip the event.
-function E.skip(enabled, split)
+function E.skip(enabled, main, split)
     if not enabled then
         return true
     end
 
     if split ~= nil or W.isRelativeWindow() then
         return true
+    end
+
+    if main ~= nil then
+        local curr = vim.api.nvim_get_current_win()
+
+        if curr == main.left or curr == main.right then
+            return true
+        end
     end
 
     return false

--- a/lua/no-neck-pain/util/trees.lua
+++ b/lua/no-neck-pain/util/trees.lua
@@ -1,0 +1,33 @@
+local T = {}
+
+function T.isSideTree(fileType)
+    return fileType == "NvimTree" or fileType == "undotree"
+end
+
+function T.getSideTrees()
+    local wins = vim.api.nvim_list_wins()
+    local trees = {
+        NvimTree = {
+            id = nil,
+            width = 0,
+        },
+        undotree = {
+            id = nil,
+            width = 0,
+        },
+    }
+
+    for _, win in pairs(wins) do
+        local fileType = vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(win), "filetype")
+        if T.isSideTree(fileType) then
+            trees[fileType] = {
+                id = win,
+                width = vim.api.nvim_win_get_width(win) * 2,
+            }
+        end
+    end
+
+    return trees
+end
+
+return T

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -1,8 +1,10 @@
 local C = require("no-neck-pain.util.color")
 local D = require("no-neck-pain.util.debug")
 local M = require("no-neck-pain.util.map")
+
 local W = {}
-local SIDES = { "left", "right" }
+
+W.SIDES = { "left", "right" }
 
 -- Creates side buffers with the correct padding.
 --
@@ -22,7 +24,7 @@ function W.createSideBuffers(wins)
         },
     }
 
-    for _, side in pairs(SIDES) do
+    for _, side in pairs(W.SIDES) do
         if _G.NoNeckPain.config.buffers[side].enabled and wins.main[side] == nil then
             local padding = W.getPadding(side, wins.external.trees)
 
@@ -88,38 +90,9 @@ function W.listWinsExcept(list)
     return validWins, size
 end
 
--- returns the available buffers and their total number, without the `list` ones.
-function W.listBufsExcept(list)
-    local bufs = vim.api.nvim_list_bufs()
-    local validBufs = {}
-    local size = 0
-
-    for _, buf in pairs(bufs) do
-        if not M.contains(list, buf) then
-            table.insert(validBufs, buf)
-            size = size + 1
-        end
-    end
-
-    return validBufs, size
-end
-
--- gets the bufs of the given `wins` list, if win are valid.
-function W.winsGetBufs(wins)
-    local bufs = {}
-
-    for _, win in pairs(wins) do
-        if win ~= nil and vim.api.nvim_win_is_valid(win) then
-            table.insert(bufs, vim.api.nvim_win_get_buf(win))
-        end
-    end
-
-    return bufs
-end
-
 -- Closes side buffers, quits Neovim if there's no other window left.
 function W.closeSideBuffers(scope, wins)
-    for _, side in pairs(SIDES) do
+    for _, side in pairs(W.SIDES) do
         if wins[side] ~= nil then
             local _, wsize = W.listWinsExcept({ wins[side] })
 
@@ -151,7 +124,7 @@ end
 function W.resizeSideBuffers(scope, wins)
     D.log(scope, "resizing side buffers")
 
-    for _, side in pairs(SIDES) do
+    for _, side in pairs(W.SIDES) do
         if wins.main[side] ~= nil then
             local padding = W.getPadding(side, wins.external.trees)
 
@@ -160,36 +133,6 @@ function W.resizeSideBuffers(scope, wins)
             end
         end
     end
-end
-
-function W.isSideTree(fileType)
-    return fileType == "NvimTree" or fileType == "undotree"
-end
-
-function W.getSideTrees()
-    local wins = vim.api.nvim_list_wins()
-    local trees = {
-        NvimTree = {
-            id = nil,
-            width = 0,
-        },
-        undotree = {
-            id = nil,
-            width = 0,
-        },
-    }
-
-    for _, win in pairs(wins) do
-        local fileType = vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(win), "filetype")
-        if W.isSideTree(fileType) then
-            trees[fileType] = {
-                id = win,
-                width = vim.api.nvim_win_get_width(win) * 2,
-            }
-        end
-    end
-
-    return trees
 end
 
 -- Determine the "padding" (width) of the buffer based on the `_G.NoNeckPain.config.width` and the width of the screen.

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -162,6 +162,10 @@ function W.resizeSideBuffers(scope, wins)
     end
 end
 
+function W.isSideTree(fileType)
+    return fileType == "NvimTree" or fileType == "undotree"
+end
+
 function W.getSideTrees()
     local wins = vim.api.nvim_list_wins()
     local trees = {
@@ -177,7 +181,7 @@ function W.getSideTrees()
 
     for _, win in pairs(wins) do
         local fileType = vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(win), "filetype")
-        if fileType == "NvimTree" or fileType == "undotree" then
+        if W.isSideTree(fileType) then
             trees[fileType] = {
                 id = win,
                 width = vim.api.nvim_win_get_width(win) * 2,
@@ -192,13 +196,13 @@ end
 --
 -- @param trees list: the external trees supported with their `width` and `id`.
 function W.getPadding(side, trees)
-    local wins = vim.api.nvim_list_uis()
+    local uis = vim.api.nvim_list_uis()
 
-    if wins[1] == nil then
-        return D.log("W.getPadding", "attempted to get the padding of a non-existing window.")
+    if uis[1] == nil then
+        return error("W.getPadding - attempted to get the padding of a non-existing UI.")
     end
 
-    local width = wins[1].width
+    local width = uis[1].width
 
     if _G.NoNeckPain.config.width >= width then
         return 1


### PR DESCRIPTION
## 📃 Summary

discovered in https://github.com/shortcuts/no-neck-pain.nvim/pull/134, we triggered some events when entering side buffers, while those should be "transparent" to the user.