### PR TITLE
fix: register unfocused splits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ test:
 deps:
 	@mkdir -p deps
 	git clone --depth 1 https://github.com/echasnovski/mini.nvim deps/mini.nvim
+	git clone --depth 1 https://github.com/nvim-treesitter/nvim-treesitter deps/nvim-treesitter
+	git clone --depth 1 https://github.com/nvim-treesitter/playground deps/playground
 
 test-ci: deps test
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -149,13 +149,16 @@ function N.enable(scope)
                     return D.log(p.event, "skip split logic: side tree")
                 end
 
-                local focusedWin = vim.api.nvim_get_current_win()
                 local wins, total = W.winsExceptState(tab, false)
 
-                if total == 0 or not vim.tbl_contains(wins, focusedWin) then
-                    return D.log(p.event, "skip split logic: no new window")
+                if total ~= 1 then
+                    return D.log(
+                        p.event,
+                        "skip split logic: no new or too many unregistered windows"
+                    )
                 end
 
+                local focusedWin = wins[1]
                 local isVSplit = true
 
                 tab, isVSplit = Sp.compute(tab, focusedWin)

--- a/scripts/init_auto_open.lua
+++ b/scripts/init_auto_open.lua
@@ -8,4 +8,3 @@ require("no-neck-pain").setup({
     autocmds = { enableOnVimEnter = true, enableOnTabEnter = true },
 })
 require("mini.test").setup()
-require("mini.doc").setup()

--- a/scripts/init_with_deps.lua
+++ b/scripts/init_with_deps.lua
@@ -1,0 +1,16 @@
+vim.cmd([[let &rtp.=','.getcwd()]])
+
+vim.cmd("set rtp+=deps/mini.nvim")
+vim.cmd("set rtp+=deps/nvim-treesitter")
+vim.cmd("set rtp+=deps/playground")
+
+require("mini.test").setup()
+require("nvim-treesitter.configs").setup({
+    playground = {
+        enable = true,
+    },
+})
+
+require("no-neck-pain").setup({
+    width = 30,
+})

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -4,6 +4,12 @@ local Helpers = {}
 -- Add extra expectations
 Helpers.expect = vim.deepcopy(MiniTest.expect)
 
+function Helpers.winsInTab(child, tab)
+    tab = tab or "_G.NoNeckPain.state.activeTab"
+
+    return child.lua_get("vim.api.nvim_tabpage_list_wins(" .. tab .. ")")
+end
+
 local function errorMessage(str, pattern)
     return string.format("Pattern: %s\nObserved string: %s", vim.inspect(pattern), str)
 end

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -4,6 +4,10 @@ local Helpers = {}
 -- Add extra expectations
 Helpers.expect = vim.deepcopy(MiniTest.expect)
 
+function Helpers.currentWin(child)
+    return child.lua_get("vim.api.nvim_get_current_win()")
+end
+
 function Helpers.winsInTab(child, tab)
     tab = tab or "_G.NoNeckPain.state.activeTab"
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -174,12 +174,9 @@ T["setup"]["width - throws with non-supported string"] = function()
 end
 
 T["setup"]["starts the plugin on VimEnter"] = function()
-    child.restart({ "-u", "scripts/test_auto_open.lua" })
+    child.restart({ "-u", "scripts/init_auto_open.lua" })
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "enabled", true)
 
     child.stop()

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -26,7 +26,7 @@ T["auto command"]["does not create side buffers window's width < options.width"]
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"), { 1000 })
+    eq(helpers.winsInTab(child), { 1000 })
     eq_state(child, "tabs[1].wins.main.curr", 1000)
     eq_state(child, "tabs[1].wins.main.left", vim.NIL)
     eq_state(child, "tabs[1].wins.main.right", vim.NIL)
@@ -39,10 +39,7 @@ T["auto command"]["does not shift using when opening/closing float window"] = fu
         require('no-neck-pain').enable()
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "tabs[1].wins.main.left", 1001)
     eq_state(child, "tabs[1].wins.main.right", 1002)
 
