### PR TITLE
fix: textColor blending

### DIFF
--- a/lua/no-neck-pain/color.lua
+++ b/lua/no-neck-pain/color.lua
@@ -117,7 +117,7 @@ function C.parse(buffers)
 
             -- if we have a transparent bg we won't be able,
             -- to default a text color so we set it to white
-            if buffers[side].backgroundColor == "NONE" then
+            if string.lower(buffers[side].backgroundColor) == "none" then
                 defaultTextColor = "#ffffff"
             end
 


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/184

pretty much a dumb error, the internal `matchAndblend` method returns the given color in lower case, which led to a casing issue when comparing with `NONE` instead of `none` 