### PR TITLE
refactor: split/vsplit state manager and fix weird resizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ require("no-neck-pain").setup({
     -- This option can be useful when switching window size frequently, example:
     -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
     --- @type integer
-    minSideBufferWidth = 5,
+    minSideBufferWidth = 10,
     -- Disables the plugin if the last valid buffer in the list have been closed.
     --- @type boolean
     disableOnLastBuffer = false,

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -205,7 +205,7 @@ values:
       -- This option can be useful when switching window size frequently, example:
       -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
       --- @type integer
-      minSideBufferWidth = 5,
+      minSideBufferWidth = 10,
       -- Disables the plugin if the last valid buffer in the list have been closed.
       --- @type boolean
       disableOnLastBuffer = false,

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -170,7 +170,7 @@ NoNeckPain.options = {
     -- This option can be useful when switching window size frequently, example:
     -- in full screen screen, width is 210, you define an NNP `width` of 100, which creates each side buffer with a width of 50. If you resize your terminal to the half of the screen, each side buffer would be of width 5 and thereforce might not be useful and/or add "noise" to your workflow.
     --- @type integer
-    minSideBufferWidth = 5,
+    minSideBufferWidth = 10,
     -- Disables the plugin if the last valid buffer in the list have been closed.
     --- @type boolean
     disableOnLastBuffer = false,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -111,7 +111,7 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "VimResized" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(tab, false) then
+                if E.skip(tab) then
                     return
                 end
 
@@ -135,7 +135,7 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "WinEnter" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(tab, false) then
+                if E.skip(tab) then
                     return
                 end
 
@@ -174,7 +174,7 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "QuitPre", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(nil, false) then
+                if E.skip(nil) then
                     return
                 end
 
@@ -208,7 +208,7 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(nil, false) or tab.wins.splits == nil or W.stateWinsActive(tab, true) then
+                if E.skip(nil) or tab.wins.splits == nil or W.stateWinsActive(tab, true) then
                     return
                 end
 
@@ -256,7 +256,7 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "WinEnter", "WinClosed" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(tab, false) then
+                if E.skip(tab) then
                     return
                 end
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -74,6 +74,7 @@ function N.init(scope, tab, goToCurr, skipTrees)
     if
         goToCurr
         or (not hadSideBuffers and (not A.sideNil(tab, "left") or not A.sideNil(tab, "right")))
+        or (A.isCurrentWin(tab.wins.main.left) or A.isCurrentWin(tab.wins.main.right))
     then
         vim.fn.win_gotoid(tab.wins.main.curr)
     end
@@ -326,7 +327,7 @@ function N.disable(scope)
     if
         tab.wins.main.curr ~= nil
         and vim.api.nvim_win_is_valid(tab.wins.main.curr)
-        and tab.wins.main.curr ~= vim.api.nvim_get_current_win()
+        and not A.isCurrentWin(tab.wins.main.curr)
     then
         vim.fn.win_gotoid(tab.wins.main.curr)
 

--- a/lua/no-neck-pain/splits.lua
+++ b/lua/no-neck-pain/splits.lua
@@ -51,6 +51,8 @@ function Sp.compute(tab, focusedWin)
     local fWidth, fHeight = A.getWidthAndHeight(focusedWin)
     local isVSplit = true
 
+    D.tprint(tab.layers)
+
     local splitInF = math.floor(sHeight / fHeight)
     if splitInF < 1 then
         splitInF = 1
@@ -68,6 +70,8 @@ function Sp.compute(tab, focusedWin)
     if vsplitInF > tab.layers.vsplit then
         isVSplit = true
     end
+
+    print("00000000000000000", sWidth, sHeight, fWidth, fHeight)
 
     -- update anyway because we want state consistency
     tab.layers.split = splitInF
@@ -94,10 +98,18 @@ function Sp.decreaseLayers(layers, isVSplit)
     if isVSplit then
         layers.vsplit = layers.vsplit - 1
 
+        if layers.vsplit < 1 then
+            layers.vsplit = 1
+        end
+
         return layers
     end
 
     layers.split = layers.split - 1
+
+    if layers.split < 1 then
+        layers.split = 1
+    end
 
     return layers
 end

--- a/lua/no-neck-pain/splits.lua
+++ b/lua/no-neck-pain/splits.lua
@@ -45,8 +45,15 @@ end
 ---@private
 function Sp.compute(tab, focusedWin)
     local side = tab.wins.main.left or tab.wins.main.right
-    local sWidth, sHeight = A.getWidthAndHeight(side)
-    sWidth = vim.api.nvim_list_uis()[1].width - sWidth
+    local sWidth, sHeight = 0, 0
+
+    if side ~= nil then
+        sWidth, sHeight = A.getWidthAndHeight(side)
+        sWidth = vim.api.nvim_list_uis()[1].width - sWidth
+    else
+        sWidth = vim.api.nvim_list_uis()[1].width
+        sHeight = vim.api.nvim_list_uis()[1].height
+    end
 
     D.tprint(tab)
 
@@ -59,20 +66,20 @@ function Sp.compute(tab, focusedWin)
         splitInF = 1
     end
 
-    if splitInF ~= tab.layers.split then
-        tab.layers.split = splitInF
+    if splitInF > tab.layers.split then
         isVSplit = false
     end
+    tab.layers.split = splitInF
 
     local vsplitInF = math.floor(sWidth / fWidth)
     if vsplitInF < 1 then
         vsplitInF = 1
     end
 
-    if vsplitInF ~= tab.layers.vsplit then
-        tab.layers.vsplit = vsplitInF
+    if vsplitInF > tab.layers.vsplit then
         isVSplit = true
     end
+    tab.layers.vsplit = vsplitInF
 
     D.log(
         "Sp.compute",
@@ -87,6 +94,24 @@ function Sp.compute(tab, focusedWin)
     )
 
     return tab, isVSplit
+end
+
+---Decreases the layers state values.
+---
+---@param layers table: the layers state.
+---@param isVSplit boolean: whether the window is a vsplit or not.
+---@return table: the updated layers state.
+---@private
+function Sp.decreaseLayers(layers, isVSplit)
+    if isVSplit then
+        layers.vsplit = layers.vsplit - 1
+
+        return layers
+    end
+
+    layers.split = layers.split - 1
+
+    return layers
 end
 
 return Sp

--- a/lua/no-neck-pain/splits.lua
+++ b/lua/no-neck-pain/splits.lua
@@ -48,14 +48,18 @@ function Sp.compute(tab, focusedWin)
     local sWidth, sHeight = 0, 0
 
     if side ~= nil then
+        local nbSide = 1
+
+        if tab.wins.main.left and tab.wins.main.right then
+            nbSide = 2
+        end
+
         sWidth, sHeight = A.getWidthAndHeight(side)
-        sWidth = vim.api.nvim_list_uis()[1].width - sWidth
+        sWidth = vim.api.nvim_list_uis()[1].width - sWidth * nbSide
     else
         sWidth = vim.api.nvim_list_uis()[1].width
         sHeight = vim.api.nvim_list_uis()[1].height
     end
-
-    D.tprint(tab)
 
     local fWidth, fHeight = A.getWidthAndHeight(focusedWin)
 

--- a/lua/no-neck-pain/splits.lua
+++ b/lua/no-neck-pain/splits.lua
@@ -51,8 +51,6 @@ function Sp.compute(tab, focusedWin)
     local fWidth, fHeight = A.getWidthAndHeight(focusedWin)
     local isVSplit = true
 
-    D.tprint(tab.layers)
-
     local splitInF = math.floor(sHeight / fHeight)
     if splitInF < 1 then
         splitInF = 1
@@ -70,8 +68,6 @@ function Sp.compute(tab, focusedWin)
     if vsplitInF > tab.layers.vsplit then
         isVSplit = true
     end
-
-    print("00000000000000000", sWidth, sHeight, fWidth, fHeight)
 
     -- update anyway because we want state consistency
     tab.layers.split = splitInF

--- a/lua/no-neck-pain/tabs.lua
+++ b/lua/no-neck-pain/tabs.lua
@@ -86,16 +86,14 @@ end
 ---@private
 function Ta.remove(tabs, id)
     local newTabs = {}
-    local total = 0
 
     for _, tab in pairs(tabs) do
         if tab.id ~= id then
             table.insert(newTabs, tab)
-            total = total + 1
         end
     end
 
-    if total == 0 then
+    if #newTabs == 0 then
         return nil
     end
 

--- a/lua/no-neck-pain/tabs.lua
+++ b/lua/no-neck-pain/tabs.lua
@@ -43,6 +43,10 @@ function Ta.insert(tabs, id)
         id = id,
         augroup = nil,
         scratchPadEnabled = false,
+        layers = {
+            vsplit = 1,
+            split = 1,
+        },
         wins = {
             main = {
                 curr = nil,

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -16,4 +16,24 @@ function A.getWidthAndHeight(win)
     return vim.api.nvim_win_get_width(win), vim.api.nvim_win_get_height(win)
 end
 
+---computes whether the "side" is defined and exists.
+---
+---@param tab table: the table where the tab information are stored.
+---@param side "left"|"right": the side of the window being resized.
+---@return boolean: whether the side exists or not.
+---@private
+function A.hasSide(tab, side)
+    return _G.NoNeckPain.config.buffers[side].enabled and tab.wins.main[side] ~= nil
+end
+
+---whether the side is nil or not.
+---
+---@param tab table: the table where the tab information are stored.
+---@param side "left"|"right": the side of the window being resized.
+---@return boolean: whether the side nil or not.
+---@private
+function A.sideNil(tab, side)
+    return tab.wins.main[side] == nil
+end
+
 return A

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -1,0 +1,19 @@
+local A = {}
+
+---returns the width and height of a given window
+---
+---@param win number?: the win number, defaults to 0 if nil
+---@return number: the width of the window
+---@return number: the height of the window
+---@private
+function A.getWidthAndHeight(win)
+    win = win or 0
+
+    if win ~= 0 and not vim.api.nvim_win_is_valid(win) then
+        win = 0
+    end
+
+    return vim.api.nvim_win_get_width(win), vim.api.nvim_win_get_height(win)
+end
+
+return A

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -36,4 +36,12 @@ function A.sideNil(tab, side)
     return tab.wins.main[side] == nil
 end
 
+---whether the currently focused window is the provided one.
+---
+---@return boolean
+---@param win number?: the win number, defaults to 0 if nil
+function A.isCurrentWin(win)
+    return vim.api.nvim_get_current_win() == win
+end
+
 return A

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -11,14 +11,13 @@ local E = {}
 --- - we are focusing one of the side buffer
 ---
 ---@param tab table?: the table where the tab information are stored.
----@param skipSplit boolean: whether we should consider a relative window or not.
 ---@private
-function E.skip(tab, skipSplit)
+function E.skip(tab)
     if _G.NoNeckPain.state == nil or not _G.NoNeckPain.state.enabled then
         return true
     end
 
-    if skipSplit or W.isRelativeWindow() then
+    if W.isRelativeWindow() then
         return true
     end
 

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -1,3 +1,4 @@
+local A = require("no-neck-pain.util.api")
 local T = require("no-neck-pain.trees")
 local W = require("no-neck-pain.wins")
 
@@ -26,9 +27,7 @@ function E.skip(tab, skipSplit)
             return true
         end
 
-        local curr = vim.api.nvim_get_current_win()
-
-        if curr == tab.wins.main.left or curr == tab.wins.main.right then
+        if A.isCurrentWin(tab.wins.main.left) or A.isCurrentWin(tab.wins.main.right) then
             return true
         end
     end

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -106,7 +106,7 @@ end
 ---@private
 local function resizeOrCloseSideBuffers(scope, tab, paddings)
     for _, side in pairs(Co.SIDES) do
-        if tab.wins.main[side] ~= nil then
+        if not A.sideNil(tab, side) then
             local padding = paddings[side].padding or W.getPadding(side, tab)
 
             if padding > _G.NoNeckPain.config.minSideBufferWidth then
@@ -195,7 +195,7 @@ function W.createSideBuffers(tab, skipTrees)
 
     -- if we still have side buffers open at this point, and we have vsplit opened,
     -- there might be width issues so we the opened vsplits.
-    if (tab.wins.main.left ~= nil or tab.wins.main.right ~= nil) and tab.wins.splits ~= nil then
+    if (not A.sideNil(tab, "left") or not A.sideNil(tab, "right")) and tab.wins.splits ~= nil then
         local side = tab.wins.main.left or tab.wins.main.right
         local sWidth, _ = A.getWidthAndHeight(side)
         local nbSide = 1

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -1,3 +1,4 @@
+local A = require("no-neck-pain.util.api")
 local C = require("no-neck-pain.colors")
 local Co = require("no-neck-pain.util.constants")
 local D = require("no-neck-pain.util.debug")
@@ -195,9 +196,21 @@ function W.createSideBuffers(tab, skipTrees)
     -- if we still have side buffers open at this point, and we have vsplit opened,
     -- there might be width issues so we the opened vsplits.
     if (tab.wins.main.left ~= nil or tab.wins.main.right ~= nil) and tab.wins.splits ~= nil then
+        local side = tab.wins.main.left or tab.wins.main.right
+        local sWidth, _ = A.getWidthAndHeight(side)
+        local nbSide = 1
+
+        if tab.wins.main.left or tab.wins.main.right then
+            nbSide = 2
+        end
+
+        -- get the available usable width (screen size without side paddings)
+        sWidth = vim.api.nvim_list_uis()[1].width - sWidth * nbSide
+        sWidth = sWidth / tab.layers.vsplit
+
         for _, split in pairs(tab.wins.splits) do
             if split.vertical then
-                resize(split.id, _G.NoNeckPain.config.width, "split")
+                resize(split.id, sWidth, "split")
             end
         end
     end

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -200,13 +200,13 @@ function W.createSideBuffers(tab, skipTrees)
         local sWidth, _ = A.getWidthAndHeight(side)
         local nbSide = 1
 
-        if tab.wins.main.left or tab.wins.main.right then
+        if tab.wins.main.left and tab.wins.main.right then
             nbSide = 2
         end
 
         -- get the available usable width (screen size without side paddings)
         sWidth = vim.api.nvim_list_uis()[1].width - sWidth * nbSide
-        sWidth = sWidth / tab.layers.vsplit
+        sWidth = math.floor(sWidth / tab.layers.vsplit)
 
         for _, split in pairs(tab.wins.splits) do
             if split.vertical then

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -54,7 +54,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
     eq_type_config(child, "buffers", "table")
 
     eq_config(child, "width", 100)
-    eq_config(child, "minSideBufferWidth", 5)
+    eq_config(child, "minSideBufferWidth", 10)
 
     eq_config(child, "autocmds.enableOnVimEnter", false)
     eq_config(child, "autocmds.enableOnTabEnter", false)

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -153,6 +153,28 @@ T["vsplit"]["does not create side buffers when there's not enough space"] = func
     )
 end
 
+T["vsplit"]["corretly size splits when opening helper with side buffers open"] = function()
+    child.set_size(150,150)
+    child.lua([[
+        require('no-neck-pain').setup({width=50})
+        require('no-neck-pain').enable()
+    ]])
+
+    child.cmd("vsplit")
+
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1001, 1003, 1000, 1002 })
+
+    eq_buf_width(child, "tabs[1].wins.splits[1].id", 50)
+    eq_buf_width(child, "tabs[1].wins.main.curr", 67)
+
+    child.cmd("h")
+
+    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1004, 1001, 1003, 1000, 1002 })
+
+    eq_buf_width(child, "tabs[1].wins.splits[1].id", 50)
+    eq_buf_width(child, "tabs[1].wins.main.curr", 67)
+end
+
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
     child.set_size(500, 500)
     child.cmd("vsplit")

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -154,7 +154,7 @@ T["vsplit"]["does not create side buffers when there's not enough space"] = func
 end
 
 T["vsplit"]["corretly size splits when opening helper with side buffers open"] = function()
