### PR TITLE
feat!: v1.0.0 - API breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ require("lazy").setup({"shortcuts/no-neck-pain.nvim"})
 </table>
 </div>
 
+## 🏗 v1.0.0 breaking changes
+
+See [the release description](https://github.com/shortcuts/no-neck-pain.nvim/pull/201) for the full list of breaking changes.
+
 ## ☄ Getting started
 
 No configuration/setup steps needed! Sit back, relax and call `:NoNeckPain`.

--- a/README.md
+++ b/README.md
@@ -117,112 +117,125 @@ No configuration/setup steps needed! Sit back, relax and call `:NoNeckPain`.
 ```lua
 require("no-neck-pain").setup({
     -- Prints useful logs about triggered events, and reasons actions are executed.
+    --- @type boolean
     debug = false,
-    -- When `true`, enables the plugin when you start Neovim.
-    enableOnVimEnter = false,
-    -- When `true`, enables the plugin when you enter a new Tab.
-    -- note: it does not trigger if it's an existing tab, to prevent unwanted interfer with user's decisions.
-    enableOnTabEnter = false,
-    -- The width of the focused window that will be centered, accepted values are:
-    -- - Any integer > 0.
-    -- - "textwidth", which retrieves the value of the `vim.bo.textwidth` option.
-    -- - "colorcolumn", which retrieves the value of the `vim.opt.colorcolumn` option.
-    -- When the terminal width is less than the `width` option, the side buffers won't be created.
+    -- The width of the focused window that will be centered. When the terminal width is less than the `width` option, the side buffers won't be created.
+    --- @type integer|"textwidth"|"colorcolumn"
     width = 100,
     -- Represents the lowest width value a side buffer should be.
     -- This option can be useful when switching window size frequently, example:
     -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
+    --- @type integer
     minSideBufferWidth = 5,
-    -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
-    -- When `false`, the mapping is not created.
-    toggleMapping = "<Leader>np",
-    -- Sets a global mapping to Neovim, which allows you to increase the width (+5) of the main window.
-    -- When `false`, the mapping is not created.
-    widthUpMapping = "<Leader>n=",
-    -- Sets a global mapping to Neovim, which allows you to decrease the width (-5) of the main window.
-    -- When `false`, the mapping is not created.
-    widthDownMapping = "<Leader>n-",
     -- Disables the plugin if the last valid buffer in the list have been closed.
+    --- @type boolean
     disableOnLastBuffer = false,
     -- When `true`, disabling the plugin closes every other windows except the initially focused one.
+    --- @type boolean
     killAllBuffersOnDisable = false,
+    -- Adds autocmd (@see `:h autocmd`) which aims at automatically enabling the plugin.
+    --- @type table
+    autocmds = {
+        -- When `true`, enables the plugin when you start Neovim.
+        -- If the main window is  a side tree (e.g. NvimTree) or a dashboard, the command is delayed until it finds a valid window.
+        -- The command is cleaned once it has successfuly ran once.
+        --- @type boolean
+        enableOnVimEnter = false,
+        -- When `true`, enables the plugin when you enter a new Tab.
+        -- note: it does not trigger if you come back to an existing tab, to prevent unwanted interfer with user's decisions.
+        --- @type boolean
+        enableOnTabEnter = false,
+    },
+    -- Creates mappings for you to easily interact with the exposed commands.
+    --- @type table
+    mappings = {
+        -- When `true`, creates all the mappings that are not set to `false`.
+        --- @type boolean
+        enabled = false,
+        -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
+        -- When `false`, the mapping is not created.
+        --- @type string
+        toggle = "<Leader>np",
+        -- Sets a global mapping to Neovim, which allows you to increase the width (+5) of the main window.
+        -- When `false`, the mapping is not created.
+        --- @type string
+        widthUp = "<Leader>n=",
+        -- Sets a global mapping to Neovim, which allows you to decrease the width (-5) of the main window.
+        -- When `false`, the mapping is not created.
+        --- @type string
+        widthDown = "<Leader>n-",
+    },
     --- Common options that are set to both side buffers.
     --- See |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+    --- @type table
     buffers = {
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
+        --- @type boolean
         setNames = false,
-        -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically save the content at the given `location`.
-        -- note: quitting an unsaved scratchpad buffer is non-blocking.
+        -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
+        -- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
+        --- @type table
         scratchPad = {
             -- When `true`, automatically sets the following options to the side buffers:
             -- - `autowriteall`
             -- - `autoread`.
+            --- @type boolean
             enabled = false,
             -- The name of the generated file. See `location` for more information.
-            -- @example: `no-neck-pain-left.norg`
+            --- @type string
+            --- @example: `no-neck-pain-left.norg`
             fileName = "no-neck-pain",
             -- By default, files are saved at the same location as the current Neovim session.
-            -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed from the buffer options globally `buffers.bo.filetype` or see |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
-            -- @example: `no-neck-pain-left.norg`
+            -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+            --- @type string?
+            --- @example: `no-neck-pain-left.norg`
             location = nil,
         },
-        -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-        -- Transparent backgrounds are supported by default.
-        backgroundColor = nil,
-        -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
-        blend = 0,
-        -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
-        textColor = nil,
+        -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
+        --- see |NoNeckPain.bufferOptionsColors|
+        colors = NoNeckPain.bufferOptionsColors,
         -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
-        bo = {
-            filetype = "no-neck-pain",
-            buftype = "nofile",
-            bufhidden = "hide",
-            buflisted = false,
-            swapfile = false,
-        },
+        --- @see NoNeckPain.bufferOptionsBo `:h NoNeckPain.bufferOptionsBo`
+        bo = NoNeckPain.bufferOptionsBo,
         -- Vim window-scoped options: any `vim.wo` options is accepted here.
-        wo = {
-            cursorline = false,
-            cursorcolumn = false,
-            colorcolumn = "0",
-            number = false,
-            relativenumber = false,
-            foldenable = false,
-            list = false,
-            wrap = true,
-            linebreak = true,
-        },
-        --- Options applied to the `left` buffer, the options defined here overrides the ones at the root of the `buffers` level.
-        --- See |NoNeckPain.bufferOptions|.
+        --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
+        wo = NoNeckPain.bufferOptionsWo,
+        --- Options applied to the `left` buffer, options defined here overrides the `buffers` ones.
+        --- @see NoNeckPain.bufferOptions `:h NoNeckPain.bufferOptions`
         left = NoNeckPain.bufferOptions,
-        --- Options applied to the `right` buffer, the options defined here overrides the ones at the root of the `buffers` level.
-        --- See |NoNeckPain.bufferOptions|.
+        --- Options applied to the `right` buffer, options defined here overrides the `buffers` ones.
+        --- @see NoNeckPain.bufferOptions `:h NoNeckPain.bufferOptions`
         right = NoNeckPain.bufferOptions,
     },
     -- Supported integrations that might clash with `no-neck-pain.nvim`'s behavior.
+    --- @type table
     integrations = {
         -- By default, if NvimTree is open, we will close it and reopen it when enabling the plugin,
         -- this prevents having the side buffers wrongly positioned.
         -- @link https://github.com/nvim-tree/nvim-tree.lua
+        --- @type table
         NvimTree = {
-            -- The position of the tree, either `left` or `right`.
+            -- The position of the tree.
+            --- @type "left"|"right"
             position = "left",
             -- When `true`, if the tree was opened before enabling the plugin, we will reopen it.
+            --- @type boolean
             reopen = true,
         },
         -- By default, if NeoTree is open, we will close it and reopen it when enabling the plugin,
         -- this prevents having the side buffers wrongly positioned.
         -- @link https://github.com/nvim-neo-tree/neo-tree.nvim
         NeoTree = {
-            -- The position of the tree, either `left` or `right`.
+            -- The position of the tree.
+            --- @type "left"|"right"
             position = "left",
             -- When `true`, if the tree was opened before enabling the plugin, we will reopen it.
             reopen = true,
         },
         -- @link https://github.com/mbbill/undotree
         undotree = {
-            -- The position of the tree, either `left` or `right`.
+            -- The position of the tree.
+            --- @type "left"|"right"
             position = "left",
         },
     },
@@ -230,34 +243,61 @@ require("no-neck-pain").setup({
 
 NoNeckPain.bufferOptions = {
     -- When `false`, the buffer won't be created.
+    --- @type boolean
     enabled = true,
+    --- @see NoNeckPain.bufferOptionsColors `:h NoNeckPain.bufferOptionsColors`
+    colors = NoNeckPain.bufferOptionsColors,
+    --- @see NoNeckPain.bufferOptionsBo `:h NoNeckPain.bufferOptionsBo`
+    bo = NoNeckPain.bufferOptionsBo,
+    --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
+    wo = NoNeckPain.bufferOptionsWo,
+}
+
+NoNeckPain.bufferOptionsWo = {
+    --- @type boolean
+    cursorline = false,
+    --- @type boolean
+    cursorcolumn = false,
+    --- @type string
+    colorcolumn = "0",
+    --- @type boolean
+    number = false,
+    --- @type boolean
+    relativenumber = false,
+    --- @type boolean
+    foldenable = false,
+    --- @type boolean
+    list = false,
+    --- @type boolean
+    wrap = true,
+    --- @type boolean
+    linebreak = true,
+}
+
+NoNeckPain.bufferOptionsBo = {
+    --- @type string
+    filetype = "no-neck-pain",
+    --- @type string
+    buftype = "nofile",
+    --- @type string
+    bufhidden = "hide",
+    --- @type boolean
+    buflisted = false,
+    --- @type boolean
+    swapfile = false,
+}
+
+NoNeckPain.bufferOptionsColors = {
     -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
     -- Transparent backgrounds are supported by default.
-    backgroundColor = nil,
+    --- @type string?
+    background = nil,
     -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
+    --- @type integer
     blend = 0,
     -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
-    textColor = nil,
-    -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
-    bo = {
-        filetype = "no-neck-pain",
-        buftype = "nofile",
-        bufhidden = "hide",
-        buflisted = false,
-        swapfile = false,
-    },
-    -- Vim window-scoped options: any `vim.wo` options is accepted here.
-    wo = {
-        cursorline = false,
-        cursorcolumn = false,
-        colorcolumn = "0",
-        number = false,
-        relativenumber = false,
-        foldenable = false,
-        list = false,
-        wrap = true,
-        linebreak = true,
-    },
+    --- @type string?
+    text = nil,
 }
 ```
 

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -27,6 +27,7 @@ Disables the plugin, clear highlight groups and autocmds, closes side buffers an
                                                     *NoNeckPain.bufferOptionsWo*
                           `NoNeckPain.bufferOptionsWo`
 NoNeckPain's buffer `vim.wo` options.
+@see window options `:h vim.wo`
 
 Type~
 `(table)`
@@ -59,6 +60,7 @@ values:
                                                     *NoNeckPain.bufferOptionsBo*
                           `NoNeckPain.bufferOptionsBo`
 NoNeckPain's buffer `vim.bo` options.
+@see buffer options `:h vim.bo`
 
 Type~
 `(table)`
@@ -135,8 +137,11 @@ values:
       -- When `false`, the buffer won't be created.
       --- @type boolean
       enabled = true,
+      --- @see NoNeckPain.bufferOptionsColors `:h NoNeckPain.bufferOptionsColors`
       colors = NoNeckPain.bufferOptionsColors,
+      --- @see NoNeckPain.bufferOptionsBo `:h NoNeckPain.bufferOptionsBo`
       bo = NoNeckPain.bufferOptionsBo,
+      --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
       wo = NoNeckPain.bufferOptionsWo,
   }
 
