### PR TITLE
feat: add built-in scratchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ require("no-neck-pain").setup({
     buffers = {
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         setNames = false,
+        -- Options related to the scratch pad for the side buffers.
+        scratchPad = {
+            -- When `true`, automatically sets the following options to the side buffers:
+            -- - `autowriteall`
+            -- - `autoread`.
+            enabled = false,
+            -- The name of the generated file. See `location` for more information.
+            -- @example: `no-neck-pain-left.norg`
+            fileName = "no-neck-pain",
+            -- By default, files are saved at the same location as the current Neovim session. Filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed from the buffer options via `buffers.bo.filetype`, `buffers.left.bo.filetype` and `buffers.right.bo.filetype`.
+            -- @example: `no-neck-pain-left.norg`
+            location = nil,
+        },
         -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
         backgroundColor = nil,
         -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ require("no-neck-pain").setup({
     buffers = {
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         setNames = false,
-        -- Options related to the scratch pad for the side buffers.
+        -- The scratchPad feature leverages the empty side buffers to take notes. It works like any Neovim buffer and will automatically save the content at the given `location`.
+        -- Quitting an unsaved scratchpad buffer is non-blocking, as it's auto-saved.
         scratchPad = {
             -- When `true`, automatically sets the following options to the side buffers:
             -- - `autowriteall`

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -106,13 +106,13 @@ Default values:
               -- When `true`, automatically sets the following options to the side buffers:
               -- - `autowriteall`
               -- - `autoread`.
-              -- - textColor is defaulted to a brighter shade of the background color.
               enabled = false,
-              -- the name of the generated file.
+              -- The name of the generated file. See `location` for more information.
+              -- @example: `no-neck-pain-left.norg`
               fileName = "no-neck-pain",
-              -- files are available at `$LOCATION/$FILENAME-$SIDE.$FILETYPE`, where `$SIDE` is either left or right.
-              -- the default filetype is `norg` (https://github.com/nvim-neorg/neorg), you can change it in `buffers.bo.filetype`.
-              location = "~/",
+              -- By default, files are saved at the same location as the current Neovim session. Filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed from the buffer options via `buffers.bo.filetype`, `buffers.left.bo.filetype` and `buffers.right.bo.filetype`.
+              -- @example: `no-neck-pain-left.norg`
+              location = nil,
           },
           -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
           -- popular theme are supported by their name:

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -101,7 +101,8 @@ Default values:
       buffers = {
           -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
           setNames = false,
-          -- Options related to the scratch pad for the side buffers.
+          -- The scratchPad feature leverages the empty side buffers to take notes. It works like any Neovim buffer and will automatically save the content at the given `location`.
+          -- Quitting an unsaved scratchpad buffer is non-blocking, as it's auto-saved.
           scratchPad = {
               -- When `true`, automatically sets the following options to the side buffers:
               -- - `autowriteall`

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -101,6 +101,19 @@ Default values:
       buffers = {
           -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
           setNames = false,
+          -- Options related to the scratch pad for the side buffers.
+          scratchPad = {
+              -- When `true`, automatically sets the following options to the side buffers:
+              -- - `autowriteall`
+              -- - `autoread`.
+              -- - textColor is defaulted to a brighter shade of the background color.
+              enabled = false,
+              -- the name of the generated file.
+              fileName = "no-neck-pain",
+              -- files are available at `$LOCATION/$FILENAME-$SIDE.$FILETYPE`, where `$SIDE` is either left or right.
+              -- the default filetype is `norg` (https://github.com/nvim-neorg/neorg), you can change it in `buffers.bo.filetype`.
+              location = "~/",
+          },
           -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
           -- popular theme are supported by their name:
           -- - catppuccin-frappe

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -79,7 +79,8 @@ NoNeckPain.options = {
     buffers = {
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         setNames = false,
-        -- Options related to the scratch pad for the side buffers.
+        -- The scratchPad feature leverages the empty side buffers to take notes. It works like any Neovim buffer and will automatically save the content at the given `location`.
+        -- Quitting an unsaved scratchpad buffer is non-blocking, as it's auto-saved.
         scratchPad = {
             -- When `true`, automatically sets the following options to the side buffers:
             -- - `autowriteall`

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -79,6 +79,19 @@ NoNeckPain.options = {
     buffers = {
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
         setNames = false,
+        -- Options related to the scratch pad for the side buffers.
+        scratchPad = {
+            -- When `true`, automatically sets the following options to the side buffers:
+            -- - `autowriteall`
+            -- - `autoread`.
+            enabled = false,
+            -- The name of the generated file. See `location` for more information.
+            -- @example: `no-neck-pain-left.norg`
+            fileName = "no-neck-pain",
+            -- By default, files are saved at the same location as the current Neovim session. Filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed from the buffer options via `buffers.bo.filetype`, `buffers.left.bo.filetype` and `buffers.right.bo.filetype`.
+            -- @example: `no-neck-pain-left.norg`
+            location = nil,
+        },
         -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
         -- popular theme are supported by their name:
         -- - catppuccin-frappe
@@ -175,6 +188,14 @@ function NoNeckPain.setup(options)
             options.buffers[side] or NoNeckPain.options.buffers,
             NoNeckPain.options.buffers[side]
         )
+
+        -- if the user wants scratchpads, but did not provided a custom filetype, we default to `norg`.
+        if
+            NoNeckPain.options.buffers.scratchPad.enabled
+            and NoNeckPain.options.buffers[side].bo.filetype == "no-neck-pain"
+        then
+            NoNeckPain.options.buffers[side].bo.filetype = "norg"
+        end
     end
 
     NoNeckPain.options.buffers = C.parseColors(NoNeckPain.options.buffers)

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -84,7 +84,12 @@ function W.createSideBuffers(wins)
                         location = location .. "/"
                     end
 
-                    location = location .. _G.NoNeckPain.config.buffers.scratchPad.fileName .. "-" .. side .. "." .. _G.NoNeckPain.config.buffers[side].bo.filetype
+                    location = location
+                        .. _G.NoNeckPain.config.buffers.scratchPad.fileName
+                        .. "-"
+                        .. side
+                        .. "."
+                        .. _G.NoNeckPain.config.buffers[side].bo.filetype
 
                     -- we edit the file if it exists, otherwise we create it
                     if vim.fn.filereadable(location) then

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -78,7 +78,7 @@ function W.createSideBuffers(wins)
 
                 -- default options for scratchpad
                 if _G.NoNeckPain.config.buffers.scratchPad.enabled then
-                    local location =  ""
+                    local location = ""
 
                     if _G.NoNeckPain.config.buffers.scratchPad.location ~= nil then
                         assert(

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -78,7 +78,16 @@ function W.createSideBuffers(wins)
 
                 -- default options for scratchpad
                 if _G.NoNeckPain.config.buffers.scratchPad.enabled then
-                    local location = _G.NoNeckPain.config.buffers.scratchPad.location or ""
+                    local location =  ""
+
+                    if _G.NoNeckPain.config.buffers.scratchPad.location ~= nil then
+                        assert(
+                            type(_G.NoNeckPain.config.buffers.scratchPad.location) == "string",
+                            "`buffers.scratchPad.location` must be a nil or a string."
+                        )
+
+                        location = _G.NoNeckPain.config.buffers.scratchPad.location
+                    end
 
                     if location ~= "" and string.sub(location, -1) ~= "/" then
                         location = location .. "/"

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -76,6 +76,29 @@ function W.createSideBuffers(wins)
                     _G.NoNeckPain.config.buffers[side].textColor
                 )
 
+                -- default options for scratchpad
+                if _G.NoNeckPain.config.buffers.scratchPad.enabled then
+                    local location = _G.NoNeckPain.config.buffers.scratchPad.location or ""
+
+                    if location ~= "" and string.sub(location, -1) ~= "/" then
+                        location = location .. "/"
+                    end
+
+                    location = location .. _G.NoNeckPain.config.buffers.scratchPad.fileName .. "-" .. side .. "." .. _G.NoNeckPain.config.buffers[side].bo.filetype
+
+                    -- we edit the file if it exists, otherwise we create it
+                    if vim.fn.filereadable(location) then
+                        vim.cmd(string.format("edit %s", location))
+                    else
+                        vim.api.nvim_buf_set_name(0, location)
+                    end
+
+                    vim.api.nvim_buf_set_option(0, "bufhidden", "")
+                    vim.api.nvim_buf_set_option(0, "buftype", "")
+                    vim.api.nvim_buf_set_option(0, "autoread", true)
+                    vim.o.autowriteall = true
+                end
+
                 wins.main[side] = id
             end
         end

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -39,9 +39,9 @@ T["install"]["sets global loaded variable and provide toggle command"] = functio
     eq_state(child, "enabled", false)
 end
 
-T["setup()"] = MiniTest.new_set()
+T["setup"] = MiniTest.new_set()
 
-T["setup()"]["sets exposed methods and default options value"] = function()
+T["setup"]["sets exposed methods and default options value"] = function()
     child.lua([[require('no-neck-pain').setup()]])
 
     eq_type_global(child, "_G.NoNeckPain", "table")
@@ -118,20 +118,7 @@ T["setup()"]["sets exposed methods and default options value"] = function()
     eq_config(child, "integrations.undotree.position", "left")
 end
 
-T["setup()"]["integrations: NvimTree with wrong values"] = function()
-    helpers.expect.error(function()
-        child.lua([[ require('no-neck-pain').setup({
-                    integrations = {
-                        NvimTree = {
-                            "position": "nope"
-                        },
-                    },
-                })
-            ]])
-    end)
-end
-
-T["setup()"]["overrides default values"] = function()
+T["setup"]["overrides default values"] = function()
     child.lua([[require('no-neck-pain').setup({
         width = 42,
         enableOnVimEnter = true,
@@ -139,239 +126,17 @@ T["setup()"]["overrides default values"] = function()
         debug = true,
         disableOnLastBuffer = true,
         killAllBuffersOnDisable = true,
-        buffers = {
-            setNames = true,
-            backgroundColor = "catppuccin-frappe",
-            blend = 0.4,
-            textColor = "#7480c2",
-            bo = {
-                filetype = "my-file-type",
-                buftype = "help",
-                bufhidden = "",
-                buflisted = true,
-                swapfile = true,
-            },
-            wo = {
-                cursorline = true,
-                cursorcolumn = true,
-                number = true,
-                relativenumber = true,
-                foldenable = true,
-                list = true,
-                wrap = false,
-                linebreak = false,
-            },
-            left = {
-                backgroundColor = "catppuccin-frappe",
-                blend = 0.2,
-            	textColor = "#7480c2",
-                bo = {
-                    filetype = "my-file-type",
-                    buftype = "help",
-                    bufhidden = "",
-                    buflisted = true,
-                    swapfile = true,
-                },
-                wo = {
-                    cursorline = true,
-                    cursorcolumn = true,
-                    number = true,
-                    relativenumber = true,
-                    foldenable = true,
-                    list = true,
-                    wrap = false,
-                    linebreak = false,
-                },
-            },
-            right = {
-                backgroundColor = "catppuccin-frappe",
-                blend = 0.2,
-            	textColor = "#7480c2",
-                bo = {
-                    filetype = "my-file-type",
-                    buftype = "help",
-                    bufhidden = "",
-                    buflisted = true,
-                    swapfile = true,
-                },
-                wo = {
-                    cursorline = true,
-                    cursorcolumn = true,
-                    number = true,
-                    relativenumber = true,
-                    foldenable = true,
-                    list = true,
-                    wrap = false,
-                    linebreak = false,
-                },
-            },
-        },
-        integrations = {
-            NvimTree = {
-                position = "right",
-                close = false,
-                reopen = false,
-            },
-            undotree = {
-                position = "right",
-            }
-        }
     })]])
 
-    -- config
     eq_config(child, "width", 42)
     eq_config(child, "enableOnVimEnter", true)
     eq_config(child, "toggleMapping", "<Leader>kz")
     eq_config(child, "debug", true)
     eq_config(child, "disableOnLastBuffer", true)
     eq_config(child, "killAllBuffersOnDisable", true)
-
-    -- buffers
-    eq_type_config(child, "buffers", "table")
-    eq_type_config(child, "buffers.bo", "table")
-    eq_type_config(child, "buffers.wo", "table")
-
-    eq_config(child, "buffers.setNames", true)
-    eq_config(child, "buffers.backgroundColor", "#828590")
-    eq_config(child, "buffers.blend", 0.4)
-    eq_config(child, "buffers.textColor", "#7480c2")
-
-    eq_config(child, "buffers.bo.filetype", "my-file-type")
-    eq_config(child, "buffers.bo.buftype", "help")
-    eq_config(child, "buffers.bo.bufhidden", "")
-    eq_config(child, "buffers.bo.buflisted", true)
-    eq_config(child, "buffers.bo.swapfile", true)
-
-    eq_config(child, "buffers.wo.cursorline", true)
-    eq_config(child, "buffers.wo.cursorcolumn", true)
-    eq_config(child, "buffers.wo.number", true)
-    eq_config(child, "buffers.wo.relativenumber", true)
-    eq_config(child, "buffers.wo.foldenable", true)
-    eq_config(child, "buffers.wo.list", true)
-    eq_config(child, "buffers.wo.wrap", false)
-    eq_config(child, "buffers.wo.linebreak", false)
-
-    for _, scope in pairs(SCOPES) do
-        eq_config(child, "buffers." .. scope .. ".backgroundColor", "#595c6b")
-        eq_config(child, "buffers." .. scope .. ".blend", 0.2)
-        eq_config(child, "buffers." .. scope .. ".textColor", "#7480c2")
-
-        eq_config(child, "buffers." .. scope .. ".bo.filetype", "my-file-type")
-        eq_config(child, "buffers." .. scope .. ".bo.buftype", "help")
-        eq_config(child, "buffers." .. scope .. ".bo.bufhidden", "")
-        eq_config(child, "buffers." .. scope .. ".bo.buflisted", true)
-        eq_config(child, "buffers." .. scope .. ".bo.swapfile", true)
-
-        eq_config(child, "buffers." .. scope .. ".wo.cursorline", true)
-        eq_config(child, "buffers." .. scope .. ".wo.cursorcolumn", true)
-        eq_config(child, "buffers." .. scope .. ".wo.number", true)
-        eq_config(child, "buffers." .. scope .. ".wo.relativenumber", true)
-        eq_config(child, "buffers." .. scope .. ".wo.foldenable", true)
-        eq_config(child, "buffers." .. scope .. ".wo.list", true)
-        eq_config(child, "buffers." .. scope .. ".wo.wrap", false)
-        eq_config(child, "buffers." .. scope .. ".wo.linebreak", false)
-    end
-
-    eq_config(child, "integrations.NvimTree.position", "right")
-    eq_config(child, "integrations.NvimTree.close", false)
-    eq_config(child, "integrations.NvimTree.reopen", false)
-    eq_config(child, "integrations.undotree.position", "right")
 end
 
-T["setup()"]["`left` or `right` buffer options overrides `common` ones"] = function()
-    child.lua([[require('no-neck-pain').setup({
-        buffers = {
-            backgroundColor = "catppuccin-frappe",
-            blend = 0.1,
-            textColor = "#7480c2",
-            bo = {
-                filetype = "TEST",
-            },
-            wo = {
-                cursorline = false,
-            },
-            left = {
-                backgroundColor = "catppuccin-frappe-dark",
-                blend = -0.8,
-                textColor = "#123123",
-                bo = {
-                    filetype = "TEST-left",
-                },
-                wo = {
-                    cursorline = true,
-                },
-            },
-            right = {
-                backgroundColor = "catppuccin-latte",
-                blend = 1,
-                textColor = "#456456",
-                bo = {
-                    filetype = "TEST-right",
-                },
-                wo = {
-                    number = true,
-                },
-            },
-        },
-    })]])
-
-    eq_config(child, "buffers.backgroundColor", "#444858")
-    eq_config(child, "buffers.blend", 0.1)
-    eq_config(child, "buffers.textColor", "#7480c2")
-    eq_config(child, "buffers.bo.filetype", "TEST")
-    eq_config(child, "buffers.wo.cursorline", false)
-
-    eq_config(child, "buffers.left.backgroundColor", "#08080b")
-    eq_config(child, "buffers.right.backgroundColor", "#ffffff")
-
-    eq_config(child, "buffers.left.blend", -0.8)
-    eq_config(child, "buffers.right.blend", 1)
-
-    eq_config(child, "buffers.left.textColor", "#123123")
-    eq_config(child, "buffers.right.textColor", "#456456")
-
-    eq_config(child, "buffers.left.bo.filetype", "TEST-left")
-    eq_config(child, "buffers.right.bo.filetype", "TEST-right")
-
-    eq_config(child, "buffers.left.wo.cursorline", true)
-    eq_config(child, "buffers.right.wo.number", true)
-end
-
-T["setup()"]["`common` options spreads it to `left` and `right` buffers"] = function()
-    child.lua([[require('no-neck-pain').setup({
-        buffers = {
-            backgroundColor = "catppuccin-frappe",
-            blend = 1,
-            bo = {
-                filetype = "TEST",
-            },
-            wo = {
-                number = true,
-            },
-        },
-    })]])
-
-    eq_config(child, "buffers.backgroundColor", "#ffffff")
-    eq_config(child, "buffers.bo.filetype", "TEST")
-    eq_config(child, "buffers.wo.number", true)
-
-    eq_config(child, "buffers.left.backgroundColor", "#ffffff")
-    eq_config(child, "buffers.right.backgroundColor", "#ffffff")
-
-    eq_config(child, "buffers.left.blend", 1)
-    eq_config(child, "buffers.right.blend", 1)
-
-    eq_config(child, "buffers.left.textColor", "#ffffff")
-    eq_config(child, "buffers.right.textColor", "#ffffff")
-
-    eq_config(child, "buffers.left.wo.number", true)
-    eq_config(child, "buffers.right.wo.number", true)
-
-    eq_config(child, "buffers.left.bo.filetype", "TEST")
-    eq_config(child, "buffers.right.bo.filetype", "TEST")
-end
-
-T["setup()"]["enables the plugin with mapping"] = function()
+T["setup"]["enables the plugin with mapping"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50,toggleMapping="nn"})
     ]])
@@ -390,7 +155,7 @@ T["setup()"]["enables the plugin with mapping"] = function()
     eq_state(child, "enabled", false)
 end
 
-T["setup()"]["starts the plugin on VimEnter"] = function()
+T["setup"]["starts the plugin on VimEnter"] = function()
     child.restart({ "-u", "scripts/test_auto_open.lua" })
 
     eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
@@ -399,9 +164,9 @@ T["setup()"]["starts the plugin on VimEnter"] = function()
     child.stop()
 end
 
-T["enable()"] = MiniTest.new_set()
+T["enable"] = MiniTest.new_set()
 
-T["enable()"]["sets state"] = function()
+T["enable"]["sets state"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
@@ -431,9 +196,9 @@ T["enable()"]["sets state"] = function()
     end
 end
 
-T["disable()"] = MiniTest.new_set()
+T["disable"] = MiniTest.new_set()
 
-T["disable()"]["resets state"] = function()
+T["disable"]["resets state"] = function()
     child.lua([[
         require('no-neck-pain').enable()
         require('no-neck-pain').disable()

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -17,6 +17,93 @@ local T = MiniTest.new_set({
 
 local SCOPES = { "left", "right" }
 
+T["setup"] = MiniTest.new_set()
+
+T["setup"]["overrides default values"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        buffers = {
+            backgroundColor = "catppuccin-frappe",
+            blend = 0.4,
+            textColor = "#7480c2",
+            left = {
+                backgroundColor = "catppuccin-frappe",
+                blend = 0.2,
+            	textColor = "#7480c2",
+            },
+            right = {
+                backgroundColor = "catppuccin-frappe",
+                blend = 0.2,
+            	textColor = "#7480c2",
+            },
+        },
+    })]])
+
+    eq_config(child, "buffers.backgroundColor", "#828590")
+    eq_config(child, "buffers.blend", 0.4)
+    eq_config(child, "buffers.textColor", "#7480c2")
+
+    for _, scope in pairs(SCOPES) do
+        eq_config(child, "buffers." .. scope .. ".backgroundColor", "#595c6b")
+        eq_config(child, "buffers." .. scope .. ".blend", 0.2)
+        eq_config(child, "buffers." .. scope .. ".textColor", "#7480c2")
+    end
+end
+
+T["setup"]["`left` or `right` buffer options overrides `common` ones"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        buffers = {
+            backgroundColor = "catppuccin-frappe",
+            blend = 0.1,
+            textColor = "#7480c2",
+            left = {
+                backgroundColor = "catppuccin-frappe-dark",
+                blend = -0.8,
+                textColor = "#123123",
+            },
+            right = {
+                backgroundColor = "catppuccin-latte",
+                blend = 1,
+                textColor = "#456456",
+            },
+        },
+    })]])
+
+    eq_config(child, "buffers.backgroundColor", "#444858")
+    eq_config(child, "buffers.blend", 0.1)
+    eq_config(child, "buffers.textColor", "#7480c2")
+
+    eq_config(child, "buffers.left.backgroundColor", "#08080b")
+    eq_config(child, "buffers.right.backgroundColor", "#ffffff")
+
+    eq_config(child, "buffers.left.blend", -0.8)
+    eq_config(child, "buffers.right.blend", 1)
+
+    eq_config(child, "buffers.left.textColor", "#123123")
+    eq_config(child, "buffers.right.textColor", "#456456")
+end
+
+T["setup"]["`common` options spreads it to `left` and `right` buffers"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        buffers = {
+            backgroundColor = "catppuccin-frappe",
+            blend = 1,
+            textColor = "#000000",
+        },
+    })]])
+
+    eq_config(child, "buffers.backgroundColor", "#ffffff")
+    eq_config(child, "buffers.textColor", "#000000")
+
+    eq_config(child, "buffers.left.backgroundColor", "#ffffff")
+    eq_config(child, "buffers.right.backgroundColor", "#ffffff")
+
+    eq_config(child, "buffers.left.blend", 1)
+    eq_config(child, "buffers.right.blend", 1)
+
+    eq_config(child, "buffers.left.textColor", "#000000")
+    eq_config(child, "buffers.right.textColor", "#000000")
+end
+
 T["color"] = MiniTest.new_set()
 
 T["color"]["map integration name to a value"] = function()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -1,0 +1,55 @@
+local helpers = dofile("tests/helpers.lua")
+
+local child = helpers.new_child_neovim()
+local eq_config = helpers.expect.config_equality
+
+local T = MiniTest.new_set({
+    hooks = {
+        -- This will be executed before every (even nested) case
+        pre_case = function()
+            -- Restart child process with custom 'init.lua' script
+            child.restart({ "-u", "scripts/minimal_init.lua" })
+        end,
+        -- This will be executed one after all tests from this set are finished
+        post_once = child.stop,
+    },
+})
+
+T["setup"] = MiniTest.new_set()
+
+T["setup"]["overrides default values"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        integrations = {
+            NvimTree = {
+                position = "right",
+                close = false,
+                reopen = false,
+            },
+            undotree = {
+                position = "right",
+            }
+        }
+    })]])
+
+    eq_config(child, "integrations.NvimTree.position", "right")
+    eq_config(child, "integrations.NvimTree.close", false)
+    eq_config(child, "integrations.NvimTree.reopen", false)
+    eq_config(child, "integrations.undotree.position", "right")
+end
+
+T["integrations"] = MiniTest.new_set()
+
+T["integrations"]["NvimTree with wrong values"] = function()
+    helpers.expect.error(function()
+        child.lua([[ require('no-neck-pain').setup({
+                    integrations = {
+                        NvimTree = {
+                            "position": "nope"
+                        },
+                    },
+                })
+            ]])
+    end)
+end
+
+return T

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -1,0 +1,104 @@
+local helpers = dofile("tests/helpers.lua")
+
+local child = helpers.new_child_neovim()
+local eq, eq_global, eq_config, eq_state =
+    helpers.expect.equality,
+    helpers.expect.global_equality,
+    helpers.expect.config_equality,
+    helpers.expect.state_equality
+local eq_type_global, eq_type_config, eq_type_state =
+    helpers.expect.global_type_equality,
+    helpers.expect.config_type_equality,
+    helpers.expect.state_type_equality
+
+local T = MiniTest.new_set({
+    hooks = {
+        -- This will be executed before every (even nested) case
+        pre_case = function()
+            -- Restart child process with custom 'init.lua' script
+            child.restart({ "-u", "scripts/minimal_init.lua" })
+        end,
+        -- This will be executed one after all tests from this set are finished
+        post_once = child.stop,
+    },
+})
+
+T["setup"] = MiniTest.new_set()
+
+T["setup"]["overrides default values"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        buffers = {
+            scratchPad = {
+                enabled = true,
+                location = "~/Documents",
+            }
+        },
+    })]])
+
+    eq_config(child, "buffers.scratchPad.enabled", true)
+    eq_config(child, "buffers.scratchPad.location", "~/Documents")
+end
+
+T["scratchPad"] = MiniTest.new_set()
+
+T["scratchPad"]["default to `norg` fileType"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        width = 50,
+        buffers = {
+            scratchPad = {
+                enabled = true
+            }
+        },
+    })]])
+    child.lua([[require('no-neck-pain').enable()]])
+
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+
+    local cwd = child.lua_get("vim.fn.getcwd()")
+
+    eq(
+        child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1001))"),
+        cwd .. "/no-neck-pain-left.norg"
+    )
+    eq(
+        child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1002))"),
+        cwd .. "/no-neck-pain-right.norg"
+    )
+end
+
+T["scratchPad"]["override to md is reflected to the buffer"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        width = 50,
+        buffers = {
+            scratchPad = {
+                enabled = true
+            },
+            left = {
+                bo = {
+                    filetype = "md",
+                },
+            },
+            right = {
+                bo = {
+                    filetype = "txt",
+                }
+            }
+        },
+    })]])
+    child.lua([[require('no-neck-pain').enable()]])
+
+    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+
+    local cwd = child.lua_get("vim.fn.getcwd()")
+
+    eq(
+        child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1001))"),
+        cwd .. "/no-neck-pain-left.md"
+    )
+    eq(
+        child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1002))"),
+        cwd .. "/no-neck-pain-right.txt"
+    )
+end
+
+return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/121
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/122

This PR adds a built-in scratch pad feature, which leverages side buffers to read/write to file of choice.

When enabled (false by default), side buffers will be created with the following options:
- `bufhidden` ""
- `buftype` ""
- `autoread` true
- `autowriteall` true

The location is configurable in case the user don't want to have the scratchpad pushed to git or something.

The filetype is defaulted to `norg`, but can be changed via the `bo` options.

-----

- [x] add configuration
- [x] add documentation
- [x] update readme
- [ ] add tests
- [x] add assertion

## 📸 Preview

with config:
```lua
require("no-neck-pain").setup({
    debug = true,
    width = 80,
    enableOnVimEnter = true,
    toggleMapping = "<Leader>kz",
    buffers = {
        backgroundColor = "onedark",
        blend = -0.1,
        scratchPad = {
            enabled = true,
        },
        left = {
            bo = {
                filetype = "md"
            },
        },
        right = {
            enabled = false,
        },
    },
})
```

<img width="1280" alt="Screenshot 2023-01-14 at 21 37 35" src="https://user-images.githubusercontent.com/20689156/212495712-6f2ab197-e439-4d12-aba6-996934155852.png">
