### PR TITLE
feat: add `NoNeckPainResize` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ NoNeckPain.bufferOptions = {
 
 |   Command   |         Description        |
 |-------------|----------------------------|
-|`:NoNeckPain`| Toggles the plugin state, between enable and disable.|
+|`:NoNeckPain`| Toggles the plugin state, between enable and disable. |
+|`:NoNeckPainResize INT`| Updates the config `width` with the given `INT` value and resizes the no-neck-pain windows. |
 
 ## ⌨ Contributing
 

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -5,6 +5,13 @@
 Toggle the plugin by calling the `enable`/`disable` methods respectively.
 
 ------------------------------------------------------------------------------
+                                                           *NoNeckPain.resize()*
+                          `NoNeckPain.resize`({width})
+Sets the config `width` to the given `width` value and resizes the NoNeckPain windows.
+
+@param width number: any positive integer superior to 0.
+
+------------------------------------------------------------------------------
                                                            *NoNeckPain.enable()*
                              `NoNeckPain.enable`()
 Initializes the plugin, sets event listeners and internal state.

--- a/doc/tags
+++ b/doc/tags
@@ -2,5 +2,6 @@ NoNeckPain.bufferOptions	no-neck-pain.txt	/*NoNeckPain.bufferOptions*
 NoNeckPain.disable()	no-neck-pain.txt	/*NoNeckPain.disable()*
 NoNeckPain.enable()	no-neck-pain.txt	/*NoNeckPain.enable()*
 NoNeckPain.options	no-neck-pain.txt	/*NoNeckPain.options*
+NoNeckPain.resize()	no-neck-pain.txt	/*NoNeckPain.resize()*
 NoNeckPain.setup()	no-neck-pain.txt	/*NoNeckPain.setup()*
 NoNeckPain.toggle()	no-neck-pain.txt	/*NoNeckPain.toggle()*

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,3 +1,4 @@
+local D = require("no-neck-pain.util.debug")
 local M = require("no-neck-pain.main")
 
 local NoNeckPain = {}
@@ -9,6 +10,27 @@ function NoNeckPain.toggle()
     end
 
     _G.NoNeckPain.state = M.toggle("publicAPI_toggle")
+end
+
+--- Sets the config `width` to the given `width` value and resizes the NoNeckPain windows.
+---
+--- @param width number: any positive integer superior to 0.
+function NoNeckPain.resize(width)
+    if not _G.NoNeckPain.state.enabled then
+        error("no-neck-pain.nvim must be enabled, run `NoNeckPain` first.")
+    end
+
+    width = tonumber(width) or 0
+
+    if _G.NoNeckPain.config.width == width then
+        return
+    end
+
+    if width > 0 then
+        _G.NoNeckPain.config = vim.tbl_deep_extend("keep", { width = width }, _G.NoNeckPain.config)
+    end
+
+    _G.NoNeckPain.state = M.init("publicAPI_resize", nil, false)
 end
 
 --- Initializes the plugin, sets event listeners and internal state.

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,4 +1,3 @@
-local D = require("no-neck-pain.util.debug")
 local M = require("no-neck-pain.main")
 
 local NoNeckPain = {}

--- a/plugin/no-neck-pain.lua
+++ b/plugin/no-neck-pain.lua
@@ -6,8 +6,13 @@ _G.NoNeckPainLoaded = true
 
 if vim.fn.has("nvim-0.7") == 0 then
     vim.cmd("command NoNeckPain lua require('no-neck-pain').toggle()")
+    vim.cmd("command -nargs=1 NoNeckPainResize lua require('no-neck-pain').toggle()")
 else
     vim.api.nvim_create_user_command("NoNeckPain", function()
         require("no-neck-pain").toggle()
-    end, {})
+    end, { desc = "Toggles the plugin" })
+
+    vim.api.nvim_create_user_command("NoNeckPainResize", function(tbl)
+        require("no-neck-pain").resize(tbl.args)
+    end, { desc = "Resizes the main centered window", nargs = 1 })
 end

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -1,12 +1,12 @@
+local Co = require("no-neck-pain.util.constants")
 local helpers = dofile("tests/helpers.lua")
 
 local child = helpers.new_child_neovim()
-local eq, eq_global, eq_config, eq_state, eq_buf_width =
+local eq, eq_global, eq_config, eq_state =
     helpers.expect.equality,
     helpers.expect.global_equality,
     helpers.expect.config_equality,
-    helpers.expect.state_equality,
-    helpers.expect.buf_width_equality
+    helpers.expect.state_equality
 local eq_type_global, eq_type_config, eq_type_state =
     helpers.expect.global_type_equality,
     helpers.expect.config_type_equality,
@@ -24,42 +24,13 @@ local T = MiniTest.new_set({
     },
 })
 
-local SCOPES = { "left", "right" }
 local EXTERNALS = { "NvimTree", "undotree" }
 
 T["install"] = MiniTest.new_set()
 
-T["install"]["sets global loaded variable and provide public commands"] = function()
+T["install"]["sets global loaded variable"] = function()
     eq_type_global(child, "_G.NoNeckPainLoaded", "boolean")
     eq_global(child, "_G.NoNeckPain", vim.NIL)
-
-    child.cmd("NoNeckPain")
-    eq_state(child, "enabled", true)
-
-    eq_global(child, "_G.NoNeckPain.config.width", 100)
-
-    child.cmd("NoNeckPainResize 20")
-
-    eq_global(child, "_G.NoNeckPain.config.width", 20)
-
-    child.cmd("NoNeckPain")
-    eq_state(child, "enabled", false)
-end
-
-T["install"]["calling `NoNeckPainResize` resizes the main window"] = function()
-    child.cmd("NoNeckPain")
-
-    eq_global(child, "_G.NoNeckPain.config.width", 100)
-
-    -- need to know why the child isn't precise enough
-    eq_buf_width(child, "tabs[1].wins.main.curr", 80)
-
-    child.cmd("NoNeckPainResize 20")
-
-    eq_global(child, "_G.NoNeckPain.config.width", 20)
-
-    -- need to know why the child isn't precise enough
-    eq_buf_width(child, "tabs[1].wins.main.curr", 20)
 end
 
 T["setup"] = MiniTest.new_set()
@@ -110,7 +81,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
     eq_config(child, "buffers.wo.wrap", true)
     eq_config(child, "buffers.wo.linebreak", true)
 
-    for _, scope in pairs(SCOPES) do
+    for _, scope in pairs(Co.SIDES) do
         eq_type_config(child, "buffers." .. scope, "table")
         eq_type_config(child, "buffers." .. scope .. ".bo", "table")
         eq_type_config(child, "buffers." .. scope .. ".wo", "table")

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -2,9 +2,7 @@ local helpers = dofile("tests/helpers.lua")
 
 local child = helpers.new_child_neovim()
 local eq_global, eq_state, eq_buf_width =
-    helpers.expect.global_equality,
-    helpers.expect.state_equality,
-    helpers.expect.buf_width_equality
+    helpers.expect.global_equality, helpers.expect.state_equality, helpers.expect.buf_width_equality
 
 local T = MiniTest.new_set({
     hooks = {

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -1,0 +1,75 @@
+local helpers = dofile("tests/helpers.lua")
+
+local child = helpers.new_child_neovim()
+local eq, eq_global, eq_config, eq_state, eq_buf_width =
+    helpers.expect.equality,
+    helpers.expect.global_equality,
+    helpers.expect.config_equality,
+    helpers.expect.state_equality,
+    helpers.expect.buf_width_equality
+local eq_type_global, eq_type_config, eq_type_state =
+    helpers.expect.global_type_equality,
+    helpers.expect.config_type_equality,
+    helpers.expect.state_type_equality
+
+local T = MiniTest.new_set({
+    hooks = {
+        -- This will be executed before every (even nested) case
+        pre_case = function()
+            -- Restart child process with custom 'init.lua' script
+            child.restart({ "-u", "scripts/minimal_init.lua" })
+        end,
+        -- This will be executed one after all tests from this set are finished
+        post_once = child.stop,
+    },
+})
+
+T["commands"] = MiniTest.new_set()
+
+T["commands"]["NoNeckPain toggles the plugin state"] = function()
+    child.cmd("NoNeckPain")
+    eq_state(child, "enabled", true)
+
+    child.cmd("NoNeckPain")
+    eq_state(child, "enabled", false)
+end
+
+T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = function()
+    child.cmd("NoNeckPain")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 100)
+
+    -- need to know why the child isn't precise enough
+    eq_buf_width(child, "tabs[1].wins.main.curr", 80)
+
+    child.cmd("NoNeckPainResize 20")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 20)
+
+    -- need to know why the child isn't precise enough
+    eq_buf_width(child, "tabs[1].wins.main.curr", 20)
+end
+
+T["commands"]["NoNeckPainResize throws with the plugin disabled"] = function()
+    helpers.expect.error(function()
+        child.cmd("NoNeckPainResize 20")
+    end)
+end
+
+T["commands"]["NoNeckPainResize does nothing with the same widht"] = function()
+    child.cmd("NoNeckPain")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 100)
+
+    -- need to know why the child isn't precise enough
+    eq_buf_width(child, "tabs[1].wins.main.curr", 80)
+
+    child.cmd("NoNeckPainResize 100")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 100)
+
+    -- need to know why the child isn't precise enough
+    eq_buf_width(child, "tabs[1].wins.main.curr", 80)
+end
+
+return T

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -1,16 +1,10 @@
 local helpers = dofile("tests/helpers.lua")
 
 local child = helpers.new_child_neovim()
-local eq, eq_global, eq_config, eq_state, eq_buf_width =
-    helpers.expect.equality,
+local eq_global, eq_state, eq_buf_width =
     helpers.expect.global_equality,
-    helpers.expect.config_equality,
     helpers.expect.state_equality,
     helpers.expect.buf_width_equality
-local eq_type_global, eq_type_config, eq_type_state =
-    helpers.expect.global_type_equality,
-    helpers.expect.config_type_equality,
-    helpers.expect.state_type_equality
 
 local T = MiniTest.new_set({
     hooks = {


### PR DESCRIPTION
## 📃 Summary

Kind of provides an escape hatch for things like https://github.com/shortcuts/no-neck-pain.nvim/issues/155

This PR provides a new `NoNeckPainResize` command, that updates the width of the main buffer and triggers a resize of the windows. This can be useful when switching context and the user don't want to update the `setup` method.
