### PR TITLE
fix: `minSidebufferWidth` casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ require("no-neck-pain").setup({
     -- Represents the lowest width value a side buffer should be.
     -- This option can be useful when switching window size frequently, example:
     -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
-    minSidebufferWidth = 5,
+    minSideBufferWidth = 5,
     -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
     -- When `false`, the mapping is not created.
     toggleMapping = "<Leader>np",

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -106,7 +106,7 @@ Default values:
       -- Represents the lowest width value a side buffer should be.
       -- This option can be useful when switching window size frequently, example:
       -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
-      minSidebufferWidth = 5,
+      minSideBufferWidth = 5,
       -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
       -- When `false`, the mapping is not created.
       toggleMapping = "<Leader>np",

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -88,7 +88,7 @@ NoNeckPain.options = {
     -- Represents the lowest width value a side buffer should be.
     -- This option can be useful when switching window size frequently, example:
     -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
-    minSidebufferWidth = 5,
+    minSideBufferWidth = 5,
     -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
     -- When `false`, the mapping is not created.
     toggleMapping = "<Leader>np",
@@ -217,8 +217,8 @@ function NoNeckPain.setup(options)
     assert(NoNeckPain.options.width > 0, "`width` must be greater than 0.")
 
     assert(
-        NoNeckPain.options.minSidebufferWidth > -1,
-        "`minSidebufferWidth` must be equal or greater than 0."
+        NoNeckPain.options.minSideBufferWidth > -1,
+        "`minSideBufferWidth` must be equal or greater than 0."
     )
 
     -- assert `integrations` values

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -54,7 +54,7 @@ function W.createSideBuffers(tab)
                 and vim.api.nvim_win_is_valid(tab.wins.main[side])
 
             if
-                W.getPadding(side, tab.wins) > _G.NoNeckPain.config.minSidebufferWidth and not valid
+                W.getPadding(side, tab.wins) > _G.NoNeckPain.config.minSideBufferWidth and not valid
             then
                 vim.cmd(cmd[side].cmd)
 
@@ -171,7 +171,7 @@ function W.resizeOrCloseSideBuffers(scope, wins)
         if wins.main[side] ~= nil then
             local padding = W.getPadding(side, wins)
 
-            if padding > _G.NoNeckPain.config.minSidebufferWidth then
+            if padding > _G.NoNeckPain.config.minSideBufferWidth then
                 resize(wins.main[side], padding, side)
             else
                 W.close(scope, wins.main[side], side)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -50,7 +50,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
     eq_type_config(child, "buffers", "table")
 
     eq_config(child, "width", 100)
-    eq_config(child, "minSidebufferWidth", 5)
+    eq_config(child, "minSideBufferWidth", 5)
     eq_config(child, "enableOnVimEnter", false)
     eq_config(child, "enableOnTabEnter", false)
     eq_config(child, "toggleMapping", "<Leader>np")
@@ -118,7 +118,7 @@ end
 T["setup"]["overrides default values"] = function()
     child.lua([[require('no-neck-pain').setup({
         width = 42,
-        minSidebufferWidth = 0,
+        minSideBufferWidth = 0,
         enableOnVimEnter = true,
         enableOnTabEnter = true,
         debug = true,
@@ -127,7 +127,7 @@ T["setup"]["overrides default values"] = function()
     })]])
 
     eq_config(child, "width", 42)
-    eq_config(child, "minSidebufferWidth", 0)
+    eq_config(child, "minSideBufferWidth", 0)
     eq_config(child, "enableOnVimEnter", true)
     eq_config(child, "enableOnTabEnter", true)
     eq_config(child, "debug", true)

--- a/tests/test_split.lua
+++ b/tests/test_split.lua
@@ -229,7 +229,7 @@ end
 
 T["vsplit"]["many vsplit leave side buffers open as long as there's space for it"] = function()
     child.set_size(300, 300)
-    child.lua([[ require('no-neck-pain').setup({width=70,minSidebufferWidth=0}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=70,minSideBufferWidth=0}) ]])
 
     eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1000 })
 


### PR DESCRIPTION
## 📃 Summary

technically not a breaking change since it's not yet released, but this PR renames `minSidebufferWidth` to `minSideBufferWidth` for camel casing consistency..
