### PR TITLE
feat(tabs): provide an option to automatically enable the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ require("no-neck-pain").setup({
     debug = false,
     -- When `true`, enables the plugin when you start Neovim.
     enableOnVimEnter = false,
+    -- When `true`, enables the plugin when you enter a new Tab.
+    -- note: it does not trigger if it's an existing tab, to prevent unwanted interfer with user's decisions.
+    enableOnTabEnter = false,
     -- The width of the focused window that will be centered, accepted values are:
     -- - Any integer > 0.
     -- - "textwidth", which retrieves the value of the `vim.bo.textwidth` option.

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -94,6 +94,9 @@ Default values:
       debug = false,
       -- When `true`, enables the plugin when you start Neovim.
       enableOnVimEnter = false,
+      -- When `true`, enables the plugin when you enter a new Tab.
+      -- note: it does not trigger if it's an existing tab, to prevent unwanted interfer with user's decisions.
+      enableOnTabEnter = false,
       -- The width of the focused window that will be centered, accepted values are:
       -- - Any integer > 0.
       -- - "textwidth", which retrieves the value of the `vim.bo.textwidth` option.

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -66,6 +66,9 @@ NoNeckPain.options = {
     debug = false,
     -- When `true`, enables the plugin when you start Neovim.
     enableOnVimEnter = false,
+    -- When `true`, enables the plugin when you enter a new Tab.
+    -- note: it does not trigger if it's an existing tab, to prevent unwanted interfer with user's decisions.
+    enableOnTabEnter = false,
     -- The width of the focused window that will be centered, accepted values are:
     -- - Any integer > 0.
     -- - "textwidth", which retrieves the value of the `vim.bo.textwidth` option.

--- a/scripts/test_auto_open.lua
+++ b/scripts/test_auto_open.lua
@@ -3,6 +3,6 @@ vim.cmd([[let &rtp.=','.getcwd()]])
 vim.cmd("set rtp+=deps/mini.nvim")
 
 -- Auto open enabled for the test
-require("no-neck-pain").setup({ width = 50, enableOnVimEnter = true })
+require("no-neck-pain").setup({ width = 50, enableOnVimEnter = true, enableOnTabEnter = true })
 require("mini.test").setup()
 require("mini.doc").setup()

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -51,6 +51,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
 
     eq_config(child, "width", 100)
     eq_config(child, "enableOnVimEnter", false)
+    eq_config(child, "enableOnTabEnter", false)
     eq_config(child, "toggleMapping", "<Leader>np")
     eq_config(child, "debug", false)
     eq_config(child, "disableOnLastBuffer", false)
@@ -115,6 +116,7 @@ T["setup"]["overrides default values"] = function()
     child.lua([[require('no-neck-pain').setup({
         width = 42,
         enableOnVimEnter = true,
+        enableOnTabEnter = true,
         toggleMapping = "<Leader>kz",
         debug = true,
         disableOnLastBuffer = true,
@@ -123,6 +125,7 @@ T["setup"]["overrides default values"] = function()
 
     eq_config(child, "width", 42)
     eq_config(child, "enableOnVimEnter", true)
+    eq_config(child, "enableOnTabEnter", true)
     eq_config(child, "toggleMapping", "<Leader>kz")
     eq_config(child, "debug", true)
     eq_config(child, "disableOnLastBuffer", true)

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -113,4 +113,71 @@ T["tabs"]["previous tab kept side buffers if enabled"] = function()
     eq_state(child, "activeTab", 1)
 end
 
+T["TabNewEntered"] = MiniTest.new_set()
+
+T["TabNewEntered"]["starts the plugin on new tab"] = function()
+    child.restart({ "-u", "scripts/test_auto_open.lua" })
+
+    eq_state(child, "enabled", true)
+
+    -- tab 1
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1001, 1000, 1002 }
+    )
+
+    eq_state(child, "activeTab", 1)
+
+    -- tab 2
+    child.cmd("tabnew")
+    eq_state(child, "activeTab", 2)
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1004, 1003, 1005 }
+    )
+
+    child.stop()
+end
+
+T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
+    child.restart({ "-u", "scripts/test_auto_open.lua" })
+
+    eq_state(child, "enabled", true)
+
+    -- tab 1
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1001, 1000, 1002 }
+    )
+
+    eq_state(child, "activeTab", 1)
+
+    -- tab 2
+    child.cmd("tabnew")
+    eq_state(child, "activeTab", 2)
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1004, 1003, 1005 }
+    )
+
+    child.cmd("NoNeckPain")
+
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"), { 1003 })
+    eq_state(child, "activeTab", 2)
+
+    -- tab 1
+    child.cmd("tabprevious")
+    eq_state(child, "activeTab", 1)
+
+    -- tab 2
+    child.cmd("tabnext")
+    eq_state(child, "activeTab", 2)
+
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"), { 1003 })
+
+    child.stop()
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

Now that we have tabs support, we can provide a way to automatically enable the plugin when entering a new tab, similarly to when entering Neovim.