@@ -51,10 +48,7 @@ T["auto command"]["does not shift using when opening/closing float window"] = fu
 
     child.lua("vim.api.nvim_open_win(0,true, {width=100,height=100,relative='cursor',row=0,col=0})")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002, 1003 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002, 1003 })
     eq_state(child, "tabs[1].wins.main.left", 1001)
     eq_state(child, "tabs[1].wins.main.right", 1002)
 
@@ -65,10 +59,7 @@ T["auto command"]["does not shift using when opening/closing float window"] = fu
     child.lua("vim.fn.win_gotoid(1003)")
     child.cmd("q")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "tabs[1].wins.main.left", 1001)
     eq_state(child, "tabs[1].wins.main.right", 1002)
 

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -217,17 +217,14 @@ T["curr"]["closing `curr` window without any other window quits Neovim"] = funct
         require('no-neck-pain').enable()
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "tabs[1].wins.main.curr", 1000)
 
     child.cmd("q")
 
     -- neovim is closed, so it errors
     helpers.expect.error(function()
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)")
+        helpers.winsInTab(child)
     end)
 end
 
@@ -290,17 +287,14 @@ T["left/right"]["closing the `left` buffer disables NNP"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "tabs[1].wins.main.left", 1001)
     eq_state(child, "tabs[1].wins.main.right", 1002)
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.left)")
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"), { 1000 })
+    eq(helpers.winsInTab(child), { 1000 })
 end
 
 T["left/right"]["closing the `right` buffer disables NNP"] = function()
@@ -309,17 +303,14 @@ T["left/right"]["closing the `right` buffer disables NNP"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "tabs[1].wins.main.left", 1001)
     eq_state(child, "tabs[1].wins.main.right", 1002)
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.right)")
     child.cmd("q")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"), { 1000 })
+    eq(helpers.winsInTab(child), { 1000 })
 end
 
 return T

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -139,10 +139,7 @@ T["setup"]["increase the width with mapping"] = function()
     ]])
 
     eq_global(child, "_G.NoNeckPain.config.width", 50)
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.lua("vim.api.nvim_input('nn')")
     child.lua("vim.api.nvim_input('nn')")
@@ -159,10 +156,7 @@ T["setup"]["decrease the width with mapping"] = function()
     ]])
 
     eq_global(child, "_G.NoNeckPain.config.width", 50)
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.lua("vim.api.nvim_input('nn')")
     child.lua("vim.api.nvim_input('nn')")

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -50,10 +50,7 @@ T["scratchPad"]["default to `norg` fileType"] = function()
     })]])
     child.lua([[require('no-neck-pain').enable()]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/no-neck-pain-left.norg"
@@ -93,10 +90,7 @@ T["scratchPad"]["override of filetype is reflected to the buffer"] = function()
     })]])
     child.lua([[require('no-neck-pain').enable()]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/no-neck-pain-left.md"
@@ -134,10 +128,7 @@ T["scratchPad"]["side buffer can have their own definition"] = function()
     })]])
     child.lua([[require('no-neck-pain').enable()]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/lua/no-neck-pain-left.norg"
@@ -174,10 +165,7 @@ T["scratchPad"]["side buffer definition overrides global one"] = function()
     })]])
     child.lua([[require('no-neck-pain').enable()]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/lua/no-neck-pain-left.norg"

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -118,16 +118,23 @@ end
 T["vsplit"] = new_set()
 
 T["vsplit"]["register new non-focused windows (TSPlayground)"] = function()
-    child.set_size(300, 300)
     child.restart({ "-u", "scripts/init_with_deps.lua" })
+    child.set_size(300, 300)
 
     child.lua([[ require('no-neck-pain').enable() ]])
 
     eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("TSPlaygroundToggle")
+    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
 
-    eq(helpers.winsInTab(child), { 1001, 1000, 1004, 1002 })
+    eq(helpers.winsInTab(child), { 1001, 1004, 1000, 1002 })
+
+    eq_state(child, "tabs[1].wins.main.curr", 1000)
+    eq_state(child, "tabs[1].wins.main.left", 1001)
+    eq_state(child, "tabs[1].wins.main.right", 1002)
+    eq_state(child, "tabs[1].wins.splits[1].id", 1004)
+    eq_state(child, "tabs[1].wins.splits[1].vertical", true)
 end
 
 T["vsplit"]["does not create side buffers when there's not enough space"] = function()

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -39,7 +39,7 @@ T["split"]["only one side buffer, closing help doesn't close NNP"] = function()
     child.cmd("q")
 
     eq(helpers.winsInTab(child), { 1001, 1000 })
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
+    eq(helpers.currentWin(child), 1000)
     eq_state(child, "enabled", true)
 end
 
@@ -62,7 +62,7 @@ T["split"]["closing `curr` makes `split` the new `curr`"] = function()
     child.cmd("q")
 
     eq(helpers.winsInTab(child), { 1001, 1003, 1002 })
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
+    eq(helpers.currentWin(child), 1003)
 end
 
 T["split"]["keeps side buffers"] = function()
@@ -94,25 +94,25 @@ T["split"]["keeps correct focus"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
+    eq(helpers.currentWin(child), 1000)
 
     child.cmd("split")
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
+    eq(helpers.currentWin(child), 1003)
 
     child.cmd("split")
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1004)
+    eq(helpers.currentWin(child), 1004)
 
     child.cmd("split")
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1005)
+    eq(helpers.currentWin(child), 1005)
 
     child.cmd("q")
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1004)
+    eq(helpers.currentWin(child), 1004)
 
     child.cmd("q")
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
+    eq(helpers.currentWin(child), 1003)
 
     child.cmd("q")
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
+    eq(helpers.currentWin(child), 1000)
 end
 
 T["vsplit"] = new_set()
