### PR TITLE
fix: register command for nvim <0.7

### DIFF
--- a/plugin/no-neck-pain.lua
+++ b/plugin/no-neck-pain.lua
@@ -11,4 +11,3 @@ else
         require("no-neck-pain").toggle()
     end, {})
 end
-

--- a/plugin/no-neck-pain.lua
+++ b/plugin/no-neck-pain.lua
@@ -4,6 +4,11 @@ end
 
 _G.NoNeckPainLoaded = true
 
-vim.api.nvim_create_user_command("NoNeckPain", function()
-    require("no-neck-pain").toggle()
-end, {})
+if vim.fn.has("nvim-0.7") == 0 then
+    vim.cmd("command NoNeckPain lua require('no-neck-pain').toggle()")
+else
+    vim.api.nvim_create_user_command("NoNeckPain", function()
+        require("no-neck-pain").toggle()
+    end, {})
+end
+


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/137

the method used to register the command is only available in Neovim 0.7 and higher, this should cover older versions.
