### PR TITLE
fix: wrong side buffer width when toggling NvimTree

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,4 +1,3 @@
-local D = require("no-neck-pain.util.debug")
 local M = require("no-neck-pain.main")
 
 local NoNeckPain = {}

--- a/lua/no-neck-pain/tabs.lua
+++ b/lua/no-neck-pain/tabs.lua
@@ -78,11 +78,11 @@ end
 
 -- returns the tab with the given `id`.
 function Ta.get(tabs, id)
-    id = id or vim.api.nvim_get_current_tabpage()
-
     if tabs == nil then
         return nil
     end
+
+    id = id or vim.api.nvim_get_current_tabpage()
 
     for _, tab in pairs(tabs) do
         if tab.id == id then

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -1,4 +1,3 @@
-local D = require("no-neck-pain.util.debug")
 local T = require("no-neck-pain.trees")
 local W = require("no-neck-pain.wins")
 

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -1,3 +1,5 @@
+local D = require("no-neck-pain.util.debug")
+local T = require("no-neck-pain.trees")
 local W = require("no-neck-pain.wins")
 
 local E = {}
@@ -26,6 +28,28 @@ function E.skip(tab, skipSplit)
         if curr == tab.wins.main.left or curr == tab.wins.main.right then
             return true
         end
+    end
+
+    return false
+end
+
+-- determines if we should skip the enabling of the plugin
+-- 1. if a tab definition already exists in the state
+-- 2. if we are focusing a relative window
+-- 3. if we are focusing a side tree or a dashboard
+function E.skipEnable(tab)
+    if tab ~= nil then
+        return true
+    end
+
+    if W.isRelativeWindow() then
+        return true
+    end
+
+    local fileType = vim.bo.filetype
+
+    if T.isSideTree(fileType) or fileType == "dashboard" then
+        return true
     end
 
     return false


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/174
partially https://github.com/shortcuts/no-neck-pain.nvim/issues/175

Toggling a side tree did not properly triggered a resize due to a strict check on the currently opened windows, we now loose this hook a bit to trigger a resize when closing the window, this allows us to increase consistency of the side buffers width.