@@ -126,7 +126,7 @@ T["vsplit"]["register new non-focused windows (TSPlayground)"] = function()
     eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("TSPlaygroundToggle")
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
+    eq(helpers.currentWin(child), 1000)
 
     eq(helpers.winsInTab(child), { 1001, 1004, 1000, 1002 })
 
@@ -224,7 +224,7 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
 
     eq_state(child, "tabs[1].wins.main.curr", 1003)
     eq(helpers.winsInTab(child), { 1001, 1003, 1002 })
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
+    eq(helpers.currentWin(child), 1003)
 end
 
 T["vsplit"]["hides side buffers"] = function()
@@ -274,13 +274,13 @@ T["vsplit"]["keeps correct focus"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
+    eq(helpers.currentWin(child), 1000)
 
     child.cmd("vsplit")
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
+    eq(helpers.currentWin(child), 1003)
 
     child.cmd("vsplit")
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1004)
+    eq(helpers.currentWin(child), 1004)
 
     eq(helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
 end
@@ -333,7 +333,7 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
     child.cmd("q")
     eq(helpers.winsInTab(child), { 1006, 1003, 1000, 1007 })
 
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
+    eq(helpers.currentWin(child), 1000)
 end
 
 T["vsplit/split"]["closing help page doens't break layout"] = function()
@@ -353,7 +353,7 @@ T["vsplit/split"]["closing help page doens't break layout"] = function()
     child.cmd("q")
     eq(helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
-    eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
+    eq(helpers.currentWin(child), 1003)
 
     eq_buf_width(child, "tabs[1].wins.main.curr", 48)
 end

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -29,10 +29,7 @@ T["split"]["only one side buffer, closing help doesn't close NNP"] = function()
 
     child.cmd("h")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1002, 1000 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1002, 1000 })
     eq_state(child, "tabs[1].wins.main.left", 1001)
     eq_state(child, "tabs[1].wins.main.right", vim.NIL)
     eq_state(child, "tabs[1].wins.splits", { { id = 1002, vertical = false } })
@@ -41,10 +38,7 @@ T["split"]["only one side buffer, closing help doesn't close NNP"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.splits[1].id)")
     child.cmd("q")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000 })
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
     eq_state(child, "enabled", true)
 end