-    child.set_size(150,150)
+    child.set_size(150, 150)
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -375,4 +375,35 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
 end
 
+T["vsplit/split"]["closing help page doens't break layout"] = function()
+    child.lua([[
+        require('no-neck-pain').setup({width=50})
+        require('no-neck-pain').enable() 
+    ]])
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1001, 1000, 1002 }
+    )
+
+    child.cmd("split")
+    child.cmd("h")
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1004, 1001, 1003, 1000, 1002 }
+    )
+
+    eq_buf_width(child, "tabs[1].wins.main.curr", 48)
+
+    child.cmd("q")
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1001, 1003, 1000, 1002 }
+    )
+
+    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
+
+    eq_buf_width(child, "tabs[1].wins.main.curr", 48)
+end
+
 return T

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -278,7 +278,7 @@ T["vsplit"]["many vsplit leave side buffers open as long as there's space for it
 end
 
 T["vsplit"]["keeps correct focus"] = function()
-    child.set_size(400, 400)
+    child.set_size(500, 500)
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
@@ -294,6 +294,11 @@ T["vsplit"]["keeps correct focus"] = function()
 
     child.cmd("vsplit")
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1005)
+
+    eq(
+        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
+        { 1001, 1005, 1004, 1003, 1000, 1002 }
+    )
 
     child.cmd("q")
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1004)
@@ -341,7 +346,7 @@ T["vsplit/split"]["state is correctly sync'd even after many changes"] = functio
 end
 
 T["vsplit/split"]["closing side buffers because of splits restores focus"] = function()
-    child.set_size(150, 150)
+    child.set_size(200, 200)
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable() 


### PR DESCRIPTION
## 📃 Summary

This PR aims at fixing some wrongly resized vsplit panes with side buffers open. It also makes the state much more consistent, same as determining which kind of split action have been done.
