### PR TITLE
feat: add `minSidebufferWidth`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ require("no-neck-pain").setup({
     -- - "colorcolumn", which retrieves the value of the `vim.opt.colorcolumn` option.
     -- When the terminal width is less than the `width` option, the side buffers won't be created.
     width = 100,
+    -- Represents the lowest width value a side buffer should be.
+    -- This option can be useful when switching window size frequently, example:
+    -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
+    minSidebufferWidth = 5,
     -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
     -- When `false`, the mapping is not created.
     toggleMapping = "<Leader>np",

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -103,6 +103,10 @@ Default values:
       -- - "colorcolumn", which retrieves the value of the `vim.opt.colorcolumn` option.
       -- When the terminal width is less than the `width` option, the side buffers won't be created.
       width = 100,
+      -- Represents the lowest width value a side buffer should be.
+      -- This option can be useful when switching window size frequently, example:
+      -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
+      minSidebufferWidth = 5,
       -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
       -- When `false`, the mapping is not created.
       toggleMapping = "<Leader>np",

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -85,6 +85,10 @@ NoNeckPain.options = {
     -- - "colorcolumn", which retrieves the value of the `vim.opt.colorcolumn` option.
     -- When the terminal width is less than the `width` option, the side buffers won't be created.
     width = 100,
+    -- Represents the lowest width value a side buffer should be.
+    -- This option can be useful when switching window size frequently, example:
+    -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
+    minSidebufferWidth = 5,
     -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
     -- When `false`, the mapping is not created.
     toggleMapping = "<Leader>np",
@@ -211,6 +215,11 @@ function NoNeckPain.setup(options)
     end
 
     assert(NoNeckPain.options.width > 0, "`width` must be greater than 0.")
+
+    assert(
+        NoNeckPain.options.minSidebufferWidth > -1,
+        "`minSidebufferWidth` must be equal or greater than 0."
+    )
 
     -- assert `integrations` values
     assert(

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -53,7 +53,9 @@ function W.createSideBuffers(tab)
             local valid = tab.wins.main[side] ~= nil
                 and vim.api.nvim_win_is_valid(tab.wins.main[side])
 
-            if W.getPadding(side, tab.wins) > 0 and not valid then
+            if
+                W.getPadding(side, tab.wins) > _G.NoNeckPain.config.minSidebufferWidth and not valid
+            then
                 vim.cmd(cmd[side].cmd)
 
                 local id = vim.api.nvim_get_current_win()
@@ -169,7 +171,7 @@ function W.resizeOrCloseSideBuffers(scope, wins)
         if wins.main[side] ~= nil then
             local padding = W.getPadding(side, wins)
 
-            if padding > 0 then
+            if padding > _G.NoNeckPain.config.minSidebufferWidth then
                 resize(wins.main[side], padding, side)
             else
                 W.close(scope, wins.main[side], side)
@@ -199,13 +201,7 @@ function W.getPadding(side, wins)
     -- if the available screen size is lower than the config width,
     -- we don't have to create side buffers.
     if _G.NoNeckPain.config.width >= width then
-        D.log(
-            "W.getPadding",
-            "[%s] - ui %s | cfg %s - no space left to create side buffers",
-            side,
-            width,
-            _G.NoNeckPain.config.width
-        )
+        D.log("W.getPadding", "[%s] - ui %s - no space left to create side buffers", side, width)
 
         return 0
     end

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -50,6 +50,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
     eq_type_config(child, "buffers", "table")
 
     eq_config(child, "width", 100)
+    eq_config(child, "minSidebufferWidth", 5)
     eq_config(child, "enableOnVimEnter", false)
     eq_config(child, "enableOnTabEnter", false)
     eq_config(child, "toggleMapping", "<Leader>np")
@@ -117,6 +118,7 @@ end
 T["setup"]["overrides default values"] = function()
     child.lua([[require('no-neck-pain').setup({
         width = 42,
+        minSidebufferWidth = 0,
         enableOnVimEnter = true,
         enableOnTabEnter = true,
         debug = true,
@@ -125,6 +127,7 @@ T["setup"]["overrides default values"] = function()
     })]])
 
     eq_config(child, "width", 42)
+    eq_config(child, "minSidebufferWidth", 0)
     eq_config(child, "enableOnVimEnter", true)
     eq_config(child, "enableOnTabEnter", true)
     eq_config(child, "debug", true)

--- a/tests/test_split.lua
+++ b/tests/test_split.lua
@@ -229,7 +229,7 @@ end
 
 T["vsplit"]["many vsplit leave side buffers open as long as there's space for it"] = function()
     child.set_size(300, 300)
-    child.lua([[ require('no-neck-pain').setup({width=70}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=70,minSidebufferWidth=0}) ]])
 
     eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1000 })
 


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/161

Side buffer can create visual noise when there's not enough space to create them (e.g. if the width is 1..5), see image 1.

With this PR, we now do not create side buffers if they don't have a width > 5, an option have also been exposed to let the user override this default value.

## 📸 Preview

<img width="1280" alt="Screenshot 2023-02-09 at 23 11 04" src="https://user-images.githubusercontent.com/20689156/217950881-e6304d13-ca59-4708-ba17-51dca53e8ca0.png">