@@ -58,10 +52,7 @@ T["split"]["closing `curr` makes `split` the new `curr`"] = function()
 
     child.cmd("split")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1003, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
     eq_state(child, "tabs[1].wins.main.left", 1001)
     eq_state(child, "tabs[1].wins.main.right", 1002)
     eq_state(child, "tabs[1].wins.splits", { { id = 1003, vertical = false } })
@@ -70,10 +61,7 @@ T["split"]["closing `curr` makes `split` the new `curr`"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.curr)")
     child.cmd("q")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1003, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1003, 1002 })
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
 end
 
@@ -86,10 +74,7 @@ T["split"]["keeps side buffers"] = function()
 
     child.cmd("split")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1003, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
     eq_state(child, "tabs[1].wins.main.left", 1001)
     eq_state(child, "tabs[1].wins.main.right", 1002)
     eq_state(child, "tabs[1].wins.splits", { { id = 1003, vertical = false } })
@@ -97,10 +82,7 @@ T["split"]["keeps side buffers"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.splits[1].id)")
     child.cmd("q")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_buf_width(child, "tabs[1].wins.main.left", 15)
     eq_buf_width(child, "tabs[1].wins.main.right", 15)
 end
@@ -135,22 +117,32 @@ end
 
 T["vsplit"] = new_set()
 
+T["vsplit"]["register new non-focused windows (TSPlayground)"] = function()
+    child.set_size(300, 300)
+    child.restart({ "-u", "scripts/init_with_deps.lua" })
+
+    child.lua([[ require('no-neck-pain').enable() ]])
+
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    child.cmd("TSPlaygroundToggle")
+
+    eq(helpers.winsInTab(child), { 1001, 1000, 1004, 1002 })
+end
+
 T["vsplit"]["does not create side buffers when there's not enough space"] = function()
     child.cmd("vsplit")
     child.cmd("vsplit")
     child.cmd("vsplit")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1003, 1002, 1001, 1000 })
+    eq(helpers.winsInTab(child, 1), { 1003, 1002, 1001, 1000 })
 
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1003, 1002, 1001, 1000 }
-    )
+    eq(helpers.winsInTab(child), { 1003, 1002, 1001, 1000 })
 end
 
 T["vsplit"]["corretly size splits when opening helper with side buffers open"] = function()
@@ -162,14 +154,14 @@ T["vsplit"]["corretly size splits when opening helper with side buffers open"] =
 
     child.cmd("vsplit")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1001, 1003, 1000, 1002 })
+    eq(helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
     eq_buf_width(child, "tabs[1].wins.splits[1].id", 50)
     eq_buf_width(child, "tabs[1].wins.main.curr", 67)
 
     child.cmd("h")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1004, 1001, 1003, 1000, 1002 })
+    eq(helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
     eq_buf_width(child, "tabs[1].wins.splits[1].id", 50)
     eq_buf_width(child, "tabs[1].wins.main.curr", 67)
@@ -179,17 +171,14 @@ T["vsplit"]["correctly position side buffers when there's enough space"] = funct
     child.set_size(500, 500)
     child.cmd("vsplit")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1001, 1000 })
+    eq(helpers.winsInTab(child, 1), { 1001, 1000 })
 
     child.lua([[
         require('no-neck-pain').setup({width=50})
         require('no-neck-pain').enable()
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1002, 1001, 1000, 1003 }
-    )
+    eq(helpers.winsInTab(child), { 1002, 1001, 1000, 1003 })
 end
 
 T["vsplit"]["preserve vsplit width when having side buffers"] = function()
@@ -199,17 +188,11 @@ T["vsplit"]["preserve vsplit width when having side buffers"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000 })
 
     child.cmd("vsplit")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1002, 1000 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1002, 1000 })
 
     eq_buf_width(child, "tabs[1].wins.splits[1].id", 65)
 end
@@ -223,10 +206,7 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
 
     child.cmd("vsplit")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1003, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
     eq_state(child, "tabs[1].wins.main.left", 1001)
     eq_state(child, "tabs[1].wins.main.right", 1002)
     eq_state(child, "tabs[1].wins.splits", { { id = 1003, vertical = true } })
