### PR TITLE
fix: leverage new Neotree commands

### DIFF
--- a/lua/no-neck-pain/trees.lua
+++ b/lua/no-neck-pain/trees.lua
@@ -8,8 +8,8 @@ local INTEGRATIONS = {
     },
     NeoTree = {
         enabled = false,
-        close = "NeoTreeClose",
-        open = "NeoTreeReveal",
+        close = "Neotree close",
+        open = "Neotree reveal",
     },
 }
 


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/212

leverages new commands deprecated of outdated ones
