### PR TITLE
fix: prevent duplicate buffer name error with `setNames`

### DIFF
--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -73,6 +73,12 @@ function W.createSideBuffers(tab)
                 local id = vim.api.nvim_get_current_win()
 
                 if _G.NoNeckPain.config.buffers.setNames then
+                    local exist = vim.fn.bufnr("no-neck-pain-" .. side)
+
+                    if exist ~= -1 then
+                        vim.api.nvim_buf_delete(exist, { force = true })
+                    end
+
                     vim.api.nvim_buf_set_name(0, "no-neck-pain-" .. side)
                 end
 

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -245,7 +245,6 @@ T["left/right"]["setNames doesn't throw when re-creating side buffers"] = functi
     eq_buf_width(child, "tabs[1].wins.main.right", 15)
 end
 
-
 T["left/right"]["have the same width"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50})

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -228,6 +228,24 @@ end
 
 T["left/right"] = MiniTest.new_set()
 
+T["left/right"]["setNames doesn't throw when re-creating side buffers"] = function()
+    child.lua([[require('no-neck-pain').setup({width=50, buffers={setNames=true}})]])
+
+    -- enable
+    child.cmd([[NoNeckPain]])
+
+    eq_buf_width(child, "tabs[1].wins.main.left", 15)
+    eq_buf_width(child, "tabs[1].wins.main.right", 15)
+
+    -- toggle
+    child.cmd([[NoNeckPain]])
+    child.cmd([[NoNeckPain]])
+
+    eq_buf_width(child, "tabs[1].wins.main.left", 15)
+    eq_buf_width(child, "tabs[1].wins.main.right", 15)
+end
+
+
 T["left/right"]["have the same width"] = function()
     child.lua([[
         require('no-neck-pain').setup({width=50})


### PR DESCRIPTION
## 📃 Summary

With `setNames=true`, toggling the plugin at least twice result in the following error:

```
FAIL in tests/test_buffers.lua | left/right | setNames doesn't throw when re-creating side buffers: Vim:Error executing Lua cal
lback: ...lm/Documents/no-neck-pain.nvim/lua/no-neck-pain/wins.lua:76: Vim:E95: Buffer with this name already exists
  stack traceback:
        [C]: in function 'nvim_buf_set_name'
        ...lm/Documents/no-neck-pain.nvim/lua/no-neck-pain/wins.lua:76: in function 'createSideBuffers'
        ...lm/Documents/no-neck-pain.nvim/lua/no-neck-pain/main.lua:44: in function 'init'
        ...lm/Documents/no-neck-pain.nvim/lua/no-neck-pain/main.lua:77: in function 'toggle'
        ...lm/Documents/no-neck-pain.nvim/lua/no-neck-pain/init.lua:11: in function 'toggle'
        .../klm/Documents/no-neck-pain.nvim/plugin/no-neck-pain.lua:18: in function <.../klm/Documents/no-neck-pain.nvim/plugin
/no-neck-pain.lua:17>
  Traceback:
    tests/test_buffers.lua:242

make: *** [test] Error 1
```

This PR solves this issue by deleting the buffer if it exist.