### PR TITLE
fix: refresh colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ require("no-neck-pain").setup({
         -- note: it does not trigger if you come back to an existing tab, to prevent unwanted interfer with user's decisions.
         --- @type boolean
         enableOnTabEnter = false,
+        -- When `true`, reloads the plugin configuration after a colorscheme change.
+        --- @type boolean
+        reloadOnColorSchemeChange = false,
     },
     -- Creates mappings for you to easily interact with the exposed commands.
     --- @type table

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -312,6 +312,8 @@ values:
       },
   }
 
+  local defaults = vim.deepcopy(NoNeckPain.options)
+
 <
 
 ------------------------------------------------------------------------------

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -312,8 +312,6 @@ values:
       },
   }
 
-  local defaults = vim.deepcopy(NoNeckPain.options)
-
 <
 
 ------------------------------------------------------------------------------

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -224,6 +224,9 @@ values:
           -- note: it does not trigger if you come back to an existing tab, to prevent unwanted interfer with user's decisions.
           --- @type boolean
           enableOnTabEnter = false,
+          -- When `true`, reloads the plugin configuration after a colorscheme change.
+          --- @type boolean
+          reloadOnColorSchemeChange = false,
       },
       -- Creates mappings for you to easily interact with the exposed commands.
       --- @type table

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -1,4 +1,3 @@
-local D = require("no-neck-pain.util.debug")
 local Co = require("no-neck-pain.util.constants")
 
 local C = {}
