### PR TITLE
feat: keeps side buffers for current tab

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -74,20 +74,6 @@ function N.enable()
         desc = "Resizes side windows after terminal has been resized, closes them if not enough space left.",
     })
 
-    vim.api.nvim_create_autocmd({ "TabLeave" }, {
-        callback = function()
-            vim.schedule(function()
-                if E.skip(S, false, false) then
-                    return
-                end
-
-                S.tabs = Ta.refresh(S.tabs)
-            end)
-        end,
-        group = "NoNeckPain",
-        desc = "Refreshes the tabs state",
-    })
-
     vim.api.nvim_create_autocmd({ "WinEnter" }, {
         callback = function(p)
             vim.schedule(function()

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -32,7 +32,7 @@ function E.skip(state, skipSplit, skipTab)
     end
 
     if state ~= nil and skipTab then
-        if Ta.refresh(state.tabs) ~= state.tabs then
+        if vim.api.nvim_win_get_tabpage(0) ~= state.tabs then
             return true
         end
     end

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -1,4 +1,5 @@
 local W = require("no-neck-pain.util.win")
+local Ta = require("no-neck-pain.util.tabs")
 
 local E = {}
 
@@ -25,9 +26,15 @@ end
 -- - we have splits open (when `skipSplit` is `true`)
 -- - we are focusing a floating window
 -- - we are focusing one of the side buffer
-function E.skip(state, skipSplit)
+function E.skip(state, skipSplit, skipTab)
     if not _G.NoNeckPain.state.enabled then
         return true
+    end
+
+    if state ~= nil and skipTab then
+        if Ta.refresh(state.tabs) ~= state.tabs then
+            return true
+        end
     end
 
     if skipSplit or W.isRelativeWindow() then

--- a/lua/no-neck-pain/util/split.lua
+++ b/lua/no-neck-pain/util/split.lua
@@ -57,7 +57,7 @@ end
 
 -- tries to get all of the active splits
 function Sp.get(state)
-    local wins = vim.api.nvim_list_wins()
+    local wins = vim.api.nvim_tabpage_list_wins(state.tabs)
     local screenWidth = vim.api.nvim_list_uis()[1].width
 
     local splits = {}

--- a/lua/no-neck-pain/util/tabs.lua
+++ b/lua/no-neck-pain/util/tabs.lua
@@ -1,0 +1,18 @@
+local D = require("no-neck-pain.util.debug")
+
+local Ta = {}
+
+-- returns the current tabpage.
+function Ta.refresh(curr)
+    local new = vim.api.nvim_win_get_tabpage(0)
+
+    if curr == new then
+        return curr
+    end
+
+    D.log("Ta.refresh", "new tab page registered: was %d, now %d", curr, new)
+
+    return new
+end
+
+return Ta

--- a/lua/no-neck-pain/util/trees.lua
+++ b/lua/no-neck-pain/util/trees.lua
@@ -6,8 +6,8 @@ function T.isSideTree(fileType)
 end
 
 -- returns all of the side trees wins and their width.
-function T.refresh()
-    local wins = vim.api.nvim_list_wins()
+function T.refresh(state)
+    local wins = vim.api.nvim_tabpage_list_wins(state.tabs)
     local trees = {
         NvimTree = {
             id = nil,

--- a/lua/no-neck-pain/util/win.lua
+++ b/lua/no-neck-pain/util/win.lua
@@ -148,7 +148,7 @@ end
 
 -- returns the available wins and their total number, without the `list` ones.
 function W.winsExceptState(state, withTrees)
-    local wins = vim.api.nvim_list_wins()
+    local wins = vim.api.nvim_tabpage_list_wins(state.tabs)
     local mergedWins = W.mergeState(
         state.wins.main,
         state.wins.splits,
@@ -282,7 +282,7 @@ end
 --
 -- @param checkSplits bool: checks for splits wins too when `true`.
 function W.stateWinsActive(state, checkSplits)
-    local wins = vim.api.nvim_list_wins()
+    local wins = vim.api.nvim_tabpage_list_wins(state.tabs)
     local swins = state.wins.main
 
     if checkSplits and state.wins.splits ~= nil then

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -140,24 +140,30 @@ T["setup"]["enables the plugin with mapping"] = function()
         require('no-neck-pain').setup({width=50,toggleMapping="nn"})
     ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1000 })
     eq_type_global(child, "_G.NoNeckPainLoaded", "boolean")
 
     child.lua("vim.api.nvim_input('nn')")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
     eq_state(child, "enabled", true)
 
     child.lua("vim.api.nvim_input('nn')")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1000 })
     eq_state(child, "enabled", false)
 end
 
 T["setup"]["starts the plugin on VimEnter"] = function()
     child.restart({ "-u", "scripts/test_auto_open.lua" })
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
     eq_state(child, "enabled", true)
 
     child.stop()

--- a/tests/test_autocmd.lua
+++ b/tests/test_autocmd.lua
@@ -26,7 +26,7 @@ T["auto command"]["does not create side buffers window's width < options.width"]
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1000 })
     eq_state(child, "wins.main.curr", 1000)
     eq_state(child, "wins.main.left", vim.NIL)
     eq_state(child, "wins.main.right", vim.NIL)
