### PR TITLE
feat: support `blend` without background color

### DIFF
--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -1,3 +1,4 @@
+local D = require("no-neck-pain.util.debug")
 local C = require("no-neck-pain.color")
 local Co = require("no-neck-pain.util.constants")
 

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -1,4 +1,3 @@
-local D = require("no-neck-pain.util.debug")
 local C = require("no-neck-pain.color")
 local Co = require("no-neck-pain.util.constants")
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -115,8 +115,7 @@ function N.enable(scope)
                 end
 
                 -- we skip side trees etc. as they are not part of the split manager.
-                local fileType = vim.api.nvim_buf_get_option(0, "filetype")
-                if T.isSideTree(fileType) then
+                if T.isSideTree(vim.api.nvim_buf_get_option(0, "filetype")) then
                     return D.log(p.event, "encountered an external window")
                 end
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -36,6 +36,10 @@ end
 T["setup"] = MiniTest.new_set()
 
 T["setup"]["sets exposed methods and default options value"] = function()
+    child.cmd([[
+        highlight Normal guibg=black guifg=white
+        set background=dark
+    ]])
     child.lua([[require('no-neck-pain').setup()]])
 
     eq_type_global(child, "_G.NoNeckPain", "table")
@@ -66,7 +70,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
     eq_type_config(child, "buffers.wo", "table")
 
     eq_config(child, "buffers.setNames", false)
-    eq_config(child, "buffers.backgroundColor", vim.NIL)
+    eq_config(child, "buffers.backgroundColor", "#000000")
     eq_config(child, "buffers.blend", 0)
     eq_config(child, "buffers.textColor", vim.NIL)
 
@@ -90,9 +94,9 @@ T["setup"]["sets exposed methods and default options value"] = function()
         eq_type_config(child, "buffers." .. scope .. ".bo", "table")
         eq_type_config(child, "buffers." .. scope .. ".wo", "table")
 
-        eq_config(child, "buffers." .. scope .. ".backgroundColor", vim.NIL)
+        eq_config(child, "buffers." .. scope .. ".backgroundColor", "#000000")
         eq_config(child, "buffers." .. scope .. ".blend", 0)
-        eq_config(child, "buffers." .. scope .. ".textColor", vim.NIL)
+        eq_config(child, "buffers." .. scope .. ".textColor", "#7f7f7f")
 
         eq_config(child, "buffers." .. scope .. ".bo.filetype", "no-neck-pain")
         eq_config(child, "buffers." .. scope .. ".bo.buftype", "nofile")

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -18,7 +18,23 @@ local T = MiniTest.new_set({
 
 T["setup"] = MiniTest.new_set()
 
+T["setup"]["supports transparent bgs"] = function()
+    child.lua([[require('no-neck-pain').setup()]])
+
+    eq_config(child, "buffers.backgroundColor", "NONE")
+    eq_config(child, "buffers.textColor", "#ffffff")
+
+    for _, scope in pairs(Co.SIDES) do
+        eq_config(child, "buffers." .. scope .. ".backgroundColor", "NONE")
+        eq_config(child, "buffers." .. scope .. ".textColor", "#ffffff")
+    end
+end
+
 T["setup"]["overrides default values"] = function()
+    child.cmd([[
+        highlight Normal guibg=black guifg=white
+        set background=dark
+    ]])
     child.lua([[require('no-neck-pain').setup({
         buffers = {
             backgroundColor = "catppuccin-frappe",
@@ -49,6 +65,10 @@ T["setup"]["overrides default values"] = function()
 end
 
 T["setup"]["`left` or `right` buffer options overrides `common` ones"] = function()
+    child.cmd([[
+        highlight Normal guibg=black guifg=white
+        set background=dark
+    ]])
     child.lua([[require('no-neck-pain').setup({
         buffers = {
             backgroundColor = "catppuccin-frappe",
@@ -82,6 +102,10 @@ T["setup"]["`left` or `right` buffer options overrides `common` ones"] = functio
 end
 
 T["setup"]["`common` options spreads it to `left` and `right` buffers"] = function()
+    child.cmd([[
+        highlight Normal guibg=black guifg=white
+        set background=dark
+    ]])
     child.lua([[require('no-neck-pain').setup({
         buffers = {
             backgroundColor = "catppuccin-frappe",


### PR DESCRIPTION
## 📃 Summary

This PR allow to use the `blend` option without specifying a custom background color.

We now also move the responsibility of setting the config background colors to the parsing method, this allow to test transparent backgrounds but also seems more correct.