### PR TITLE
fix: side trees infinite polling

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -256,25 +256,42 @@ function N.enable(scope)
                     return
                 end
 
-                local wins, _ = W.winsExceptState(tab, false)
+                local fileType = vim.api.nvim_buf_get_option(0, "filetype")
+
+                -- We can skip enter hooks that are not on a side tree
+                if p.event == "WinEnter" and not T.isSideTree(fileType) then
+                    D.log(p.event, "skipping %s, not a side tree", fileType)
+
+                    return
+                end
+
+                -- if a buffer have been closed but we don't have trees in the state
+                if
+                    p.event == "WinClosed"
+                    and vim.tbl_count(W.mergeState(nil, nil, tab.wins.external.trees)) == 0
+                then
+                    D.log(p.event, "skipping tree event, no trees in state")
+
+                    return
+                end
+
                 local trees = T.refresh(tab)
+                local treesIDs = W.mergeState(nil, nil, trees)
 
                 -- we cycle over supported integrations to see which got closed or opened
                 for name, tree in pairs(tab.wins.external.trees) do
-                    -- if there was a tree[name] but not anymore, we resize
-                    if tree.id ~= nil and not vim.tbl_contains(wins, tree.id) then
-                        D.log(p.event, "%s have been closed, resizing", name)
+                    if
+                        -- if we have an id in the state but it's not active anymore
+                        (tree.id ~= nil and not vim.tbl_contains(treesIDs, tree.id))
+                        -- we have a new tree registered, we can resize
+                        or (
+                            trees[name].id ~= nil
+                            and trees[name].id ~= tab.wins.external.trees[name].id
+                        )
+                    then
+                        D.log(p.event, "%s have changed, resizing", name)
 
-                        S = N.init(p.event, tab)
-
-                        return
-                    end
-
-                    -- we have a new tree registered, we can resize
-                    if trees[name].id ~= tab.wins.external.trees[name].id then
-                        D.log(p.event, "%s have been opened, resizing", name)
-
-                        S = N.init(p.event, tab)
+                        S.tabs = Ta.update(S.tabs, tab.id, W.createSideBuffers(tab, true))
 
                         return
                     end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -284,10 +284,7 @@ function N.enable(scope)
                         -- if we have an id in the state but it's not active anymore
                         (tree.id ~= nil and not vim.tbl_contains(treesIDs, tree.id))
                         -- we have a new tree registered, we can resize
-                        or (
-                            trees[name].id ~= nil
-                            and trees[name].id ~= tab.wins.external.trees[name].id
-                        )
+                        or (trees[name].id ~= nil and trees[name].id ~= tree.id)
                     then
                         D.log(p.event, "%s have changed, resizing", name)
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -51,7 +51,7 @@ end
 
 --- Creates side buffers and set the tab state, focuses the `curr` window if required.
 ---@private
-function N.init(scope, tab, goToCurr)
+function N.init(scope, tab, goToCurr, skipTrees)
     if tab == nil then
         tab = Ta.get(S.tabs)
 
@@ -71,7 +71,7 @@ function N.init(scope, tab, goToCurr)
         hadSideBuffers = false
     end
 
-    tab = W.createSideBuffers(tab)
+    tab = W.createSideBuffers(tab, skipTrees)
 
     if
         goToCurr
@@ -288,7 +288,7 @@ function N.enable(scope)
                     then
                         D.log(p.event, "%s have changed, resizing", name)
 
-                        S.tabs = Ta.update(S.tabs, tab.id, W.createSideBuffers(tab, true))
+                        S = N.init(p.event, tab, false, true)
 
                         return
                     end

--- a/lua/no-neck-pain/trees.lua
+++ b/lua/no-neck-pain/trees.lua
@@ -47,6 +47,11 @@ function T.refresh(tab)
     for _, win in pairs(wins) do
         local fileType = vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(win), "filetype")
         if T.isSideTree(fileType) then
+            -- NeoTree filetype is cased differently than the plugin name
+            if fileType == "neo-tree" then
+                fileType = "NeoTree"
+            end
+
             trees[fileType] = {
                 id = win,
                 width = vim.api.nvim_win_get_width(win) * 2,

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -100,9 +100,10 @@ end
 --- - If it already exists, we resize it.
 ---
 ---@param tab table: the table where the tab information are stored.
+---@param skipTrees boolean?: skip trees action when true.
 ---@return table: the updated tab.
 ---@private
-function W.createSideBuffers(tab)
+function W.createSideBuffers(tab, skipTrees)
     -- before creating side buffers, we determine if we should consider externals
     tab.wins.external.trees = T.refresh(tab)
 
@@ -111,7 +112,11 @@ function W.createSideBuffers(tab)
         right = { cmd = "botright vnew", padding = 0 },
     }
 
-    local integrations = T.close(tab)
+    local integrations = nil
+
+    if not skipTrees then
+        integrations = T.close(tab)
+    end
 
     for _, side in pairs(Co.SIDES) do
         if _G.NoNeckPain.config.buffers[side].enabled then
@@ -155,7 +160,9 @@ function W.createSideBuffers(tab)
         end
     end
 
-    T.reopen(integrations)
+    if not skipTrees then
+        T.reopen(integrations)
+    end
 
     tab.wins.main.left, tab.wins.main.right =
         W.resizeOrCloseSideBuffers("W.createSideBuffers", tab.wins, wins)
@@ -311,16 +318,18 @@ end
 
 ---Merges the state windows in a single table containing all of their IDs.
 ---
----@param main table: the `main` window state.
----@param splits table: the `splits` window state.
+---@param main table?: the `main` window state.
+---@param splits table?: the `splits` window state.
 ---@param trees table?: the `external.trees` window state.
 ---@return table: the state window IDs.
 ---@private
 function W.mergeState(main, splits, trees)
     local wins = {}
 
-    for _, side in pairs(main) do
-        table.insert(wins, side)
+    if main ~= nil then
+        for _, side in pairs(main) do
+            table.insert(wins, side)
+        end
     end
 
     if splits ~= nil then


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/191

This PR kind of fixes all integrations, where we were constantly polling for side trees which could lead to performance issues (maybe contributes to https://github.com/shortcuts/no-neck-pain.nvim/issues/171)

NeoTree in particular was broken due to the filetype having a different name than the integration, which led to non-registered windows, and therefore wrongly sized buffers (see closes https://github.com/shortcuts/no-neck-pain.nvim/issues/191)