@@ -236,10 +216,7 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
     child.cmd("q")
 
     eq_state(child, "tabs[1].wins.main.curr", 1003)
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1003, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1003, 1002 })
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
 end
 
@@ -251,10 +228,7 @@ T["vsplit"]["hides side buffers"] = function()
 
     child.cmd("vsplit")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1003, 1000 }
-    )
+    eq(helpers.winsInTab(child), { 1003, 1000 })
     eq_state(child, "tabs[1].wins.main.left", vim.NIL)
     eq_state(child, "tabs[1].wins.main.right", vim.NIL)
     eq_state(child, "tabs[1].wins.splits", { { id = 1003, vertical = true } })
@@ -262,10 +236,7 @@ T["vsplit"]["hides side buffers"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.splits[1].id)")
     child.cmd("q")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1004, 1000, 1005 }
-    )
+    eq(helpers.winsInTab(child), { 1004, 1000, 1005 })
     eq_state(child, "tabs[1].wins.main.left", 1004)
     eq_state(child, "tabs[1].wins.main.right", 1005)
     eq_state(child, "tabs[1].wins.splits", vim.NIL)
@@ -278,23 +249,14 @@ T["vsplit"]["many vsplit leave side buffers open as long as there's space for it
         require('no-neck-pain').enable() 
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("vsplit")
     child.cmd("vsplit")
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1004, 1003, 1000 }
-    )
+    eq(helpers.winsInTab(child), { 1004, 1003, 1000 })
     child.cmd("q")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1005, 1003, 1000, 1006 }
-    )
+    eq(helpers.winsInTab(child), { 1005, 1003, 1000, 1006 })
     eq_state(child, "tabs[_G.NoNeckPain.state.activeTab].wins.main.curr", 1000)
 end
 
@@ -313,10 +275,7 @@ T["vsplit"]["keeps correct focus"] = function()
     child.cmd("vsplit")
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1004)
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1004, 1003, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
 end
 
 T["vsplit/split"] = new_set()
@@ -325,40 +284,25 @@ T["vsplit/split"]["state is correctly sync'd even after many changes"] = functio
     child.set_size(100, 100)
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1000 })
+    eq(helpers.winsInTab(child, 1), { 1000 })
 
     child.lua([[ require('no-neck-pain').enable() ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("split")
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1003, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
     child.cmd("q")
 
     child.cmd("vsplit")
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1004, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1004, 1000, 1002 })
 
     child.cmd("vsplit")
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1005, 1004, 1000 }
-    )
+    eq(helpers.winsInTab(child), { 1005, 1004, 1000 })
     child.cmd("q")
     child.cmd("q")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1006, 1004, 1007 }
-    )
+    eq(helpers.winsInTab(child), { 1006, 1004, 1007 })
     eq_state(child, "tabs[_G.NoNeckPain.state.activeTab].wins.main.curr", 1004)
 end
 
@@ -369,30 +313,18 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
         require('no-neck-pain').enable() 
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("vsplit")
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1003, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
     child.cmd("vsplit")
     child.cmd("vsplit")
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1005, 1004, 1003, 1000 }
-    )
+    eq(helpers.winsInTab(child), { 1005, 1004, 1003, 1000 })
 
     child.cmd("q")
     child.cmd("q")
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1006, 1003, 1000, 1007 }
-    )
+    eq(helpers.winsInTab(child), { 1006, 1003, 1000, 1007 })
 
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
 end
@@ -403,25 +335,16 @@ T["vsplit/split"]["closing help page doens't break layout"] = function()
         require('no-neck-pain').enable() 
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("split")
     child.cmd("h")
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1004, 1001, 1003, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
     eq_buf_width(child, "tabs[1].wins.main.curr", 48)
 
     child.cmd("q")
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1003, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
     eq(child.lua_get("vim.api.nvim_get_current_win()"), 1003)
 

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -36,15 +36,12 @@ T["tabs"]["new tab doesn't have side buffers"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "activeTab", 1)
 
     child.cmd("tabnew")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"), { 1003 })