@@ -145,7 +150,7 @@ values:
 ------------------------------------------------------------------------------
                                                             *NoNeckPain.options*
                               `NoNeckPain.options`
-Plugin config
+NoNeckPain's plugin config.
 
 Type~
 `(table)`
@@ -231,16 +236,16 @@ values:
           --- see |NoNeckPain.bufferOptionsColors|
           colors = NoNeckPain.bufferOptionsColors,
           -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
-          --- see |NoNeckPain.bufferOptionsBo|
+          --- @see NoNeckPain.bufferOptionsBo `:h NoNeckPain.bufferOptionsBo`
           bo = NoNeckPain.bufferOptionsBo,
           -- Vim window-scoped options: any `vim.wo` options is accepted here.
-          --- see |NoNeckPain.bufferOptionsWo|
+          --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
           wo = NoNeckPain.bufferOptionsWo,
           --- Options applied to the `left` buffer, options defined here overrides the `buffers` ones.
-          --- See |NoNeckPain.bufferOptions|.
+          --- @see NoNeckPain.bufferOptions `:h NoNeckPain.bufferOptions`
           left = NoNeckPain.bufferOptions,
           --- Options applied to the `right` buffer, options defined here overrides the `buffers` ones.
-          --- See |NoNeckPain.bufferOptions|.
+          --- @see NoNeckPain.bufferOptions `:h NoNeckPain.bufferOptions`
           right = NoNeckPain.bufferOptions,
       },
       -- Supported integrations that might clash with `no-neck-pain.nvim`'s behavior.

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -24,16 +24,72 @@ Disables the plugin, clear highlight groups and autocmds, closes side buffers an
 
 ==============================================================================
 ------------------------------------------------------------------------------
-                                                      *NoNeckPain.bufferOptions*
-                           `NoNeckPain.bufferOptions`
-NoNeckPain buffer options
+                                                    *NoNeckPain.bufferOptionsWo*
+                          `NoNeckPain.bufferOptionsWo`
+NoNeckPain's buffer `vim.wo` options.
 
-Default values:
+Type~
+`(table)`
+values:
 >
-  NoNeckPain.bufferOptions = {
-      -- When `false`, the buffer won't be created.
-      enabled = true,
-      -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A).
+  NoNeckPain.bufferOptionsWo = {
+      --- @type boolean
+      cursorline = false,
+      --- @type boolean
+      cursorcolumn = false,
+      --- @type string
+      colorcolumn = "0",
+      --- @type boolean
+      number = false,
+      --- @type boolean
+      relativenumber = false,
+      --- @type boolean
+      foldenable = false,
+      --- @type boolean
+      list = false,
+      --- @type boolean
+      wrap = true,
+      --- @type boolean
+      linebreak = true,
+  }
+
+<
+
+------------------------------------------------------------------------------
+                                                    *NoNeckPain.bufferOptionsBo*
+                          `NoNeckPain.bufferOptionsBo`
+NoNeckPain's buffer `vim.bo` options.
+
+Type~
+`(table)`
+values:
+>
+  NoNeckPain.bufferOptionsBo = {
+      --- @type string
+      filetype = "no-neck-pain",
+      --- @type string
+      buftype = "nofile",
+      --- @type string
+      bufhidden = "hide",
+      --- @type boolean
+      buflisted = false,
+      --- @type boolean
+      swapfile = false,
+  }
+
+<
+
+------------------------------------------------------------------------------
+                                                *NoNeckPain.bufferOptionsColors*
+                        `NoNeckPain.bufferOptionsColors`
+NoNeckPain's buffer color options.
+
+Type~
+`(table)`
+values:
+>
+  NoNeckPain.bufferOptionsColors = {
+      -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
       -- Transparent backgrounds are supported by default.
       -- popular theme are supported by their name:
       -- - catppuccin-frappe
@@ -54,31 +110,34 @@ Default values:
       -- - tokyonight-moon
       -- - tokyonight-night
       -- - tokyonight-storm
-      backgroundColor = nil,
+      --- @type string?
+      background = nil,
       -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
+      --- @type integer
       blend = 0,
       -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
-      textColor = nil,
-      -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
-      bo = {
-          filetype = "no-neck-pain",
-          buftype = "nofile",
-          bufhidden = "hide",
-          buflisted = false,
-          swapfile = false,
-      },
-      -- Vim window-scoped options: any `vim.wo` options is accepted here.
-      wo = {
-          cursorline = false,
-          cursorcolumn = false,
-          colorcolumn = "0",
-          number = false,
-          relativenumber = false,
-          foldenable = false,
-          list = false,
-          wrap = true,
-          linebreak = true,
-      },
+      --- @type string?
+      text = nil,
+  }
+
+<
+
+------------------------------------------------------------------------------
+                                                      *NoNeckPain.bufferOptions*
+                           `NoNeckPain.bufferOptions`
+NoNeckPain's buffer side buffer option.
+
+Type~
+`(table)`
+values:
+>
+  NoNeckPain.bufferOptions = {
+      -- When `false`, the buffer won't be created.
+      --- @type boolean
+      enabled = true,
+      colors = NoNeckPain.bufferOptionsColors,
+      bo = NoNeckPain.bufferOptionsBo,
+      wo = NoNeckPain.bufferOptionsWo,
   }
 
 <
@@ -88,135 +147,131 @@ Default values:
                               `NoNeckPain.options`
 Plugin config
 
