### PR TITLE
fix(internal): prevent unsync state

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,4 +1,5 @@
 local M = require("no-neck-pain.main")
+local D = require("no-neck-pain.util.debug")
 local cfg = require("no-neck-pain.config")
 
 local NoNeckPain = {}
@@ -43,7 +44,7 @@ function NoNeckPain.resize(width)
         _G.NoNeckPain.config = vim.tbl_deep_extend("keep", { width = width }, _G.NoNeckPain.config)
     end
 
-    _G.NoNeckPain.state = M.init("publicAPI_resize", nil, false)
+    _G.NoNeckPain.state = M.init("publicAPI_resize", false)
 end
 
 --- Initializes the plugin, sets event listeners and internal state.
@@ -88,7 +89,7 @@ function NoNeckPain.setup(opts)
                     end
 
                     _G.NoNeckPain.config = cfg.defaults(opts)
-                    M.init("ColorScheme", nil)
+                    M.init("ColorScheme")
                 end)
             end,
             group = "NoNeckPainAutocmd",
@@ -119,8 +120,12 @@ function NoNeckPain.setup(opts)
 
     if _G.NoNeckPain.config.autocmds.enableOnTabEnter then
         vim.api.nvim_create_autocmd({ "TabNewEntered" }, {
-            callback = function()
+            callback = function(p)
                 vim.schedule(function()
+                    if _G.NoNeckPain.state == nil or not _G.NoNeckPain.state.enabled then
+                        return D.log(p.event, "plugin is disabled")
+                    end
+
                     NoNeckPain.enable()
                 end)
             end,

--- a/lua/no-neck-pain/tabs.lua
+++ b/lua/no-neck-pain/tabs.lua
@@ -48,12 +48,11 @@ end
 ---
 ---@param tabs table?: the `tabs` state list.
 ---@return table: the updated tabs state.
----@return table: the newly initialized tab.
 ---@private
 function Ta.insert(tabs, id)
     tabs = tabs or {}
 
-    local newTab = {
+    tabs[id] = {
         id = id,
         scratchPadEnabled = false,
         layers = {
@@ -86,9 +85,7 @@ function Ta.insert(tabs, id)
         },
     }
 
-    table.insert(tabs, newTab)
-
-    return tabs, newTab
+    return tabs
 end
 
 ---Gets the tab with the given `id` for the state
@@ -104,13 +101,7 @@ function Ta.get(tabs, id)
 
     id = id or vim.api.nvim_get_current_tabpage()
 
-    for _, tab in pairs(tabs) do
-        if tab.id == id then
-            return tab
-        end
-    end
-
-    return nil
+    return tabs[id]
 end
 
 ---Replaces the tab with the given `id` by the `updatedTab`
@@ -125,17 +116,9 @@ function Ta.update(tabs, id, updatedTab)
         return nil
     end
 
-    local updatedTabs = {}
+    tabs[id] = updatedTab
 
-    for _, tab in pairs(tabs) do
-        if tab.id == id then
-            table.insert(updatedTabs, updatedTab)
-        elseif tab.id ~= id then
-            table.insert(updatedTabs, tab)
-        end
-    end
-
-    return updatedTabs
+    return tabs
 end
 
 return Ta

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -23,6 +23,10 @@ end
 ---@return boolean: whether the side exists or not.
 ---@private
 function A.sideExist(tab, side)
+    if tab == nil then
+        return false
+    end
+
     return _G.NoNeckPain.config.buffers[side].enabled and tab.wins.main[side] ~= nil
 end
 

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -247,7 +247,6 @@ end
 ---@param tab table: the table where the tab information are stored.
 ---@param withTrees boolean: whether we should consider external windows or not.
 ---@return table: the wins that are not in `tab`.
----@return number: the total number of `wins`.
 ---@private
 function W.winsExceptState(tab, withTrees)
     local wins = vim.api.nvim_tabpage_list_wins(tab.id)
@@ -255,16 +254,14 @@ function W.winsExceptState(tab, withTrees)
         W.mergeState(tab.wins.main, tab.wins.splits, withTrees and tab.wins.external.trees or nil)
 
     local validWins = {}
-    local size = 0
 
     for _, win in pairs(wins) do
         if not vim.tbl_contains(mergedWins, win) and not W.isRelativeWindow(win) then
             table.insert(validWins, win)
-            size = size + 1
         end
     end
 
-    return validWins, size
+    return validWins
 end
 
 ---Determine the "padding" (width) of the buffer based on the `_G.NoNeckPain.config.width` and the width of the screen.


### PR DESCRIPTION
## 📃 Summary

relying on a copy of the current state tab indeed prevent race conditions, but makes it harder to manage state updates.

this new approach makes it more reliable to work on the state.