### PR TITLE
fix: tab state synchronization

### DIFF
--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -22,7 +22,7 @@ function E.skip(tab)
     end
 
     if tab ~= nil then
-        if vim.api.nvim_win_get_tabpage(0) ~= tab.id then
+        if vim.api.nvim_get_current_tabpage() ~= tab.id then
             return true
         end
 

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -369,6 +369,10 @@ end
 ---@return boolean: whether all windows are active and valid or not.
 ---@private
 function W.stateWinsActive(tab, checkSplits)
+    if not vim.api.nvim_tabpage_is_valid(tab.id) then
+        return false
+    end
+
     local wins = vim.api.nvim_tabpage_list_wins(tab.id)
     local swins = tab.wins.main
 

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -150,4 +150,29 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
     child.stop()
 end
 
+T["tabnew/tabclose"] = MiniTest.new_set()
+
+T["tabnew/tabclose"]["opening and closing tabs does not throw any error"] = function()
+    child.restart({ "-u", "scripts/init_auto_open.lua" })
+
+    eq_state(child, "enabled", true)
+    eq_state(child, "activeTab", 1)
+
+    child.cmd("tabnew")
+    eq_state(child, "activeTab", 2)
+
+    child.cmd("tabclose")
+    eq_state(child, "activeTab", 1)
+
+    child.cmd("tabnew")
+    child.cmd("tabnew")
+    eq_state(child, "activeTab", 4)
+
+    child.cmd("tabclose")
+    eq_state(child, "activeTab", 3)
+
+    child.cmd("tabclose")
+    eq_state(child, "activeTab", 1)
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/229

There's a synchronization issue with the tab state on `TabLeave` events, which ends up in invalid IDs when navigating through tab windows.

This PR provides a new way of synchronizing state on `TabLeave` and `NoNeckPain.disable` events, however it highlights an other issue with closed tabs left in state, which will be tackled in https://github.com/shortcuts/no-neck-pain.nvim/issues/230