@@ -56,7 +55,7 @@ local function matchAndBlend(colorCode, factor)
 
     if factor ~= nil then
         assert(
-            factor >= -1 and factor <= 1,
+            type(factor) == "number" and factor >= -1 and factor <= 1,
             string.format(
                 "`blend` value %s does not match the range constraint, number must be between -1 and 1.",
                 factor
@@ -86,10 +85,9 @@ end
 ---Parses to color for each buffer parameters, considering transparent backgrounds.
 ---
 ---@param buffers table: the buffers table to parse.
----@param reload boolean?: when true, doen't rely on already stored color value.
 ---@return table: the parsed buffers.
 ---@private
-function C.parse(buffers, reload)
+function C.parse(buffers)
     local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
 
     -- if the user did not provided a custom background color, and have a transparent bg,
@@ -102,18 +100,13 @@ function C.parse(buffers, reload)
         buffers.colors.text = "#ffffff"
     else
         buffers.colors.background = matchAndBlend(
-            (not reload and buffers.colors.background) or string.format("#%06X", defaultBackground),
+            buffers.colors.background or string.format("#%06X", defaultBackground),
             buffers.colors.blend
         )
     end
 
     for _, side in pairs(Co.SIDES) do
         if buffers[side].enabled then
-            if reload then
-                buffers[side].colors.background = nil
-                buffers[side].colors.text = nil
-            end
-
             -- if the side buffer colors.background is not defined, we fallback to the common option.
             buffers[side].colors.background = matchAndBlend(
                 buffers[side].colors.background,
@@ -147,8 +140,6 @@ end
 ---@param side "left"|"right": the side of the window being resized, used for logging only.
 ---@private
 function C.init(win, tab, side)
-    D.log("colors", "initializing colors for %s side", side)
-
     local backgroundGroup = string.format("NoNeckPain_background_tab_%s_side_%s", tab, side)
     local textGroup = string.format("NoNeckPain_text_tab_%s_side_%s", tab, side)
 

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -86,12 +86,10 @@ end
 ---Parses to color for each buffer parameters, considering transparent backgrounds.
 ---
 ---@param buffers table: the buffers table to parse.
+---@param reload boolean?: when true, doen't rely on already stored color value.
 ---@return table: the parsed buffers.
----@return boolean?: when true, doen't rely on already stored color value.
 ---@private
 function C.parse(buffers, reload)
-    D.log("colors", "parsing colors")
-
     local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
 
     -- if the user did not provided a custom background color, and have a transparent bg,
@@ -111,9 +109,6 @@ function C.parse(buffers, reload)
 
     for _, side in pairs(Co.SIDES) do
         if buffers[side].enabled then
-            D.log("colors", "aaaaaaaaaa %s", buffers[side].colors.background)
-            D.log("colors", "zzzzzzzzzz %s", buffers[side].colors.text)
-
             if reload then
                 buffers[side].colors.background = nil
                 buffers[side].colors.text = nil
@@ -136,9 +131,6 @@ function C.parse(buffers, reload)
             buffers[side].colors.text = buffers[side].colors.text
                 or buffers.colors.text
                 or matchAndBlend(defaultTextColor, 0.5)
-
-            D.log("colors", "bbbbbbbbbb %s", buffers[side].colors.background)
-            D.log("colors", "yyyyyyyyyy %s", buffers[side].colors.text)
         end
     end
 

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -277,6 +277,7 @@ NoNeckPain.options = {
     },
 }
 
+---@private
 local defaults = vim.deepcopy(NoNeckPain.options)
 
 --- Defaults NoNeckPain options by merging user provided options with the default plugin values.
@@ -288,7 +289,7 @@ function NoNeckPain.defaults(options)
     options.buffers = options.buffers or {}
 
     local tde = function(t1, t2)
-        return vim.tbl_deep_extend("keep", t1 or {}, t2 or {})
+        return vim.deepcopy(vim.tbl_deep_extend("keep", t1 or {}, t2 or {}))
     end
 
     for _, side in pairs(Co.SIDES) do

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -189,6 +189,9 @@ NoNeckPain.options = {
         -- note: it does not trigger if you come back to an existing tab, to prevent unwanted interfer with user's decisions.
         --- @type boolean
         enableOnTabEnter = false,
+        -- When `true`, reloads the plugin configuration after a colorscheme change.
+        --- @type boolean
+        reloadOnColorSchemeChange = false,
     },
     -- Creates mappings for you to easily interact with the exposed commands.
     --- @type table

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -277,13 +277,14 @@ NoNeckPain.options = {
     },
 }
 
---- Define your no-neck-pain setup.
+local defaults = vim.deepcopy(NoNeckPain.options)
+
+--- Defaults NoNeckPain options by merging user provided options with the default plugin values.
 ---
 ---@param options table Module config table. See |NoNeckPain.options|.
 ---
----@usage `require("no-neck-pain").setup()` (add `{}` with your |NoNeckPain.options| table)
-function NoNeckPain.setup(options)
-    options = options or {}
+---@private
+function NoNeckPain.defaults(options)
     options.buffers = options.buffers or {}
 
     local tde = function(t1, t2)
@@ -309,9 +310,8 @@ function NoNeckPain.setup(options)
         end
     end
 
-    NoNeckPain.options = tde(options, NoNeckPain.options)
-
-    D.warnDeprecation(NoNeckPain.options)
+    NoNeckPain.options = tde(options, defaults)
+    NoNeckPain.options.buffers = C.parse(NoNeckPain.options.buffers)
 
     -- assert `width` values through vim options
     if NoNeckPain.options.width == "textwidth" then
@@ -340,8 +340,18 @@ function NoNeckPain.setup(options)
         )
     end
 
