### PR TITLE
fix: wrong size buffer width with NvimTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,7 @@ require("no-neck-pain").setup({
         NvimTree = {
             -- The position of the tree, either `left` or `right`.
             position = "left",
-            -- When `true`, we close NvimTree if it's currently open when enabling the plugin.
-            close = true,
-            -- Paired with the `close` parameter, when `false` we don't re-open the side tree.
+            -- When `true`, if the tree was opened before enabling the plugin, we will reopen it.
             reopen = true,
         },
         -- @link https://github.com/mbbill/undotree

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -174,9 +174,7 @@ Default values:
           NvimTree = {
               -- The position of the tree, either `left` or `right`.
               position = "left",
-              -- When `true`, we close NvimTree if it's currently open when enabling the plugin.
-              close = true,
-              -- Paired with the `close` parameter, when `false` we don't re-open the side tree.
+              -- When `true`, if the tree was opened before enabling the plugin, we will reopen it.
               reopen = true,
           },
           -- @link https://github.com/mbbill/undotree

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -152,9 +152,7 @@ NoNeckPain.options = {
         NvimTree = {
             -- The position of the tree, either `left` or `right`.
             position = "left",
-            -- When `true`, we close NvimTree if it's currently open when enabling the plugin.
-            close = true,
-            -- Paired with the `close` parameter, when `false` we don't re-open the side tree.
+            -- When `true`, if the tree was opened before enabling the plugin, we will reopen it.
             reopen = true,
         },
         -- @link https://github.com/mbbill/undotree

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -40,10 +40,7 @@ function W.createSideBuffers(wins)
     }
 
     -- we close the side tree if it's already opened to prevent unwanted layout issue.
-    if
-        wins.external.trees.NvimTree.id ~= nil
-        and _G.NoNeckPain.config.integrations.NvimTree.close
-    then
+    if wins.external.trees.NvimTree.id ~= nil then
         integrations.NvimTree = true
         vim.cmd("NvimTreeClose")
     end
@@ -120,8 +117,15 @@ function W.createSideBuffers(wins)
     end
 
     -- if we've closed the user side tree but they still want it to be opened.
-    if integrations.NvimTree and _G.NoNeckPain.config.integrations.NvimTree.reopen == true then
-        vim.cmd("NvimTreeOpen")
+    if integrations.NvimTree then
+        if _G.NoNeckPain.config.integrations.NvimTree.reopen == true then
+            vim.cmd("NvimTreeOpen")
+        else
+            wins.external.trees.NvimTree = {
+                id = nil,
+                width = 0,
+            }
+        end
     end
 
     return W.resizeOrCloseSideBuffers("W.createSideBuffers", wins)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -113,7 +113,6 @@ T["setup"]["sets exposed methods and default options value"] = function()
     end
 
     eq_config(child, "integrations.NvimTree.position", "left")
-    eq_config(child, "integrations.NvimTree.close", true)
     eq_config(child, "integrations.NvimTree.reopen", true)
     eq_config(child, "integrations.undotree.position", "left")
 end

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -22,7 +22,6 @@ T["setup"]["overrides default values"] = function()
         integrations = {
             NvimTree = {
                 position = "right",
-                close = false,
                 reopen = false,
             },
             undotree = {
@@ -32,7 +31,6 @@ T["setup"]["overrides default values"] = function()
     })]])
 
     eq_config(child, "integrations.NvimTree.position", "right")
-    eq_config(child, "integrations.NvimTree.close", false)
     eq_config(child, "integrations.NvimTree.reopen", false)
     eq_config(child, "integrations.undotree.position", "right")
 end


### PR DESCRIPTION
## 📃 Summary

contributes to https://github.com/shortcuts/no-neck-pain.nvim/issues/133
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/142

The width of the tree was still taken into account with the `reopen = false` option. We now reset the registered trees width before computing the padding, if `reopen` is `false`.

### Other changes

The `close` option doesn't make sense actually, we close it anyway, a single option is enough.

## 📸 Preview

### before

<img width="1280" alt="Screenshot 2023-01-15 at 21 36 44" src="https://user-images.githubusercontent.com/20689156/212565890-aff580d7-c526-4d6e-85d0-b15482b9c9ca.png">

### after

<img width="1280" alt="Screenshot 2023-01-15 at 21 37 32" src="https://user-images.githubusercontent.com/20689156/212565930-e433a8d4-629f-4012-b248-2cd815c6951b.png">
