### PR TITLE
fix: vsplit wrongly sized

### DIFF
--- a/lua/no-neck-pain/util/debug.lua
+++ b/lua/no-neck-pain/util/debug.lua
@@ -32,7 +32,7 @@ end
 ---prints the table if debug is true.
 ---
 ---@param table table: the table to print.
----@param indent number: the default indent value, starts at 0.
+---@param indent number?: the default indent value, starts at 0.
 ---@private
 function D.tprint(table, indent)
     if _G.NoNeckPain.config ~= nil and not _G.NoNeckPain.config.debug then

--- a/tests/test_split.lua
+++ b/tests/test_split.lua
@@ -170,6 +170,28 @@ T["vsplit"]["correctly position side buffers when there's enough space"] = funct
     )
 end
 
+T["vsplit"]["preserve vsplit width when having side buffers"] = function()
+    child.set_size(500, 500)
+    child.lua([[
+        require('no-neck-pain').setup({width=50,buffers={right={enabled=false}}})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1001, 1000 }
+    )
+
+    child.cmd("vsplit")
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1001, 1002, 1000 }
+    )
+
+    eq_buf_width(child, "tabs[1].wins.splits[1].id", 242)
+end
+
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
     child.set_size(400, 400)
     child.lua([[


### PR DESCRIPTION
## 📃 Summary

Opening vsplit windows while having **only one side buffer** opened might result in wrongly size panes, this is because the side buffers are resized **after** the split have been opened. 

We now resize all opened vsplit for this case.

## 📸 Preview

before

<img width="1280" alt="Screenshot 2023-02-26 at 18 38 19" src="https://user-images.githubusercontent.com/20689156/221426796-b0e1db02-b8f6-46a8-a9e5-06d794d91148.png">

after

<img width="1280" alt="Screenshot 2023-02-26 at 18 37 55" src="https://user-images.githubusercontent.com/20689156/221426783-4f270c17-1f5c-4c78-b027-56ce8ef451ea.png">