@@ -39,7 +39,10 @@ T["auto command"]["does not shift using when opening/closing float window"] = fu
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", 1002)
 
@@ -48,7 +51,10 @@ T["auto command"]["does not shift using when opening/closing float window"] = fu
 
     child.lua("vim.api.nvim_open_win(0,true, {width=100,height=100,relative='cursor',row=0,col=0})")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002, 1003 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002, 1003 }
+    )
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", 1002)
 
@@ -59,7 +65,10 @@ T["auto command"]["does not shift using when opening/closing float window"] = fu
     child.lua("vim.fn.win_gotoid(1003)")
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", 1002)
 

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -213,14 +213,17 @@ T["curr"]["closing `curr` window without any other window quits Neovim"] = funct
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
     eq_state(child, "wins.main.curr", 1000)
 
     child.cmd("q")
 
     -- neovim is closed, so it errors
     helpers.expect.error(function()
-        child.lua_get("vim.api.nvim_list_wins()")
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)")
     end)
 end
 
@@ -266,14 +269,17 @@ T["left/right"]["closing the `left` buffer disables NNP"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", 1002)
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.wins.main.left)")
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1000 })
 
     eq_state(child, "enabled", false)
 end
@@ -284,14 +290,17 @@ T["left/right"]["closing the `right` buffer disables NNP"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", 1002)
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.wins.main.right)")
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1000 })
 
     eq_state(child, "enabled", false)
 end

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -52,7 +52,10 @@ T["scratchPad"]["default to `norg` fileType"] = function()
     })]])
     child.lua([[require('no-neck-pain').enable()]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/no-neck-pain-left.norg"
@@ -92,7 +95,10 @@ T["scratchPad"]["override to md is reflected to the buffer"] = function()
     })]])
     child.lua([[require('no-neck-pain').enable()]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/no-neck-pain-left.md"

--- a/tests/test_split.lua
+++ b/tests/test_split.lua
@@ -29,7 +29,10 @@ T["split"]["only one side buffer, closing help doesn't close NNP"] = function()
 
     child.cmd("h")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1002, 1000 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1002, 1000 }
+    )
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", vim.NIL)
     eq_state(child, "wins.splits", { { id = 1002, vertical = false } })
@@ -38,7 +41,7 @@ T["split"]["only one side buffer, closing help doesn't close NNP"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.wins.splits[1].id)")
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1001, 1000 })
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
     eq_state(child, "enabled", true)
 end
@@ -52,7 +55,10 @@ T["split"]["closing `curr` makes `split` the new `curr`"] = function()
 
     child.cmd("split")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1003, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1003, 1000, 1002 }
+    )
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", 1002)
     eq_state(child, "wins.splits", { { id = 1003, vertical = false } })