-    -- set theme options
-    NoNeckPain.options.buffers = C.parse(NoNeckPain.options.buffers)
+    return NoNeckPain.options
+end
+
+--- Define your no-neck-pain setup.
+---
+---@param options table Module config table. See |NoNeckPain.options|.
+---
+---@usage `require("no-neck-pain").setup()` (add `{}` with your |NoNeckPain.options| table)
+function NoNeckPain.setup(options)
+    NoNeckPain.options = NoNeckPain.defaults(options or {})
+
+    D.warnDeprecation(NoNeckPain.options)
 
     registerMappings(NoNeckPain.options.mappings, {
         toggle = ":NoNeckPain<CR>",

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,12 +1,13 @@
 local M = require("no-neck-pain.main")
 local C = require("no-neck-pain.colors")
+local cfg = require("no-neck-pain.config")
 
 local NoNeckPain = {}
 
 --- Toggle the plugin by calling the `enable`/`disable` methods respectively.
 function NoNeckPain.toggle()
     if _G.NoNeckPain.config == nil then
-        _G.NoNeckPain.config = require("no-neck-pain.config").options
+        _G.NoNeckPain.config = cfg.options
     end
 
     _G.NoNeckPain.state = M.toggle("publicAPI_toggle")
@@ -19,7 +20,7 @@ function NoNeckPain.toggleScratchPad()
     end
 
     if _G.NoNeckPain.config == nil then
-        _G.NoNeckPain.config = require("no-neck-pain.config").options
+        _G.NoNeckPain.config = cfg.options
     end
 
     _G.NoNeckPain.state = M.toggleScratchPad()
@@ -49,7 +50,7 @@ end
 --- Initializes the plugin, sets event listeners and internal state.
 function NoNeckPain.enable()
     if _G.NoNeckPain.config == nil then
-        _G.NoNeckPain.config = require("no-neck-pain.config").options
+        _G.NoNeckPain.config = cfg.options
     end
 
     local state = M.enable("publicAPI_enable")
@@ -68,7 +69,7 @@ end
 
 -- setup NoNeckPain options and merge them with user provided ones.
 function NoNeckPain.setup(opts)
-    _G.NoNeckPain.config = require("no-neck-pain.config").setup(opts)
+    _G.NoNeckPain.config = cfg.setup(opts)
 
     if
         _G.NoNeckPain.config.autocmds.enableOnVimEnter
@@ -87,7 +88,7 @@ function NoNeckPain.setup(opts)
                         return
                     end
 
-                    _G.NoNeckPain.config.buffers = C.parse(_G.NoNeckPain.config.buffers, true)
+                    _G.NoNeckPain.config = cfg.defaults(opts)
                     M.init("ColorScheme", nil)
                 end)
             end,

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,4 +1,5 @@
 local M = require("no-neck-pain.main")
+local C = require("no-neck-pain.colors")
 
 local NoNeckPain = {}
 
@@ -72,8 +73,27 @@ function NoNeckPain.setup(opts)
     if
         _G.NoNeckPain.config.autocmds.enableOnVimEnter
         or _G.NoNeckPain.config.autocmds.enableOnTabEnter
+        or _G.NoNeckPain.config.autocmds.reloadOnColorSchemeChange
     then
         vim.api.nvim_create_augroup("NoNeckPainAutocmd", { clear = true })
+    end
+
+    if _G.NoNeckPain.config.autocmds.reloadOnColorSchemeChange then
+        vim.api.nvim_create_autocmd({ "ColorScheme" }, {
+            pattern = "*",
+            callback = function()
+                vim.schedule(function()
+                    if _G.NoNeckPain.state == nil or not _G.NoNeckPain.state.enabled then
+                        return
+                    end
+
+                    _G.NoNeckPain.config.buffers = C.parse(_G.NoNeckPain.config.buffers, true)
+                    M.init("ColorScheme", nil)
+                end)
+            end,
+            group = "NoNeckPainAutocmd",
+            desc = "Triggers until it finds the correct moment/buffer to enable the plugin.",
+        })
     end
 
     if _G.NoNeckPain.config.autocmds.enableOnVimEnter then

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,5 +1,4 @@
 local M = require("no-neck-pain.main")
-local C = require("no-neck-pain.colors")
 local cfg = require("no-neck-pain.config")
 
 local NoNeckPain = {}

--- a/lua/no-neck-pain/util/debug.lua
+++ b/lua/no-neck-pain/util/debug.lua
@@ -29,35 +29,6 @@ function D.log(scope, str, ...)
     )
 end
 