+    eq(helpers.winsInTab(child), { 1003 })
 end
 
 T["tabs"]["side buffers coexist on many tabs"] = function()
@@ -54,35 +51,26 @@ T["tabs"]["side buffers coexist on many tabs"] = function()
     ]])
 
     -- tab 1
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "activeTab", 1)
 
     -- tab 2
     child.cmd("tabnew")
     child.lua([[ require('no-neck-pain').enable() ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1004, 1003, 1005 }
-    )
+    eq(helpers.winsInTab(child), { 1004, 1003, 1005 })
     eq_state(child, "activeTab", 2)
 
     -- tab 3
     child.cmd("tabnew")
     child.lua([[ require('no-neck-pain').enable() ]])
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1007, 1006, 1008 }
-    )
+    eq(helpers.winsInTab(child), { 1007, 1006, 1008 })
     eq_state(child, "activeTab", 3)
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(1)"), { 1001, 1000, 1002 })
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(2)"), { 1004, 1003, 1005 })
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(3)"), { 1007, 1006, 1008 })
+    eq(helpers.winsInTab(child, 1), { 1001, 1000, 1002 })
+    eq(helpers.winsInTab(child, 2), { 1004, 1003, 1005 })
+    eq(helpers.winsInTab(child, 3), { 1007, 1006, 1008 })
 end
 
 T["tabs"]["previous tab kept side buffers if enabled"] = function()
@@ -92,39 +80,30 @@ T["tabs"]["previous tab kept side buffers if enabled"] = function()
     ]])
 
     -- tab 1
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "activeTab", 1)
 
     -- tab 2
     child.cmd("tabnew")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"), { 1003 })
+    eq(helpers.winsInTab(child), { 1003 })
 
     -- tab 1
     child.cmd("tabprevious")
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
     eq_state(child, "activeTab", 1)
 end
 
 T["TabNewEntered"] = MiniTest.new_set()
 
 T["TabNewEntered"]["starts the plugin on new tab"] = function()
-    child.restart({ "-u", "scripts/test_auto_open.lua" })
+    child.restart({ "-u", "scripts/init_auto_open.lua" })
 
     eq_state(child, "enabled", true)
 
     -- tab 1
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     eq_state(child, "activeTab", 1)
 
@@ -132,24 +111,18 @@ T["TabNewEntered"]["starts the plugin on new tab"] = function()
     child.cmd("tabnew")
     eq_state(child, "activeTab", 2)
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1004, 1003, 1005 }
-    )
+    eq(helpers.winsInTab(child), { 1004, 1003, 1005 })
 
     child.stop()
 end
 
 T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
-    child.restart({ "-u", "scripts/test_auto_open.lua" })
+    child.restart({ "-u", "scripts/init_auto_open.lua" })
 
     eq_state(child, "enabled", true)
 
     -- tab 1
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1001, 1000, 1002 }
-    )
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     eq_state(child, "activeTab", 1)
 
@@ -157,14 +130,11 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
     child.cmd("tabnew")
     eq_state(child, "activeTab", 2)
 
-    eq(
-        child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"),
-        { 1004, 1003, 1005 }
-    )
+    eq(helpers.winsInTab(child), { 1004, 1003, 1005 })
 
     child.cmd("NoNeckPain")
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"), { 1003 })
+    eq(helpers.winsInTab(child), { 1003 })
     eq_state(child, "activeTab", 2)
 
     -- tab 1
@@ -175,7 +145,7 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
     child.cmd("tabnext")
     eq_state(child, "activeTab", 2)
 
-    eq(child.lua_get("vim.api.nvim_tabpage_list_wins(_G.NoNeckPain.state.activeTab)"), { 1003 })
+    eq(helpers.winsInTab(child), { 1003 })
 
     child.stop()
 end


### PR DESCRIPTION
## 📃 Summary

entering a new vsplit/split window that is not the currently focused window doesn't register the split, which can end up in unwanted layout issue.

we now consider any non registered window in the vsplit/split handler 