@@ -61,7 +67,10 @@ T["split"]["closing `curr` makes `split` the new `curr`"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.wins.main.curr)")
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1003, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1003, 1002 }
+    )
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
 end
 
@@ -74,7 +83,10 @@ T["split"]["keeps side buffers"] = function()
 
     child.cmd("split")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1003, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1003, 1000, 1002 }
+    )
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", 1002)
     eq_state(child, "wins.splits", { { id = 1003, vertical = false } })
@@ -82,7 +94,10 @@ T["split"]["keeps side buffers"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.wins.splits[1].id)")
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
     eq_buf_width(child, "main.left", 15)
     eq_buf_width(child, "main.right", 15)
 end
@@ -122,28 +137,34 @@ T["vsplit"]["does not create side buffers when there's not enough space"] = func
     child.cmd("vsplit")
     child.cmd("vsplit")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1003, 1002, 1001, 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1003, 1002, 1001, 1000 })
 
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1003, 1002, 1001, 1000 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1003, 1002, 1001, 1000 }
+    )
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
     child.set_size(500, 500)
     child.cmd("vsplit")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1001, 1000 })
 
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1002, 1001, 1000, 1003 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1002, 1001, 1000, 1003 }
+    )
 end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
@@ -155,7 +176,10 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
 
     child.cmd("vsplit")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1003, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1003, 1000, 1002 }
+    )
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", 1002)
     eq_state(child, "wins.splits", { { id = 1003, vertical = false } })
@@ -165,7 +189,10 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
     child.cmd("q")
 
     eq_state(child, "wins.main.curr", 1003)
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1003, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1003, 1002 }
+    )
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
 end
 
@@ -177,7 +204,7 @@ T["vsplit"]["hides side buffers"] = function()
 
     child.cmd("vsplit")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1003, 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1003, 1000 })
     eq_state(child, "wins.main.left", vim.NIL)
     eq_state(child, "wins.main.right", vim.NIL)
     eq_state(child, "wins.splits", { { id = 1003, vertical = true } })
@@ -185,7 +212,10 @@ T["vsplit"]["hides side buffers"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.wins.splits[1].id)")
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1000, 1005 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1004, 1000, 1005 }
+    )
     eq_state(child, "wins.main.left", 1004)
     eq_state(child, "wins.main.right", 1005)
     eq_state(child, "wins.splits", vim.NIL)
@@ -195,11 +225,14 @@ T["vsplit"]["many vsplit leave side buffers open as long as there's space for it
     child.set_size(300, 300)
     child.lua([[ require('no-neck-pain').setup({width=70}) ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1000 })
 
     child.lua([[ require('no-neck-pain').enable() ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
 
     eq_state(child, "wins.main.left", 1001)
     eq_state(child, "wins.main.right", 1002)
@@ -207,7 +240,10 @@ T["vsplit"]["many vsplit leave side buffers open as long as there's space for it
     child.cmd("vsplit")
     child.cmd("vsplit")
     child.cmd("vsplit")
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1005, 1004, 1003, 1000 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1005, 1004, 1003, 1000 }
+    )
 
     eq_state(child, "wins.main.left", vim.NIL)
     eq_state(child, "wins.main.right", vim.NIL)
@@ -247,21 +283,30 @@ T["vsplit/split"]["state is correctly sync'd even after many changes"] = functio
     child.set_size(100, 100)
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1000 })
 
     child.lua([[ require('no-neck-pain').enable() ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
 
     child.cmd("split")
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1003, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1003, 1000, 1002 }
+    )
     child.cmd("q")
 
     child.cmd("vsplit")
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1000 })
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1004, 1000 })
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1005, 1000, 1006 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1005, 1000, 1006 }
+    )
 end
 
 T["vsplit/split"]["closing side buffers because of splits restores focus"] = function()
