### PR TITLE
chore: bump neovim on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 2
     strategy:
       matrix:
-        neovim_version: ['v0.7.2', 'v0.8.3', 'v0.9.1', 'nightly']
+        neovim_version: ['v0.7.2', 'v0.8.3', 'v0.9.4', 'nightly']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## 📃 Summary

run tests against neovim 9.4