-Default values:
+Type~
+`(table)`
+values:
 >
   NoNeckPain.options = {
       -- Prints useful logs about triggered events, and reasons actions are executed.
+      --- @type boolean
       debug = false,
-      -- When `true`, enables the plugin when you start Neovim.
-      enableOnVimEnter = false,
-      -- When `true`, enables the plugin when you enter a new Tab.
-      -- note: it does not trigger if it's an existing tab, to prevent unwanted interfer with user's decisions.
-      enableOnTabEnter = false,
-      -- The width of the focused window that will be centered, accepted values are:
-      -- - Any integer > 0.
-      -- - "textwidth", which retrieves the value of the `vim.bo.textwidth` option.
-      -- - "colorcolumn", which retrieves the value of the `vim.opt.colorcolumn` option.
-      -- When the terminal width is less than the `width` option, the side buffers won't be created.
+      -- The width of the focused window that will be centered. When the terminal width is less than the `width` option, the side buffers won't be created.
+      --- @type integer|"textwidth"|"colorcolumn"
       width = 100,
       -- Represents the lowest width value a side buffer should be.
       -- This option can be useful when switching window size frequently, example:
       -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
+      --- @type integer
       minSideBufferWidth = 5,
-      -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
-      -- When `false`, the mapping is not created.
-      toggleMapping = "<Leader>np",
-      -- Sets a global mapping to Neovim, which allows you to increase the width (+5) of the main window.
-      -- When `false`, the mapping is not created.
-      widthUpMapping = "<Leader>n=",
-      -- Sets a global mapping to Neovim, which allows you to decrease the width (-5) of the main window.
-      -- When `false`, the mapping is not created.
-      widthDownMapping = "<Leader>n-",
       -- Disables the plugin if the last valid buffer in the list have been closed.
+      --- @type boolean
       disableOnLastBuffer = false,
       -- When `true`, disabling the plugin closes every other windows except the initially focused one.
+      --- @type boolean
       killAllBuffersOnDisable = false,
+      -- Adds autocmd (@see `:h autocmd`) which aims at automatically enabling the plugin.
+      --- @type table
+      autocmds = {
+          -- When `true`, enables the plugin when you start Neovim.
+          -- If the main window is  a side tree (e.g. NvimTree) or a dashboard, the command is delayed until it finds a valid window.
+          -- The command is cleaned once it has successfuly ran once.
+          --- @type boolean
+          enableOnVimEnter = false,
+          -- When `true`, enables the plugin when you enter a new Tab.
+          -- note: it does not trigger if you come back to an existing tab, to prevent unwanted interfer with user's decisions.
+          --- @type boolean
+          enableOnTabEnter = false,
+      },
+      -- Creates mappings for you to easily interact with the exposed commands.
+      --- @type table
+      mappings = {
+          -- When `true`, creates all the mappings that are not set to `false`.
+          --- @type boolean
+          enabled = false,
+          -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
+          -- When `false`, the mapping is not created.
+          --- @type string
+          toggle = "<Leader>np",
+          -- Sets a global mapping to Neovim, which allows you to increase the width (+5) of the main window.
+          -- When `false`, the mapping is not created.
+          --- @type string
+          widthUp = "<Leader>n=",
+          -- Sets a global mapping to Neovim, which allows you to decrease the width (-5) of the main window.
+          -- When `false`, the mapping is not created.
+          --- @type string
+          widthDown = "<Leader>n-",
+      },
       --- Common options that are set to both side buffers.
       --- See |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+      --- @type table
       buffers = {
           -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
+          --- @type boolean
           setNames = false,
-          -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically save the content at the given `location`.
-          -- note: quitting an unsaved scratchpad buffer is non-blocking.
+          -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
+          -- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
+          --- @type table
           scratchPad = {
               -- When `true`, automatically sets the following options to the side buffers:
               -- - `autowriteall`
               -- - `autoread`.
+              --- @type boolean
               enabled = false,
               -- The name of the generated file. See `location` for more information.
-              -- @example: `no-neck-pain-left.norg`
+              --- @type string
+              --- @example: `no-neck-pain-left.norg`
               fileName = "no-neck-pain",
               -- By default, files are saved at the same location as the current Neovim session.
-              -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed from the buffer options globally `buffers.bo.filetype` or see |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
-              -- @example: `no-neck-pain-left.norg`
+              -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+              --- @type string?
+              --- @example: `no-neck-pain-left.norg`
               location = nil,
           },
-          -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-          -- Transparent backgrounds are supported by default.
-          -- popular theme are supported by their name:
-          -- - catppuccin-frappe
-          -- - catppuccin-frappe-dark
-          -- - catppuccin-latte
-          -- - catppuccin-latte-dark
-          -- - catppuccin-macchiato
-          -- - catppuccin-macchiato-dark
-          -- - catppuccin-mocha
-          -- - catppuccin-mocha-dark
-          -- - github-nvim-theme-dark
-          -- - github-nvim-theme-dimmed
-          -- - github-nvim-theme-light
-          -- - rose-pine
-          -- - rose-pine-dawn
-          -- - rose-pine-moon
-          -- - tokyonight-day
-          -- - tokyonight-moon
-          -- - tokyonight-night
-          -- - tokyonight-storm
-          backgroundColor = nil,
-          -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
-          blend = 0,
-          -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
-          textColor = nil,
+          -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
+          --- see |NoNeckPain.bufferOptionsColors|
+          colors = NoNeckPain.bufferOptionsColors,
           -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
-          bo = {
-              filetype = "no-neck-pain",
-              buftype = "nofile",
-              bufhidden = "hide",
-              buflisted = false,
-              swapfile = false,
-          },
+          --- see |NoNeckPain.bufferOptionsBo|
+          bo = NoNeckPain.bufferOptionsBo,
           -- Vim window-scoped options: any `vim.wo` options is accepted here.
-          wo = {
-              cursorline = false,
-              cursorcolumn = false,
-              colorcolumn = "0",
-              number = false,
-              relativenumber = false,
-              foldenable = false,
-              list = false,
-              wrap = true,
-              linebreak = true,
-          },
-          --- Options applied to the `left` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+          --- see |NoNeckPain.bufferOptionsWo|
+          wo = NoNeckPain.bufferOptionsWo,
+          --- Options applied to the `left` buffer, options defined here overrides the `buffers` ones.
           --- See |NoNeckPain.bufferOptions|.
           left = NoNeckPain.bufferOptions,
-          --- Options applied to the `right` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+          --- Options applied to the `right` buffer, options defined here overrides the `buffers` ones.
           --- See |NoNeckPain.bufferOptions|.
           right = NoNeckPain.bufferOptions,
       },
       -- Supported integrations that might clash with `no-neck-pain.nvim`'s behavior.
+      --- @type table
       integrations = {
           -- By default, if NvimTree is open, we will close it and reopen it when enabling the plugin,
           -- this prevents having the side buffers wrongly positioned.
           -- @link https://github.com/nvim-tree/nvim-tree.lua
+          --- @type table
           NvimTree = {
-              -- The position of the tree, either `left` or `right`.
+              -- The position of the tree.
+              --- @type "left"|"right"
               position = "left",
               -- When `true`, if the tree was opened before enabling the plugin, we will reopen it.
+              --- @type boolean
               reopen = true,
           },
           -- By default, if NeoTree is open, we will close it and reopen it when enabling the plugin,
           -- this prevents having the side buffers wrongly positioned.
           -- @link https://github.com/nvim-neo-tree/neo-tree.nvim
           NeoTree = {
-              -- The position of the tree, either `left` or `right`.
+              -- The position of the tree.
+              --- @type "left"|"right"
               position = "left",
               -- When `true`, if the tree was opened before enabling the plugin, we will reopen it.
               reopen = true,
           },
           -- @link https://github.com/mbbill/undotree
           undotree = {
-              -- The position of the tree, either `left` or `right`.
+              -- The position of the tree.
+              --- @type "left"|"right"
               position = "left",
           },
       },

--- a/doc/tags
+++ b/doc/tags
@@ -1,4 +1,7 @@
 NoNeckPain.bufferOptions	no-neck-pain.txt	/*NoNeckPain.bufferOptions*
+NoNeckPain.bufferOptionsBo	no-neck-pain.txt	/*NoNeckPain.bufferOptionsBo*
+NoNeckPain.bufferOptionsColors	no-neck-pain.txt	/*NoNeckPain.bufferOptionsColors*
+NoNeckPain.bufferOptionsWo	no-neck-pain.txt	/*NoNeckPain.bufferOptionsWo*
 NoNeckPain.disable()	no-neck-pain.txt	/*NoNeckPain.disable()*
 NoNeckPain.enable()	no-neck-pain.txt	/*NoNeckPain.enable()*
 NoNeckPain.options	no-neck-pain.txt	/*NoNeckPain.options*

--- a/lua/no-neck-pain/color.lua
+++ b/lua/no-neck-pain/color.lua
@@ -1,3 +1,4 @@
+local D = require("no-neck-pain.util.debug")
 local Co = require("no-neck-pain.util.constants")
 
 local C = {}
@@ -49,7 +50,7 @@ end
 ---@return string?: the blended color code.
 ---@private
 local function matchAndBlend(colorCode, factor)
-    if colorCode == nil then
+    if colorCode == nil or string.lower(colorCode) == "none" then
         return nil
     end
 

--- a/lua/no-neck-pain/color.lua
+++ b/lua/no-neck-pain/color.lua
@@ -1,4 +1,3 @@
-local D = require("no-neck-pain.util.debug")
 local Co = require("no-neck-pain.util.constants")
 
 local C = {}

--- a/lua/no-neck-pain/color.lua
+++ b/lua/no-neck-pain/color.lua
@@ -93,36 +93,36 @@ function C.parse(buffers)
     -- if the user did not provided a custom background color, and have a transparent bg,
     -- we set it to the global options and let the loop do the spread below.
     if
-        buffers.backgroundColor == nil
+        buffers.colors.background == nil
         and (defaultBackground == nil or string.lower(defaultBackground) == "none")
     then
-        buffers.backgroundColor = "NONE"
-        buffers.textColor = "#ffffff"
+        buffers.colors.background = "NONE"
+        buffers.colors.text = "#ffffff"
     else
-        buffers.backgroundColor = matchAndBlend(
-            buffers.backgroundColor or string.format("#%06X", defaultBackground),
-            buffers.blend
+        buffers.colors.background = matchAndBlend(
+            buffers.colors.background or string.format("#%06X", defaultBackground),
+            buffers.colors.blend
         )
     end
 
     for _, side in pairs(Co.SIDES) do
         if buffers[side].enabled then
-            -- if the side buffer backgroundColor is not defined, we fallback to the common option.
-            buffers[side].backgroundColor = matchAndBlend(
-                buffers[side].backgroundColor,
-                buffers[side].blend or buffers.blend
-            ) or buffers.backgroundColor
+            -- if the side buffer colors.background is not defined, we fallback to the common option.
+            buffers[side].colors.background = matchAndBlend(
+                buffers[side].colors.background,
+                buffers[side].colors.blend or buffers.colors.blend
+            ) or buffers.colors.background
 
-            local defaultTextColor = buffers[side].backgroundColor
+            local defaultTextColor = buffers[side].colors.background
 
             -- if we have a transparent bg we won't be able,
             -- to default a text color so we set it to white
-            if string.lower(buffers[side].backgroundColor) == "none" then
+            if string.lower(buffers[side].colors.background) == "none" then
                 defaultTextColor = "#ffffff"
             end
 
-            buffers[side].textColor = buffers[side].textColor
-                or buffers.textColor
+            buffers[side].colors.text = buffers[side].colors.text
+                or buffers.colors.text
                 or matchAndBlend(defaultTextColor, 0.5)
         end
     end
@@ -152,8 +152,8 @@ function C.init(win, tab, side)
         string.format(
             "highlight! %s guifg=%s guibg=%s",
             backgroundGroup,
-            _G.NoNeckPain.config.buffers[side].backgroundColor,
-            _G.NoNeckPain.config.buffers[side].backgroundColor
+            _G.NoNeckPain.config.buffers[side].colors.background,
+            _G.NoNeckPain.config.buffers[side].colors.background
         )
     )
 
@@ -162,8 +162,8 @@ function C.init(win, tab, side)
         string.format(
             "highlight! %s guifg=%s guibg=%s",
             textGroup,
-            _G.NoNeckPain.config.buffers[side].textColor,
-            _G.NoNeckPain.config.buffers[side].backgroundColor
+            _G.NoNeckPain.config.buffers[side].colors.text,
+            _G.NoNeckPain.config.buffers[side].colors.background
         )
     )
 
@@ -173,7 +173,7 @@ function C.init(win, tab, side)
     }
 
     -- on transparent backgrounds we don't set those two to prevent white lines.
-    if _G.NoNeckPain.config.buffers[side].backgroundColor ~= "NONE" then
+    if _G.NoNeckPain.config.buffers[side].colors.background ~= "NONE" then
         groups = vim.tbl_extend("keep", groups, {
             WinSeparator = backgroundGroup,
             VertSplit = backgroundGroup,

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -13,14 +13,57 @@ local function registerMapping(options, mapping, fn)
     vim.api.nvim_set_keymap("n", options[mapping], fn, { silent = true })
 end
 
---- NoNeckPain buffer options
+--- NoNeckPain's buffer `vim.wo` options.
 ---
---- Default values:
+---@type table
+---Default values:
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
-NoNeckPain.bufferOptions = {
-    -- When `false`, the buffer won't be created.
-    enabled = true,
-    -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A).
+NoNeckPain.bufferOptionsWo = {
+    --- @type boolean
+    cursorline = false,
+    --- @type boolean
+    cursorcolumn = false,
+    --- @type string
+    colorcolumn = "0",
+    --- @type boolean
+    number = false,
+    --- @type boolean
+    relativenumber = false,
+    --- @type boolean
+    foldenable = false,
+    --- @type boolean
+    list = false,
+    --- @type boolean
+    wrap = true,
+    --- @type boolean
+    linebreak = true,
+}
+
+--- NoNeckPain's buffer `vim.bo` options.
+---
+---@type table
+---Default values:
+---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
+NoNeckPain.bufferOptionsBo = {
+    --- @type string
+    filetype = "no-neck-pain",
+    --- @type string
+    buftype = "nofile",
+    --- @type string
+    bufhidden = "hide",
+    --- @type boolean
+    buflisted = false,
+    --- @type boolean
+    swapfile = false,
+}
+
+--- NoNeckPain's buffer color options.
+---
+---@type table
+---Default values:
+---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
+NoNeckPain.bufferOptionsColors = {
+    -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
     -- Transparent backgrounds are supported by default.
     -- popular theme are supported by their name:
     -- - catppuccin-frappe
@@ -41,164 +84,156 @@ NoNeckPain.bufferOptions = {
     -- - tokyonight-moon
     -- - tokyonight-night
     -- - tokyonight-storm
-    backgroundColor = nil,
+    --- @type string?
+    background = nil,
     -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
+    --- @type integer
     blend = 0,
     -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
-    textColor = nil,
-    -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
-    bo = {
-        filetype = "no-neck-pain",
-        buftype = "nofile",
-        bufhidden = "hide",
-        buflisted = false,
-        swapfile = false,
-    },
-    -- Vim window-scoped options: any `vim.wo` options is accepted here.
-    wo = {
-        cursorline = false,
-        cursorcolumn = false,
-        colorcolumn = "0",
-        number = false,
-        relativenumber = false,
-        foldenable = false,
-        list = false,
-        wrap = true,
-        linebreak = true,
-    },
+    --- @type string?
+    text = nil,
 }
 
---- Plugin config
+--- NoNeckPain's buffer side buffer option.
 ---
---- Default values:
+---@type table
+---Default values:
+---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
+NoNeckPain.bufferOptions = {
+    -- When `false`, the buffer won't be created.
+    --- @type boolean
+    enabled = true,
+    colors = NoNeckPain.bufferOptionsColors,
+    bo = NoNeckPain.bufferOptionsBo,
+    wo = NoNeckPain.bufferOptionsWo,
+}
+
+--- NoNeckPain's plugin config.
+---
+---@type table
+---Default values:
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
 NoNeckPain.options = {
     -- Prints useful logs about triggered events, and reasons actions are executed.
+    --- @type boolean
     debug = false,
-    -- When `true`, enables the plugin when you start Neovim.
-    enableOnVimEnter = false,
-    -- When `true`, enables the plugin when you enter a new Tab.
-    -- note: it does not trigger if it's an existing tab, to prevent unwanted interfer with user's decisions.
-    enableOnTabEnter = false,
-    -- The width of the focused window that will be centered, accepted values are:
-    -- - Any integer > 0.
-    -- - "textwidth", which retrieves the value of the `vim.bo.textwidth` option.
-    -- - "colorcolumn", which retrieves the value of the `vim.opt.colorcolumn` option.
-    -- When the terminal width is less than the `width` option, the side buffers won't be created.
+    -- The width of the focused window that will be centered. When the terminal width is less than the `width` option, the side buffers won't be created.
+    --- @type integer|"textwidth"|"colorcolumn"
     width = 100,
     -- Represents the lowest width value a side buffer should be.
     -- This option can be useful when switching window size frequently, example:
     -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
+    --- @type integer
     minSideBufferWidth = 5,
-    -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
-    -- When `false`, the mapping is not created.
-    toggleMapping = "<Leader>np",
-    -- Sets a global mapping to Neovim, which allows you to increase the width (+5) of the main window.
-    -- When `false`, the mapping is not created.
-    widthUpMapping = "<Leader>n=",
-    -- Sets a global mapping to Neovim, which allows you to decrease the width (-5) of the main window.
-    -- When `false`, the mapping is not created.
-    widthDownMapping = "<Leader>n-",
     -- Disables the plugin if the last valid buffer in the list have been closed.
+    --- @type boolean
     disableOnLastBuffer = false,
     -- When `true`, disabling the plugin closes every other windows except the initially focused one.
+    --- @type boolean
     killAllBuffersOnDisable = false,
+    -- Adds autocmd (@see `:h autocmd`) which aims at automatically enabling the plugin.
+    --- @type table
+    autocmds = {
+        -- When `true`, enables the plugin when you start Neovim.
+        -- If the main window is  a side tree (e.g. NvimTree) or a dashboard, the command is delayed until it finds a valid window.
+        -- The command is cleaned once it has successfuly ran once.
+        --- @type boolean
+        enableOnVimEnter = false,
+        -- When `true`, enables the plugin when you enter a new Tab.
+        -- note: it does not trigger if you come back to an existing tab, to prevent unwanted interfer with user's decisions.
+        --- @type boolean
+        enableOnTabEnter = false,
+    },
+    -- Creates mappings for you to easily interact with the exposed commands.
+    --- @type table
+    mappings = {
+        -- When `true`, creates all the mappings that are not set to `false`.
+        --- @type boolean
+        enabled = false,
+        -- Sets a global mapping to Neovim, which allows you to toggle the plugin.
+        -- When `false`, the mapping is not created.
+        --- @type string
+        toggle = "<Leader>np",
+        -- Sets a global mapping to Neovim, which allows you to increase the width (+5) of the main window.
+        -- When `false`, the mapping is not created.
+        --- @type string
+        widthUp = "<Leader>n=",
+        -- Sets a global mapping to Neovim, which allows you to decrease the width (-5) of the main window.
+        -- When `false`, the mapping is not created.
+        --- @type string
+        widthDown = "<Leader>n-",
+    },
     --- Common options that are set to both side buffers.
     --- See |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+    --- @type table
     buffers = {
         -- When `true`, the side buffers will be named `no-neck-pain-left` and `no-neck-pain-right` respectively.
+        --- @type boolean
         setNames = false,
-        -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically save the content at the given `location`.
-        -- note: quitting an unsaved scratchpad buffer is non-blocking.
+        -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
+        -- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
+        --- @type table
         scratchPad = {
             -- When `true`, automatically sets the following options to the side buffers:
             -- - `autowriteall`
             -- - `autoread`.
+            --- @type boolean
             enabled = false,
             -- The name of the generated file. See `location` for more information.
-            -- @example: `no-neck-pain-left.norg`
+            --- @type string
+            --- @example: `no-neck-pain-left.norg`
             fileName = "no-neck-pain",
             -- By default, files are saved at the same location as the current Neovim session.
-            -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed from the buffer options globally `buffers.bo.filetype` or see |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
-            -- @example: `no-neck-pain-left.norg`
+            -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+            --- @type string?
+            --- @example: `no-neck-pain-left.norg`
             location = nil,
         },
-        -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
-        -- Transparent backgrounds are supported by default.
-        -- popular theme are supported by their name:
-        -- - catppuccin-frappe
-        -- - catppuccin-frappe-dark
-        -- - catppuccin-latte
-        -- - catppuccin-latte-dark
-        -- - catppuccin-macchiato
-        -- - catppuccin-macchiato-dark
-        -- - catppuccin-mocha
-        -- - catppuccin-mocha-dark
-        -- - github-nvim-theme-dark
-        -- - github-nvim-theme-dimmed
-        -- - github-nvim-theme-light
-        -- - rose-pine
-        -- - rose-pine-dawn
-        -- - rose-pine-moon
-        -- - tokyonight-day
-        -- - tokyonight-moon
-        -- - tokyonight-night
-        -- - tokyonight-storm
-        backgroundColor = nil,
-        -- Brighten (positive) or darken (negative) the side buffers background color. Accepted values are [-1..1].
-        blend = 0,
-        -- Hexadecimal color code to override the current text color of the buffer. (e.g. #7480c2)
-        textColor = nil,
+        -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
+        --- see |NoNeckPain.bufferOptionsColors|
+        colors = NoNeckPain.bufferOptionsColors,
         -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
-        bo = {
-            filetype = "no-neck-pain",
-            buftype = "nofile",
-            bufhidden = "hide",
-            buflisted = false,
-            swapfile = false,
-        },
+        --- see |NoNeckPain.bufferOptionsBo|
+        bo = NoNeckPain.bufferOptionsBo,
         -- Vim window-scoped options: any `vim.wo` options is accepted here.
-        wo = {
-            cursorline = false,
-            cursorcolumn = false,
-            colorcolumn = "0",
-            number = false,
-            relativenumber = false,
-            foldenable = false,
-            list = false,
-            wrap = true,
-            linebreak = true,
-        },
-        --- Options applied to the `left` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+        --- see |NoNeckPain.bufferOptionsWo|
+        wo = NoNeckPain.bufferOptionsWo,
+        --- Options applied to the `left` buffer, options defined here overrides the `buffers` ones.
         --- See |NoNeckPain.bufferOptions|.
         left = NoNeckPain.bufferOptions,
-        --- Options applied to the `right` buffer, the options defined here overrides the ones at the root of the `buffers` level.
+        --- Options applied to the `right` buffer, options defined here overrides the `buffers` ones.
         --- See |NoNeckPain.bufferOptions|.
         right = NoNeckPain.bufferOptions,
     },
     -- Supported integrations that might clash with `no-neck-pain.nvim`'s behavior.
+    --- @type table
     integrations = {
         -- By default, if NvimTree is open, we will close it and reopen it when enabling the plugin,
         -- this prevents having the side buffers wrongly positioned.
         -- @link https://github.com/nvim-tree/nvim-tree.lua
+        --- @type table
         NvimTree = {
-            -- The position of the tree, either `left` or `right`.
+            -- The position of the tree.
+            --- @type "left"|"right"
             position = "left",
             -- When `true`, if the tree was opened before enabling the plugin, we will reopen it.
+            --- @type boolean
             reopen = true,
         },
         -- By default, if NeoTree is open, we will close it and reopen it when enabling the plugin,
         -- this prevents having the side buffers wrongly positioned.
         -- @link https://github.com/nvim-neo-tree/neo-tree.nvim
         NeoTree = {
-            -- The position of the tree, either `left` or `right`.
+            -- The position of the tree.
+            --- @type "left"|"right"
             position = "left",
             -- When `true`, if the tree was opened before enabling the plugin, we will reopen it.
             reopen = true,
         },
         -- @link https://github.com/mbbill/undotree
         undotree = {
-            -- The position of the tree, either `left` or `right`.
+            -- The position of the tree.
+            --- @type "left"|"right"
             position = "left",
         },
     },

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -3,14 +3,14 @@ local Co = require("no-neck-pain.util.constants")
 
 local NoNeckPain = {}
 
-local function registerMapping(options, mapping, fn)
-    if options[mapping] == false then
+local function registerMapping(mappings, name, fn)
+    if mappings[name] == false then
         return
     end
 
-    assert(type(options[mapping]) == "string", string.format("`%s` must be a string", mapping))
+    assert(type(mappings[name]) == "string", string.format("`%s` must be a string", name))
 
-    vim.api.nvim_set_keymap("n", options[mapping], fn, { silent = true })
+    vim.api.nvim_set_keymap("n", mappings[name], fn, { silent = true })
 end
 
 --- NoNeckPain's buffer `vim.wo` options.
@@ -301,15 +301,15 @@ function NoNeckPain.setup(options)
     -- set theme options
     NoNeckPain.options.buffers = C.parse(NoNeckPain.options.buffers)
 
-    registerMapping(NoNeckPain.options, "toggleMapping", ":NoNeckPain<CR>")
+    registerMapping(NoNeckPain.options.mappings, "toggle", ":NoNeckPain<CR>")
     registerMapping(
-        NoNeckPain.options,
-        "widthUpMapping",
+        NoNeckPain.options.mappings,
+        "widthUp",
         ":lua require('no-neck-pain').resize(_G.NoNeckPain.config.width + 5)<CR>"
     )
     registerMapping(
-        NoNeckPain.options,
-        "widthDownMapping",
+        NoNeckPain.options.mappings,
+        "widthDown",
         ":lua require('no-neck-pain').resize(_G.NoNeckPain.config.width - 5)<CR>"
     )
 

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -1,3 +1,4 @@
+local D = require("no-neck-pain.util.debug")
 local C = require("no-neck-pain.color")
 local Co = require("no-neck-pain.util.constants")
 
@@ -253,6 +254,8 @@ function NoNeckPain.setup(options)
     options = options or {}
     options.buffers = options.buffers or {}
     NoNeckPain.options = vim.tbl_deep_extend("keep", options, NoNeckPain.options)
+
+    D.warnDeprecation(NoNeckPain.options)
 
     -- assert `width` values through vim options
     if NoNeckPain.options.width == "textwidth" then

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -14,6 +14,7 @@ local function registerMapping(options, mapping, fn)
 end
 
 --- NoNeckPain's buffer `vim.wo` options.
+--- @see window options `:h vim.wo`
 ---
 ---@type table
 ---Default values:
@@ -40,6 +41,7 @@ NoNeckPain.bufferOptionsWo = {
 }
 
 --- NoNeckPain's buffer `vim.bo` options.
+--- @see buffer options `:h vim.bo`
 ---
 ---@type table
 ---Default values:
@@ -103,8 +105,11 @@ NoNeckPain.bufferOptions = {
     -- When `false`, the buffer won't be created.
     --- @type boolean
     enabled = true,
+    --- @see NoNeckPain.bufferOptionsColors `:h NoNeckPain.bufferOptionsColors`
     colors = NoNeckPain.bufferOptionsColors,
+    --- @see NoNeckPain.bufferOptionsBo `:h NoNeckPain.bufferOptionsBo`
     bo = NoNeckPain.bufferOptionsBo,
+    --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
     wo = NoNeckPain.bufferOptionsWo,
 }
 
@@ -193,16 +198,16 @@ NoNeckPain.options = {
         --- see |NoNeckPain.bufferOptionsColors|
         colors = NoNeckPain.bufferOptionsColors,
         -- Vim buffer-scoped options: any `vim.bo` options is accepted here.
-        --- see |NoNeckPain.bufferOptionsBo|
+        --- @see NoNeckPain.bufferOptionsBo `:h NoNeckPain.bufferOptionsBo`
         bo = NoNeckPain.bufferOptionsBo,
         -- Vim window-scoped options: any `vim.wo` options is accepted here.
-        --- see |NoNeckPain.bufferOptionsWo|
+        --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
         wo = NoNeckPain.bufferOptionsWo,
         --- Options applied to the `left` buffer, options defined here overrides the `buffers` ones.
-        --- See |NoNeckPain.bufferOptions|.
+        --- @see NoNeckPain.bufferOptions `:h NoNeckPain.bufferOptions`
         left = NoNeckPain.bufferOptions,
         --- Options applied to the `right` buffer, options defined here overrides the `buffers` ones.
-        --- See |NoNeckPain.bufferOptions|.
+        --- @see NoNeckPain.bufferOptions `:h NoNeckPain.bufferOptions`
         right = NoNeckPain.bufferOptions,
     },
     -- Supported integrations that might clash with `no-neck-pain.nvim`'s behavior.

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -56,11 +56,14 @@ end
 function NoNeckPain.setup(opts)
     _G.NoNeckPain.config = require("no-neck-pain.config").setup(opts)
 
-    if _G.NoNeckPain.config.enableOnVimEnter or _G.NoNeckPain.config.enableOnTabEnter then
+    if
+        _G.NoNeckPain.config.autocmds.enableOnVimEnter
+        or _G.NoNeckPain.config.autocmds.enableOnTabEnter
+    then
         vim.api.nvim_create_augroup("NoNeckPainAutocmd", { clear = true })
     end
 
-    if _G.NoNeckPain.config.enableOnVimEnter then
+    if _G.NoNeckPain.config.autocmds.enableOnVimEnter then
         vim.api.nvim_create_autocmd({ "BufEnter" }, {
             pattern = "*",
             callback = function(p)
@@ -81,7 +84,7 @@ function NoNeckPain.setup(opts)
         })
     end
 
-    if _G.NoNeckPain.config.enableOnTabEnter then
+    if _G.NoNeckPain.config.autocmds.enableOnTabEnter then
         vim.api.nvim_create_autocmd({ "TabNewEntered" }, {
             callback = function()
                 vim.schedule(function()

--- a/lua/no-neck-pain/util/debug.lua
+++ b/lua/no-neck-pain/util/debug.lua
@@ -58,4 +58,53 @@ function D.tprint(table, indent)
     end
 end
 
+---analyzes the user provided `setup` parameters and sends a message if they use a deprecated option, then gives the new option to use.
+---
+---@param options table: the options provided by the user.
+---@private
+function D.warnDeprecation(options)
+    local usesDeprecatedOption = false
+
+    local notice = "is now deprecated, use `%s` instead."
+    local rootDeprecated = {
+        enableOnVimEnter = "autocmds.enableOnVimEnter",
+        enableOnTabEnter = "autocmds.enableOnTabEnter",
+        toggleMapping = "mappings.toggle",
+        widthUpMapping = "mappings.widthUp",
+        widthDownMapping = "mappings.widthDown",
+    }
+    local buffersDeprecated = {
+        backgroundColor = "colors.background",
+        textColor = "colors.text",
+        blend = "colors.blend",
+    }
+
+    for name, warning in pairs(rootDeprecated) do
+        if options[name] ~= nil then
+            usesDeprecatedOption = true
+            print(
+                string.format("[no-neck-pain.nvim] `%s` %s", name, string.format(notice, warning))
+            )
+        end
+    end
+
+    for name, warning in pairs(buffersDeprecated) do
+        if
+            options.buffers[name] ~= nil
+            or options.buffers.left[name] ~= nil
+            or options.buffers.right[name] ~= nil
+        then
+            usesDeprecatedOption = true
+            print(
+                string.format("[no-neck-pain.nvim] `%s` %s", name, string.format(notice, warning))
+            )
+        end
+    end
+
+    if usesDeprecatedOption then
+        print("[no-neck-pain.nvim]     sorry to bother you with the breaking changes :(")
+        print("[no-neck-pain.nvim]     use `:h NoNeckPain.options` to read more.")
+    end
+end
+
 return D

--- a/scripts/test_auto_open.lua
+++ b/scripts/test_auto_open.lua
@@ -3,6 +3,9 @@ vim.cmd([[let &rtp.=','.getcwd()]])
 vim.cmd("set rtp+=deps/mini.nvim")
 
 -- Auto open enabled for the test
-require("no-neck-pain").setup({ width = 50, enableOnVimEnter = true, enableOnTabEnter = true })
+require("no-neck-pain").setup({
+    width = 50,
+    autocmds = { enableOnVimEnter = true, enableOnTabEnter = true },
+})
 require("mini.test").setup()
 require("mini.doc").setup()

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -55,8 +55,8 @@ T["setup"]["sets exposed methods and default options value"] = function()
 
     eq_config(child, "width", 100)
     eq_config(child, "minSideBufferWidth", 5)
-    eq_config(child, "enableOnVimEnter", false)
-    eq_config(child, "enableOnTabEnter", false)
+    eq_config(child, "autocmds.enableOnVimEnter", false)
+    eq_config(child, "autocmds.enableOnTabEnter", false)
     eq_config(child, "toggleMapping", "<Leader>np")
     eq_config(child, "widthUpMapping", "<Leader>n=")
     eq_config(child, "widthDownMapping", "<Leader>n-")
@@ -127,8 +127,10 @@ T["setup"]["overrides default values"] = function()
     child.lua([[require('no-neck-pain').setup({
         width = 42,
         minSideBufferWidth = 0,
-        enableOnVimEnter = true,
-        enableOnTabEnter = true,
+        autocmds = {
+            enableOnVimEnter = true,
+            enableOnTabEnter = true,
+        },
         debug = true,
         disableOnLastBuffer = true,
         killAllBuffersOnDisable = true,
@@ -136,8 +138,8 @@ T["setup"]["overrides default values"] = function()
 
     eq_config(child, "width", 42)
     eq_config(child, "minSideBufferWidth", 0)
-    eq_config(child, "enableOnVimEnter", true)
-    eq_config(child, "enableOnTabEnter", true)
+    eq_config(child, "autocmds.enableOnVimEnter", true)
+    eq_config(child, "autocmds.enableOnTabEnter", true)
     eq_config(child, "debug", true)
     eq_config(child, "disableOnLastBuffer", true)
     eq_config(child, "killAllBuffersOnDisable", true)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -55,11 +55,15 @@ T["setup"]["sets exposed methods and default options value"] = function()
 
     eq_config(child, "width", 100)
     eq_config(child, "minSideBufferWidth", 5)
+
     eq_config(child, "autocmds.enableOnVimEnter", false)
     eq_config(child, "autocmds.enableOnTabEnter", false)
-    eq_config(child, "toggleMapping", "<Leader>np")
-    eq_config(child, "widthUpMapping", "<Leader>n=")
-    eq_config(child, "widthDownMapping", "<Leader>n-")
+
+    eq_config(child, "mappings.enabled", false)
+    eq_config(child, "mappings.toggle", "<Leader>np")
+    eq_config(child, "mappings.widthUp", "<Leader>n=")
+    eq_config(child, "mappings.widthDown", "<Leader>n-")
+
     eq_config(child, "debug", false)
     eq_config(child, "disableOnLastBuffer", false)
     eq_config(child, "killAllBuffersOnDisable", false)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -71,7 +71,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
 
     eq_config(child, "buffers.setNames", false)
     eq_config(child, "buffers.colors.background", "#000000")
-    eq_config(child, "buffers.blend", 0)
+    eq_config(child, "buffers.colors.blend", 0)
     eq_config(child, "buffers.colors.text", vim.NIL)
 
     eq_config(child, "buffers.bo.filetype", "no-neck-pain")
@@ -96,7 +96,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
         eq_type_config(child, "buffers." .. scope .. ".wo", "table")
 
         eq_config(child, "buffers." .. scope .. ".colors.background", "#000000")
-        eq_config(child, "buffers." .. scope .. ".blend", 0)
+        eq_config(child, "buffers." .. scope .. ".colors.blend", 0)
         eq_config(child, "buffers." .. scope .. ".colors.text", "#7f7f7f")
 
         eq_config(child, "buffers." .. scope .. ".bo.filetype", "no-neck-pain")

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -70,9 +70,9 @@ T["setup"]["sets exposed methods and default options value"] = function()
     eq_type_config(child, "buffers.wo", "table")
 
     eq_config(child, "buffers.setNames", false)
-    eq_config(child, "buffers.backgroundColor", "#000000")
+    eq_config(child, "buffers.colors.background", "#000000")
     eq_config(child, "buffers.blend", 0)
-    eq_config(child, "buffers.textColor", vim.NIL)
+    eq_config(child, "buffers.colors.text", vim.NIL)
 
     eq_config(child, "buffers.bo.filetype", "no-neck-pain")
     eq_config(child, "buffers.bo.buftype", "nofile")
@@ -95,9 +95,9 @@ T["setup"]["sets exposed methods and default options value"] = function()
         eq_type_config(child, "buffers." .. scope .. ".bo", "table")
         eq_type_config(child, "buffers." .. scope .. ".wo", "table")
 
-        eq_config(child, "buffers." .. scope .. ".backgroundColor", "#000000")
+        eq_config(child, "buffers." .. scope .. ".colors.background", "#000000")
         eq_config(child, "buffers." .. scope .. ".blend", 0)
-        eq_config(child, "buffers." .. scope .. ".textColor", "#7f7f7f")
+        eq_config(child, "buffers." .. scope .. ".colors.text", "#7f7f7f")
 
         eq_config(child, "buffers." .. scope .. ".bo.filetype", "no-neck-pain")
         eq_config(child, "buffers." .. scope .. ".bo.buftype", "nofile")

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -53,7 +53,7 @@ T["setup"]["overrides default values"] = function()
 
     for _, scope in pairs(Co.SIDES) do
         eq_config(child, "buffers." .. scope .. ".colors.background", "#595c6b")
-        eq_config(child, "buffers." .. scope .. ".blend", 0.2)
+        eq_config(child, "buffers." .. scope .. ".colors.blend", 0.2)
         eq_config(child, "buffers." .. scope .. ".colors.text", "#7480c2")
     end
 end

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -25,24 +25,30 @@ T["setup"]["overrides default values"] = function()
     ]])
     child.lua([[require('no-neck-pain').setup({
         buffers = {
-            colors.background = "catppuccin-frappe",
-            blend = 0.4,
-            colors.text = "#7480c2",
+            colors = {
+                background = "catppuccin-frappe",
+                blend = 0.4,
+                text = "#7480c2",
+            }
             left = {
-                colors.background = "catppuccin-frappe",
-                blend = 0.2,
-            	colors.text = "#7480c2",
+                colors = {
+                    background = "catppuccin-frappe",
+                    blend = 0.2,
+            	    text = "#7480c2",
+                }
             },
             right = {
-                colors.background = "catppuccin-frappe",
-                blend = 0.2,
-            	colors.text = "#7480c2",
+                colors = {
+                    background = "catppuccin-frappe",
+                    blend = 0.2,
+            	    text = "#7480c2",
+                },
             },
         },
     })]])
 
     eq_config(child, "buffers.colors.background", "#828590")
-    eq_config(child, "buffers.blend", 0.4)
+    eq_config(child, "buffers.colors.blend", 0.4)
     eq_config(child, "buffers.colors.text", "#7480c2")
 
     for _, scope in pairs(Co.SIDES) do
@@ -59,31 +65,37 @@ T["setup"]["`left` or `right` buffer options overrides `common` ones"] = functio
     ]])
     child.lua([[require('no-neck-pain').setup({
         buffers = {
-            colors.background = "catppuccin-frappe",
-            blend = 0.1,
-            colors.text = "#7480c2",
+            colors = {
+                background = "catppuccin-frappe",
+                blend = 0.1,
+                text = "#7480c2",
+            }
             left = {
-                colors.background = "catppuccin-frappe-dark",
-                blend = -0.8,
-                colors.text = "#123123",
+                colors = {
+                    background = "catppuccin-frappe-dark",
+                    blend = -0.8,
+                    text = "#123123",
+                }
             },
             right = {
-                colors.background = "catppuccin-latte",
-                blend = 1,
-                colors.text = "#456456",
+                colors = {
+                    background = "catppuccin-latte",
+                    blend = 1,
+                    text = "#456456",
+                },
             },
         },
     })]])
 
     eq_config(child, "buffers.colors.background", "#444858")
-    eq_config(child, "buffers.blend", 0.1)
+    eq_config(child, "buffers.colors.blend", 0.1)
     eq_config(child, "buffers.colors.text", "#7480c2")
 
     eq_config(child, "buffers.left.colors.background", "#08080b")
     eq_config(child, "buffers.right.colors.background", "#ffffff")
 
-    eq_config(child, "buffers.left.blend", -0.8)
-    eq_config(child, "buffers.right.blend", 1)
+    eq_config(child, "buffers.left.colors.blend", -0.8)
+    eq_config(child, "buffers.right.colors.blend", 1)
 
     eq_config(child, "buffers.left.colors.text", "#123123")
     eq_config(child, "buffers.right.colors.text", "#456456")
@@ -96,9 +108,11 @@ T["setup"]["`common` options spreads it to `left` and `right` buffers"] = functi
     ]])
     child.lua([[require('no-neck-pain').setup({
         buffers = {
-            colors.background = "catppuccin-frappe",
-            blend = 1,
-            colors.text = "#000000",
+            colors = {
+                background = "catppuccin-frappe",
+                blend = 1,
+                text = "#000000",
+            },
         },
     })]])
 
@@ -108,8 +122,8 @@ T["setup"]["`common` options spreads it to `left` and `right` buffers"] = functi
     eq_config(child, "buffers.left.colors.background", "#ffffff")
     eq_config(child, "buffers.right.colors.background", "#ffffff")
 
-    eq_config(child, "buffers.left.blend", 1)
-    eq_config(child, "buffers.right.blend", 1)
+    eq_config(child, "buffers.left.colors.blend", 1)
+    eq_config(child, "buffers.right.colors.blend", 1)
 
     eq_config(child, "buffers.left.colors.text", "#000000")
     eq_config(child, "buffers.right.colors.text", "#000000")
@@ -146,9 +160,11 @@ T["color"]["map integration name to a value"] = function()
         child.lua(string.format(
             [[ require('no-neck-pain').setup({
                 buffers = {
-                    colors.background = "%s",
-                    left = { colors.background = "%s" },
-                    right = { colors.background = "%s" },
+                    colors = {
+                        background = "%s",
+                        left = { colors = { background = "%s"} },
+                        right = { colors = { background = "%s"} },
+                    },
                 },
             })]],
             integration,
@@ -163,7 +179,7 @@ end
 
 T["color"]["buffers: throws with wrong values"] = function()
     local keyValueSetupErrors = {
-        { "colors.background", "no-neck-pain" },
+        { "background", "no-neck-pain" },
         { "blend", 30 },
     }
 
@@ -172,7 +188,9 @@ T["color"]["buffers: throws with wrong values"] = function()
             child.lua(string.format(
                 [[require('no-neck-pain').setup({
                     buffers = {
-                        %s = "%s",
+                        colors = {
+                            %s = "%s",
+                        },
                     },
                 })]],
                 keyValueSetupError[1],

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -29,13 +29,13 @@ T["setup"]["overrides default values"] = function()
                 background = "catppuccin-frappe",
                 blend = 0.4,
                 text = "#7480c2",
-            }
+            },
             left = {
                 colors = {
                     background = "catppuccin-frappe",
                     blend = 0.2,
             	    text = "#7480c2",
-                }
+                },
             },
             right = {
                 colors = {
@@ -69,13 +69,13 @@ T["setup"]["`left` or `right` buffer options overrides `common` ones"] = functio
                 background = "catppuccin-frappe",
                 blend = 0.1,
                 text = "#7480c2",
-            }
+            },
             left = {
                 colors = {
                     background = "catppuccin-frappe-dark",
                     blend = -0.8,
                     text = "#123123",
-                }
+                },
             },
             right = {
                 colors = {
@@ -142,7 +142,7 @@ T["setup"]["supports transparent bgs"] = function()
 end
 
 T["setup"]["colors.background overrides a nil background when defined"] = function()
-    child.lua([[require('no-neck-pain').setup({buffers={colors.background="#abcabc"}})]])
+    child.lua([[require('no-neck-pain').setup({buffers={colors={background="#abcabc"}}})]])
 
     eq_config(child, "buffers.colors.background", "#abcabc")
     eq_config(child, "buffers.colors.text", vim.NIL)
@@ -160,11 +160,9 @@ T["color"]["map integration name to a value"] = function()
         child.lua(string.format(
             [[ require('no-neck-pain').setup({
                 buffers = {
-                    colors = {
-                        background = "%s",
-                        left = { colors = { background = "%s"} },
-                        right = { colors = { background = "%s"} },
-                    },
+                    colors = { background = "%s" },
+                    left = { colors = { background = "%s" } },
+                    right = { colors = { background = "%s" } },
                 },
             })]],
             integration,
@@ -176,7 +174,7 @@ T["color"]["map integration name to a value"] = function()
         end
     end
 end
-
+--
 T["color"]["buffers: throws with wrong values"] = function()
     local keyValueSetupErrors = {
         { "background", "no-neck-pain" },

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -25,30 +25,30 @@ T["setup"]["overrides default values"] = function()
     ]])
     child.lua([[require('no-neck-pain').setup({
         buffers = {
-            backgroundColor = "catppuccin-frappe",
+            colors.background = "catppuccin-frappe",
             blend = 0.4,
-            textColor = "#7480c2",
+            colors.text = "#7480c2",
             left = {
-                backgroundColor = "catppuccin-frappe",
+                colors.background = "catppuccin-frappe",
                 blend = 0.2,
-            	textColor = "#7480c2",
+            	colors.text = "#7480c2",
             },
             right = {
-                backgroundColor = "catppuccin-frappe",
+                colors.background = "catppuccin-frappe",
                 blend = 0.2,
-            	textColor = "#7480c2",
+            	colors.text = "#7480c2",
             },
         },
     })]])
 
-    eq_config(child, "buffers.backgroundColor", "#828590")
+    eq_config(child, "buffers.colors.background", "#828590")
     eq_config(child, "buffers.blend", 0.4)
-    eq_config(child, "buffers.textColor", "#7480c2")
+    eq_config(child, "buffers.colors.text", "#7480c2")
 
     for _, scope in pairs(Co.SIDES) do
-        eq_config(child, "buffers." .. scope .. ".backgroundColor", "#595c6b")
+        eq_config(child, "buffers." .. scope .. ".colors.background", "#595c6b")
         eq_config(child, "buffers." .. scope .. ".blend", 0.2)
-        eq_config(child, "buffers." .. scope .. ".textColor", "#7480c2")
+        eq_config(child, "buffers." .. scope .. ".colors.text", "#7480c2")
     end
 end
 
@@ -59,34 +59,34 @@ T["setup"]["`left` or `right` buffer options overrides `common` ones"] = functio
     ]])
     child.lua([[require('no-neck-pain').setup({
         buffers = {
-            backgroundColor = "catppuccin-frappe",
+            colors.background = "catppuccin-frappe",
             blend = 0.1,
-            textColor = "#7480c2",
+            colors.text = "#7480c2",
             left = {
-                backgroundColor = "catppuccin-frappe-dark",
+                colors.background = "catppuccin-frappe-dark",
                 blend = -0.8,
-                textColor = "#123123",
+                colors.text = "#123123",
             },
             right = {
-                backgroundColor = "catppuccin-latte",
+                colors.background = "catppuccin-latte",
                 blend = 1,
-                textColor = "#456456",
+                colors.text = "#456456",
             },
         },
     })]])
 
-    eq_config(child, "buffers.backgroundColor", "#444858")
+    eq_config(child, "buffers.colors.background", "#444858")
     eq_config(child, "buffers.blend", 0.1)
-    eq_config(child, "buffers.textColor", "#7480c2")
+    eq_config(child, "buffers.colors.text", "#7480c2")
 
-    eq_config(child, "buffers.left.backgroundColor", "#08080b")
-    eq_config(child, "buffers.right.backgroundColor", "#ffffff")
+    eq_config(child, "buffers.left.colors.background", "#08080b")
+    eq_config(child, "buffers.right.colors.background", "#ffffff")
 
     eq_config(child, "buffers.left.blend", -0.8)
     eq_config(child, "buffers.right.blend", 1)
 
-    eq_config(child, "buffers.left.textColor", "#123123")
-    eq_config(child, "buffers.right.textColor", "#456456")
+    eq_config(child, "buffers.left.colors.text", "#123123")
+    eq_config(child, "buffers.right.colors.text", "#456456")
 end
 
 T["setup"]["`common` options spreads it to `left` and `right` buffers"] = function()
@@ -96,46 +96,46 @@ T["setup"]["`common` options spreads it to `left` and `right` buffers"] = functi
     ]])
     child.lua([[require('no-neck-pain').setup({
         buffers = {
-            backgroundColor = "catppuccin-frappe",
+            colors.background = "catppuccin-frappe",
             blend = 1,
-            textColor = "#000000",
+            colors.text = "#000000",
         },
     })]])
 
-    eq_config(child, "buffers.backgroundColor", "#ffffff")
-    eq_config(child, "buffers.textColor", "#000000")
+    eq_config(child, "buffers.colors.background", "#ffffff")
+    eq_config(child, "buffers.colors.text", "#000000")
 
-    eq_config(child, "buffers.left.backgroundColor", "#ffffff")
-    eq_config(child, "buffers.right.backgroundColor", "#ffffff")
+    eq_config(child, "buffers.left.colors.background", "#ffffff")
+    eq_config(child, "buffers.right.colors.background", "#ffffff")
 
     eq_config(child, "buffers.left.blend", 1)
     eq_config(child, "buffers.right.blend", 1)
 
-    eq_config(child, "buffers.left.textColor", "#000000")
-    eq_config(child, "buffers.right.textColor", "#000000")
+    eq_config(child, "buffers.left.colors.text", "#000000")
+    eq_config(child, "buffers.right.colors.text", "#000000")
 end
 
 T["setup"]["supports transparent bgs"] = function()
     child.lua([[require('no-neck-pain').setup()]])
 
-    eq_config(child, "buffers.backgroundColor", "NONE")
-    eq_config(child, "buffers.textColor", "#ffffff")
+    eq_config(child, "buffers.colors.background", "NONE")
+    eq_config(child, "buffers.colors.text", "#ffffff")
 
     for _, scope in pairs(Co.SIDES) do
-        eq_config(child, "buffers." .. scope .. ".backgroundColor", "NONE")
-        eq_config(child, "buffers." .. scope .. ".textColor", "#ffffff")
+        eq_config(child, "buffers." .. scope .. ".colors.background", "NONE")
+        eq_config(child, "buffers." .. scope .. ".colors.text", "#ffffff")
     end
 end
 
-T["setup"]["backgroundColor overrides a nil background when defined"] = function()
-    child.lua([[require('no-neck-pain').setup({buffers={backgroundColor="#abcabc"}})]])
+T["setup"]["colors.background overrides a nil background when defined"] = function()
+    child.lua([[require('no-neck-pain').setup({buffers={colors.background="#abcabc"}})]])
 
-    eq_config(child, "buffers.backgroundColor", "#abcabc")
-    eq_config(child, "buffers.textColor", vim.NIL)
+    eq_config(child, "buffers.colors.background", "#abcabc")
+    eq_config(child, "buffers.colors.text", vim.NIL)
 
     for _, scope in pairs(Co.SIDES) do
-        eq_config(child, "buffers." .. scope .. ".backgroundColor", "#abcabc")
-        eq_config(child, "buffers." .. scope .. ".textColor", "#d5e4dd")
+        eq_config(child, "buffers." .. scope .. ".colors.background", "#abcabc")
+        eq_config(child, "buffers." .. scope .. ".colors.text", "#d5e4dd")
     end
 end
 
@@ -146,9 +146,9 @@ T["color"]["map integration name to a value"] = function()
         child.lua(string.format(
             [[ require('no-neck-pain').setup({
                 buffers = {
-                    backgroundColor = "%s",
-                    left = { backgroundColor = "%s" },
-                    right = { backgroundColor = "%s" },
+                    colors.background = "%s",
+                    left = { colors.background = "%s" },
+                    right = { colors.background = "%s" },
                 },
             })]],
             integration,
@@ -156,14 +156,14 @@ T["color"]["map integration name to a value"] = function()
             integration
         ))
         for _, scope in pairs(Co.SIDES) do
-            eq_config(child, "buffers." .. scope .. ".backgroundColor", value)
+            eq_config(child, "buffers." .. scope .. ".colors.background", value)
         end
     end
 end
 
 T["color"]["buffers: throws with wrong values"] = function()
     local keyValueSetupErrors = {
-        { "backgroundColor", "no-neck-pain" },
+        { "colors.background", "no-neck-pain" },
         { "blend", 30 },
     }
 

--- a/tests/test_mapping.lua
+++ b/tests/test_mapping.lua
@@ -1,16 +1,8 @@
-local Co = require("no-neck-pain.util.constants")
 local helpers = dofile("tests/helpers.lua")
 
 local child = helpers.new_child_neovim()
-local eq, eq_global, eq_config, eq_state =
-    helpers.expect.equality,
-    helpers.expect.global_equality,
-    helpers.expect.config_equality,
-    helpers.expect.state_equality
-local eq_type_global, eq_type_config, eq_type_state =
-    helpers.expect.global_type_equality,
-    helpers.expect.config_type_equality,
-    helpers.expect.state_type_equality
+local eq, eq_global, eq_config =
+    helpers.expect.equality, helpers.expect.global_equality, helpers.expect.config_equality
 
 local T = MiniTest.new_set({
     hooks = {
@@ -28,19 +20,23 @@ T["setup"] = MiniTest.new_set()
 
 T["setup"]["overrides default values"] = function()
     child.lua([[require('no-neck-pain').setup({
-        toggleMapping = "<Leader>kz",
-        widthUpMapping = "<Leader>k-",
-        widthDownMapping = "<Leader>k=",
+        mappings = {
+            enabled = true,
+            toggle = "<Leader>kz",
+            widthUp = "<Leader>k-",
+            widthDown = "<Leader>k=",
+        }
     })]])
 
-    eq_config(child, "toggleMapping", "<Leader>kz")
-    eq_config(child, "widthUpMapping", "<Leader>k-")
-    eq_config(child, "widthDownMapping", "<Leader>k=")
+    eq_config(child, "mappings.enabled", true)
+    eq_config(child, "mappings.toggle", "<Leader>kz")
+    eq_config(child, "mappings.widthUp", "<Leader>k-")
+    eq_config(child, "mappings.widthDown", "<Leader>k=")
 end
 
 T["setup"]["increase the width with mapping"] = function()
     child.lua([[
-        require('no-neck-pain').setup({width=50,widthUpMapping="nn"})
+        require('no-neck-pain').setup({width=50,mappings={widthUp="nn"}})
         require('no-neck-pain').enable()
     ]])
 
@@ -60,7 +56,7 @@ end
 
 T["setup"]["decrease the width with mapping"] = function()
     child.lua([[
-        require('no-neck-pain').setup({width=50,widthDownMapping="nn"})
+        require('no-neck-pain').setup({width=50,mappings={widthDown="nn"}})
         require('no-neck-pain').enable()
     ]])
 

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -1,9 +1,7 @@
 local helpers = dofile("tests/helpers.lua")
 
 local child = helpers.new_child_neovim()
-local eq, eq_config =
-    helpers.expect.equality,
-    helpers.expect.config_equality
+local eq, eq_config = helpers.expect.equality, helpers.expect.config_equality
 
 local T = MiniTest.new_set({
     hooks = {

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -66,47 +66,47 @@ T["scratchPad"]["default to `norg` fileType"] = function()
     )
 end
 
--- T["scratchPad"]["override to md is reflected to the buffer"] = function()
---     child.lua([[require('no-neck-pain').setup({
---         width = 50,
---         buffers = {
---             scratchPad = {
---                 enabled = true
---             },
---             left = {
---                 bo = {
---                     filetype = "md",
---                 },
---             },
---             right = {
---                 bo = {
---                     filetype = "txt",
---                 }
---             }
---         },
---     })]])
---     child.lua([[require('no-neck-pain').enable()]])
---
---     eq(
---         child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
---         { 1001, 1000, 1002 }
---     )
---
---     local cwd = child.lua_get("vim.fn.getcwd()")
---     local left = cwd .. "/no-neck-pain-left.md"
---     local right = cwd .. "/no-neck-pain-right.txt"
---
---     eq(child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1001))"), left)
---     eq(
---         child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1001), 'buflisted')"),
---         false
---     )
---
---     eq(child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1002))"), right)
---     eq(
---         child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1002), 'buflisted')"),
---         false
---     )
--- end
+T["scratchPad"]["override to md is reflected to the buffer"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        width = 50,
+        buffers = {
+            scratchPad = {
+                enabled = true
+            },
+            left = {
+                bo = {
+                    filetype = "md",
+                },
+            },
+            right = {
+                bo = {
+                    filetype = "txt",
+                }
+            }
+        },
+    })]])
+    child.lua([[require('no-neck-pain').enable()]])
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1001, 1000, 1002 }
+    )
+
+    local cwd = child.lua_get("vim.fn.getcwd()")
+    local left = cwd .. "/no-neck-pain-left.md"
+    local right = cwd .. "/no-neck-pain-right.txt"
+
+    eq(child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1001))"), left)
+    eq(
+        child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1001), 'buflisted')"),
+        false
+    )
+
+    eq(child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1002))"), right)
+    eq(
+        child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1002), 'buflisted')"),
+        false
+    )
+end
 
 return T

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -1,15 +1,9 @@
 local helpers = dofile("tests/helpers.lua")
 
 local child = helpers.new_child_neovim()
-local eq, eq_global, eq_config, eq_state =
+local eq, eq_config =
     helpers.expect.equality,
-    helpers.expect.global_equality,
-    helpers.expect.config_equality,
-    helpers.expect.state_equality
-local eq_type_global, eq_type_config, eq_type_state =
-    helpers.expect.global_type_equality,
-    helpers.expect.config_type_equality,
-    helpers.expect.state_type_equality
+    helpers.expect.config_equality
 
 local T = MiniTest.new_set({
     hooks = {
@@ -74,47 +68,47 @@ T["scratchPad"]["default to `norg` fileType"] = function()
     )
 end
 
-T["scratchPad"]["override to md is reflected to the buffer"] = function()
-    child.lua([[require('no-neck-pain').setup({
-        width = 50,
-        buffers = {
-            scratchPad = {
-                enabled = true
-            },
-            left = {
-                bo = {
-                    filetype = "md",
-                },
-            },
-            right = {
-                bo = {
-                    filetype = "txt",
-                }
-            }
-        },
-    })]])
-    child.lua([[require('no-neck-pain').enable()]])
-
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
-
-    local cwd = child.lua_get("vim.fn.getcwd()")
-    local left = cwd .. "/no-neck-pain-left.md"
-    local right = cwd .. "/no-neck-pain-right.txt"
-
-    eq(child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1001))"), left)
-    eq(
-        child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1001), 'buflisted')"),
-        false
-    )
-
-    eq(child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1002))"), right)
-    eq(
-        child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1002), 'buflisted')"),
-        false
-    )
-end
+-- T["scratchPad"]["override to md is reflected to the buffer"] = function()
+--     child.lua([[require('no-neck-pain').setup({
+--         width = 50,
+--         buffers = {
+--             scratchPad = {
+--                 enabled = true
+--             },
+--             left = {
+--                 bo = {
+--                     filetype = "md",
+--                 },
+--             },
+--             right = {
+--                 bo = {
+--                     filetype = "txt",
+--                 }
+--             }
+--         },
+--     })]])
+--     child.lua([[require('no-neck-pain').enable()]])
+--
+--     eq(
+--         child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+--         { 1001, 1000, 1002 }
+--     )
+--
+--     local cwd = child.lua_get("vim.fn.getcwd()")
+--     local left = cwd .. "/no-neck-pain-left.md"
+--     local right = cwd .. "/no-neck-pain-right.txt"
+--
+--     eq(child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1001))"), left)
+--     eq(
+--         child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1001), 'buflisted')"),
+--         false
+--     )
+--
+--     eq(child.lua_get("vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(1002))"), right)
+--     eq(
+--         child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1002), 'buflisted')"),
+--         false
+--     )
+-- end
 
 return T


### PR DESCRIPTION
## 📃 Summary

This PR introduces the v1.0.0 of the plugin, which comes with several breaking changes at the API level.

The plugin evolved fast but some part of the API are not extensible enough to continue the iteration, this much needed breaking change allow future features to be added without having to break the it again.

------

### Breaking changes

|   Before   |         After        |
|-------------|----------------------------|
|`enableOnVimEnter`|`autocmds.enableOnVimEnter`|
|`enableOnTabEnter`|`autocmds.enableOnTabEnter`|
|`toggleMapping`|`mappings.toggle`|
|`widthUpMapping`|`mappings.widthUp`|
|`widthDownMapping`|`mappings.widthDown`|
|`backgroundColor`|`colors.background`|
|`textColor`|`colors.text`|
|`blend`|`colors.blend`|
|`left.backgroundColor`|`left.colors.background`|
|`left.textColor`|`left.colors.text`|
|`left.blend`|`left.colors.blend`|
|`right.backgroundColor`|`right.colors.background`|
|`right.textColor`|`right.colors.text`|
|`right.blend`|`right.colors.blend`|

------

- [x] add warning for all the following deprecation changes
- [x] group all `mappings` under a dedicated object
  - [x] disable `mappings` by default to prevent impacting other users workflow
  - [x] set default values when `enabled`
- [x] group all `colors` under a dedicated object
  - [x] global to both buffers
  - [x] for each side buffer
- [x] group all `autocmds` under a dedicated object
- [x] more documentation with type definitions
- [x] ensure all tests passes
- [x] update README.md