@@ -271,16 +316,28 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
         require('no-neck-pain').enable() 
     ]])
 
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
 
     child.cmd("vsplit")
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1001, 1003, 1000, 1002 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1003, 1000, 1002 }
+    )
 
     child.cmd("vsplit")
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1004, 1003, 1000 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1004, 1003, 1000 }
+    )
 
     child.cmd("q")
-    eq(child.lua_get("vim.api.nvim_list_wins()"), { 1005, 1003, 1000, 1006 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1005, 1003, 1000, 1006 }
+    )
 
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
 end

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -1,7 +1,7 @@
 local helpers = dofile("tests/helpers.lua")
 
 local child = helpers.new_child_neovim()
-local eq, eq_state = helpers.expect.equality, helpers.expect.global_equality
+local eq, eq_state = helpers.expect.equality, helpers.expect.state_equality
 
 local T = MiniTest.new_set({
     hooks = {

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -1,0 +1,77 @@
+local helpers = dofile("tests/helpers.lua")
+
+local child = helpers.new_child_neovim()
+local eq, eq_state = helpers.expect.equality, helpers.expect.global_equality
+
+local T = MiniTest.new_set({
+    hooks = {
+        -- This will be executed before every (even nested) case
+        pre_case = function()
+            -- Restart child process with custom 'init.lua' script
+            child.restart({ "-u", "scripts/minimal_init.lua" })
+        end,
+        -- This will be executed one after all tests from this set are finished
+        post_once = child.stop,
+    },
+})
+
+T["tabs"] = MiniTest.new_set()
+
+T["tabs"]["keeps track of the current tab page"] = function()
+    child.lua([[
+        require('no-neck-pain').setup({width=50})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq_state(child, "tabs", 1)
+
+    child.cmd("tabnew")
+
+    eq_state(child, "tabs", 2)
+end
+
+T["tabs"]["tabnew closes side buffers"] = function()
+    child.lua([[
+        require('no-neck-pain').setup({width=50})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
+    eq_state(child, "tabs", 1)
+
+    child.cmd("tabnew")
+
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1003 })
+    eq_state(child, "tabs", 2)
+end
+
+T["tabs"]["previous tab kept side buffers if enabled"] = function()
+    child.lua([[
+        require('no-neck-pain').setup({width=50})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
+    eq_state(child, "tabs", 1)
+
+    child.cmd("tabnew")
+
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1003 })
+    eq_state(child, "tabs", 2)
+
+    child.cmd("tabprevious")
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
+    eq_state(child, "tabs", 1)
+end
+
+return T

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -17,7 +17,7 @@ local T = MiniTest.new_set({
 
 T["tabs"] = MiniTest.new_set()
 
-T["tabs"]["keeps track of the current tab page"] = function()
+T["tabs"]["keeps the enabled tab in state"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
@@ -27,10 +27,10 @@ T["tabs"]["keeps track of the current tab page"] = function()
 
     child.cmd("tabnew")
 
-    eq_state(child, "tabs", 2)
+    eq_state(child, "tabs", 1)
 end
 
-T["tabs"]["tabnew closes side buffers"] = function()
+T["tabs"]["new tab doesn't have side buffers"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
@@ -44,8 +44,11 @@ T["tabs"]["tabnew closes side buffers"] = function()
 
     child.cmd("tabnew")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1003 })
-    eq_state(child, "tabs", 2)
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(2)"), { 1003 })
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"),
+        { 1001, 1000, 1002 }
+    )
 end
 
 T["tabs"]["previous tab kept side buffers if enabled"] = function()
@@ -62,8 +65,7 @@ T["tabs"]["previous tab kept side buffers if enabled"] = function()
 
     child.cmd("tabnew")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.tabs)"), { 1003 })
-    eq_state(child, "tabs", 2)
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(2)"), { 1003 })
 
     child.cmd("tabprevious")
 


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/89

This PR is a first step of the tabs support, it allows restoring the state correctly when executing `tabprevious`, so the side buffers are not closed.

State-per-tab will be followed in https://github.com/shortcuts/no-neck-pain.nvim/issues/152
