### PR TITLE
fix: transparent background support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ require("no-neck-pain").setup({
             location = nil,
         },
         -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+        -- Transparent backgrounds are supported by default.
         backgroundColor = nil,
         -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
         blend = 0,
@@ -206,6 +207,7 @@ NoNeckPain.bufferOptions = {
     -- When `false`, the buffer won't be created.
     enabled = true,
     -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+    -- Transparent backgrounds are supported by default.
     backgroundColor = nil,
     -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
     blend = 0,

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -33,7 +33,8 @@ Default values:
   NoNeckPain.bufferOptions = {
       -- When `false`, the buffer won't be created.
       enabled = true,
-      -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+      -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A).
+      -- Transparent backgrounds are supported by default.
       -- popular theme are supported by their name:
       -- - catppuccin-frappe
       -- - catppuccin-frappe-dark
@@ -125,6 +126,7 @@ Default values:
               location = nil,
           },
           -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+          -- Transparent backgrounds are supported by default.
           -- popular theme are supported by their name:
           -- - catppuccin-frappe
           -- - catppuccin-frappe-dark

--- a/lua/no-neck-pain/color.lua
+++ b/lua/no-neck-pain/color.lua
@@ -128,24 +128,31 @@ function C.init(win, tab, side)
         )
     )
 
-    vim.api.nvim_win_set_option(
-        win,
-        "winhl",
-        string.format(
-            "Normal:%s,NormalNC:%s,CursorColumn:%s,CursorLineNr:%s,NonText:%s,SignColumn:%s,Cursor:%s,LineNr:%s,EndOfBuffer:%s,WinSeparator:%s,VertSplit:%s",
-            textGroup,
-            textGroup,
-            backgroundGroup,
-            backgroundGroup,
-            backgroundGroup,
-            backgroundGroup,
-            backgroundGroup,
-            backgroundGroup,
-            backgroundGroup,
-            backgroundGroup,
-            backgroundGroup
-        )
-    )
+    local groups = {
+        Normal = textGroup,
+        NormalNC = textGroup,
+        CursorColumn = backgroundGroup,
+        CursorLineNr = backgroundGroup,
+        NonText = backgroundGroup,
+        SignColumn = backgroundGroup,
+        Cursor = backgroundGroup,
+        LineNr = backgroundGroup,
+    }
+
+    -- on transparent backgrounds we don't set those two to prevent white lines.
+    if backgroundColor ~= "NONE" then
+        groups.WinSeparator = backgroundGroup
+        groups.VertSplit = backgroundGroup
+        groups.EndOfBuffer = backgroundGroup
+    end
+
+    local stringGroups = {}
+
+    for hl, group in pairs(groups) do
+        table.insert(stringGroups, string.format("%s:%s", hl, group))
+    end
+
+    vim.api.nvim_win_set_option(win, "winhl", table.concat(stringGroups, ","))
 end
 
 return C

--- a/lua/no-neck-pain/color.lua
+++ b/lua/no-neck-pain/color.lua
@@ -146,7 +146,6 @@ function C.init(win, tab, side)
             Cursor = backgroundGroup,
             LineNr = backgroundGroup,
         })
-
     end
 
     local stringGroups = {}

--- a/lua/no-neck-pain/color.lua
+++ b/lua/no-neck-pain/color.lua
@@ -93,6 +93,10 @@ function C.init(win, tab, side)
     local backgroundGroup = string.format("NoNeckPain_background_tab_%s_side_%s", tab, side)
     local textGroup = string.format("NoNeckPain_text_tab_%s_side_%s", tab, side)
 
+    -- clear groups
+    vim.cmd(string.format("highlight! clear %s NONE", backgroundGroup))
+    vim.cmd(string.format("highlight! clear %s NONE", textGroup))
+
     local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
 
     -- check if the user has a transparent background.
@@ -103,10 +107,6 @@ function C.init(win, tab, side)
     end
 
     local backgroundColor = _G.NoNeckPain.config.buffers[side].backgroundColor or defaultBackground
-
-    -- clear groups
-    vim.cmd(string.format("highlight! clear %s NONE", backgroundGroup))
-    vim.cmd(string.format("highlight! clear %s NONE", textGroup))
 
     -- create group for background
     vim.cmd(
@@ -131,19 +131,22 @@ function C.init(win, tab, side)
     local groups = {
         Normal = textGroup,
         NormalNC = textGroup,
-        CursorColumn = backgroundGroup,
-        CursorLineNr = backgroundGroup,
-        NonText = backgroundGroup,
-        SignColumn = backgroundGroup,
-        Cursor = backgroundGroup,
-        LineNr = backgroundGroup,
     }
 
     -- on transparent backgrounds we don't set those two to prevent white lines.
     if backgroundColor ~= "NONE" then
-        groups.WinSeparator = backgroundGroup
-        groups.VertSplit = backgroundGroup
-        groups.EndOfBuffer = backgroundGroup
+        groups = vim.tbl_extend("keep", groups, {
+            WinSeparator = backgroundGroup,
+            VertSplit = backgroundGroup,
+            EndOfBuffer = backgroundGroup,
+            CursorColumn = backgroundGroup,
+            CursorLineNr = backgroundGroup,
+            NonText = backgroundGroup,
+            SignColumn = backgroundGroup,
+            Cursor = backgroundGroup,
+            LineNr = backgroundGroup,
+        })
+
     end
 
     local stringGroups = {}

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -10,7 +10,8 @@ local NoNeckPain = {}
 NoNeckPain.bufferOptions = {
     -- When `false`, the buffer won't be created.
     enabled = true,
-    -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+    -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A).
+    -- Transparent backgrounds are supported by default.
     -- popular theme are supported by their name:
     -- - catppuccin-frappe
     -- - catppuccin-frappe-dark
@@ -97,6 +98,7 @@ NoNeckPain.options = {
             location = nil,
         },
         -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
+        -- Transparent backgrounds are supported by default.
         -- popular theme are supported by their name:
         -- - catppuccin-frappe
         -- - catppuccin-frappe-dark


### PR DESCRIPTION
## 📃 Summary

fixes https://github.com/shortcuts/no-neck-pain.nvim/issues/120
fixes https://github.com/shortcuts/no-neck-pain.nvim/issues/104

The plugin generates unwanted white lines on transparent backgrounds, we now keep the default Neovim behavior.

bonus: easier to maintain syntax

## 📸 Preview

Before: https://github.com/shortcuts/no-neck-pain.nvim/issues/120#issue-1518599089

After

<img width="1280" alt="Screenshot 2023-02-02 at 22 25 16" src="https://user-images.githubusercontent.com/20689156/216453008-b86fb067-c421-4ad2-b771-fbf66b1cec3d.png">