----prints the table if debug is true.
----
----@param table table: the table to print.
----@param indent number?: the default indent value, starts at 0.
----@private
-function D.tprint(table, indent)
-    if _G.NoNeckPain.config ~= nil and not _G.NoNeckPain.config.debug then
-        return
-    end
-
-    if not indent then
-        indent = 0
-    end
-
-    for k, v in pairs(table) do
-        local formatting = string.rep("  ", indent) .. k .. ": "
-        if type(v) == "table" then
-            print(formatting)
-            D.tprint(v, indent + 1)
-        elseif type(v) == "boolean" then
-            print(formatting .. tostring(v))
-        elseif type(v) == "function" then
-            print(formatting .. "FUNCTION")
-        else
-            print(formatting .. v)
-        end
-    end
-end
-
 ---analyzes the user provided `setup` parameters and sends a message if they use a deprecated option, then gives the new option to use.
 ---
 ---@param options table: the options provided by the user.

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -174,8 +174,6 @@ function W.createSideBuffers(tab, skipTrees)
                     vim.api.nvim_win_set_option(id, opt, val)
                 end
 
-                C.init(id, tab.id, side)
-
                 if _G.NoNeckPain.config.buffers[side].scratchPad.enabled then
                     W.initScratchPad(side)
                     tab.scratchPadEnabled = true
@@ -183,6 +181,8 @@ function W.createSideBuffers(tab, skipTrees)
 
                 tab.wins.main[side] = id
             end
+
+            C.init(tab.wins.main[side], tab.id, side)
         end
     end
 

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -182,7 +182,9 @@ function W.createSideBuffers(tab, skipTrees)
                 tab.wins.main[side] = id
             end
 
-            C.init(tab.wins.main[side], tab.id, side)
+            if tab.wins.main[side] ~= nil then
+                C.init(tab.wins.main[side], tab.id, side)
+            end
         end
     end
 

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -174,28 +174,19 @@ T["color"]["map integration name to a value"] = function()
         end
     end
 end
---
-T["color"]["buffers: throws with wrong values"] = function()
-    local keyValueSetupErrors = {
-        { "background", "no-neck-pain" },
-        { "blend", 30 },
-    }
 
-    for _, keyValueSetupError in pairs(keyValueSetupErrors) do
-        helpers.expect.error(function()
-            child.lua(string.format(
-                [[require('no-neck-pain').setup({
-                    buffers = {
-                        colors = {
-                            %s = "%s",
-                        },
-                    },
-                })]],
-                keyValueSetupError[1],
-                keyValueSetupError[2]
-            ))
-        end)
-    end
+T["color"]["buffers: throws with wrong background value"] = function()
+    helpers.expect.error(function()
+        child.lua([[
+        require('no-neck-pain').setup({
+            buffers = {
+                colors = {
+                    background = "no-neck-pain",
+                },
+            },
+        })
+        ]])
+    end)
 end
 
 return T

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -189,4 +189,25 @@ T["color"]["buffers: throws with wrong background value"] = function()
     end)
 end
 
+T["color"]["refreshes the stored color when changing colorscheme"] = function()
+    child.lua([[
+    require('no-neck-pain').setup({
+        autocmds = {
+            reloadOnColorSchemeChange=true,
+        },
+    })
+    require('no-neck-pain').enable()
+    ]])
+
+    eq_config(child, "buffers.colors.background", "NONE")
+    eq_config(child, "buffers.colors.blend", 0)
+    eq_config(child, "buffers.colors.text", "#ffffff")
+
+    child.cmd([[colorscheme peachpuff]])
+
+    eq_config(child, "buffers.colors.background", "#ffdab9")
+    eq_config(child, "buffers.colors.blend", 0)
+    eq_config(child, "buffers.colors.text", vim.NIL)
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/222

provides an autocmd that the user can enable in order to refresh the configuration when changing the colorscheme.