### PR TITLE
feat(mappins): allow custom values for widthUp and widthDown

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,11 @@ require("no-neck-pain").setup({
         toggle = "<Leader>np",
         -- Sets a global mapping to Neovim, which allows you to increase the width (+5) of the main window.
         -- When `false`, the mapping is not created.
-        --- @type string
+        --- @type string | { mapping: string, value: number }
         widthUp = "<Leader>n=",
         -- Sets a global mapping to Neovim, which allows you to decrease the width (-5) of the main window.
         -- When `false`, the mapping is not created.
-        --- @type string
+        --- @type string | { mapping: string, value: number }
         widthDown = "<Leader>n-",
         -- Sets a global mapping to Neovim, which allows you to toggle the scratchpad feature.
         -- When `false`, the mapping is not created.

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -240,11 +240,11 @@ values:
           toggle = "<Leader>np",
           -- Sets a global mapping to Neovim, which allows you to increase the width (+5) of the main window.
           -- When `false`, the mapping is not created.
-          --- @type string
+          --- @type string | { mapping: string, value: number }
           widthUp = "<Leader>n=",
           -- Sets a global mapping to Neovim, which allows you to decrease the width (-5) of the main window.
           -- When `false`, the mapping is not created.
-          --- @type string
+          --- @type string | { mapping: string, value: number }
           widthDown = "<Leader>n-",
           -- Sets a global mapping to Neovim, which allows you to toggle the scratchpad feature.
           -- When `false`, the mapping is not created.

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -4,42 +4,6 @@ local Co = require("no-neck-pain.util.constants")
 
 local NoNeckPain = {}
 
---- Registers the plugin mappings if the option is enabled.
----
----@param options table The mappins provided by the user.
----@param mappings table A key value map of the mapping name and its command.
----
----@private
-local function registerMappings(options, mappings)
-    -- all of the mappings are disabled
-    if not options.enabled then
-        return
-    end
-
-    for name, command in pairs(mappings) do
-        -- this specific mapping is disabled
-        if not options[name] then
-            return
-        end
-
-        if (name == "widthUp" or name == "widthDown") and type(options[name]) ~= "string" then
-            assert(
-                type(options[name]) == "table"
-                    and options[name]["mapping"] ~= nil
-                    and options[name]["value"] ~= nil,
-                string.format(
-                    "`%s` must be a string or a table with the following properties {mapping: 'your_mapping', value: 5}",
-                    name
-                )
-            )
-            vim.api.nvim_set_keymap("n", options[name].mapping, command, { silent = true })
-        else
-            assert(type(options[name]) == "string", string.format("`%s` must be a string", name))
-            vim.api.nvim_set_keymap("n", options[name], command, { silent = true })
-        end
-    end
-end
-
 --- NoNeckPain's buffer `vim.wo` options.
 --- @see window options `:h vim.wo`
 ---
@@ -380,6 +344,43 @@ function NoNeckPain.defaults(options)
 
     return NoNeckPain.options
 end
+
+--- Registers the plugin mappings if the option is enabled.
+---
+---@param options table The mappins provided by the user.
+---@param mappings table A key value map of the mapping name and its command.
+---
+---@private
+local function registerMappings(options, mappings)
+    -- all of the mappings are disabled
+    if not options.enabled then
+        return
+    end
+
+    for name, command in pairs(mappings) do
+        -- this specific mapping is disabled
+        if not options[name] then
+            return
+        end
+
+        if (name == "widthUp" or name == "widthDown") and type(options[name]) ~= "string" then
+            assert(
+                type(options[name]) == "table"
+                    and options[name]["mapping"] ~= nil
+                    and options[name]["value"] ~= nil,
+                string.format(
+                    "`%s` must be a string or a table with the following properties {mapping: 'your_mapping', value: 5}",
+                    name
+                )
+            )
+            vim.api.nvim_set_keymap("n", options[name].mapping, command, { silent = true })
+        else
+            assert(type(options[name]) == "string", string.format("`%s` must be a string", name))
+            vim.api.nvim_set_keymap("n", options[name], command, { silent = true })
+        end
+    end
+end
+
 
 --- Define your no-neck-pain setup.
 ---

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -22,8 +22,21 @@ local function registerMappings(options, mappings)
             return
         end
 
-        assert(type(options[name]) == "string", string.format("`%s` must be a string", name))
-        vim.api.nvim_set_keymap("n", options[name], command, { silent = true })
+        if (name == "widthUp" or name == "widthDown") and type(options[name]) ~= "string" then
+            assert(
+                type(options[name]) == "table"
+                    and options[name]["mapping"] ~= nil
+                    and options[name]["value"] ~= nil,
+                string.format(
+                    "`%s` must be a string or a table with the following properties {mapping: 'your_mapping', value: 5}",
+                    name
+                )
+            )
+            vim.api.nvim_set_keymap("n", options[name].mapping, command, { silent = true })
+        else
+            assert(type(options[name]) == "string", string.format("`%s` must be a string", name))
+            vim.api.nvim_set_keymap("n", options[name], command, { silent = true })
+        end
     end
 end
 
@@ -205,11 +218,11 @@ NoNeckPain.options = {
         toggle = "<Leader>np",
         -- Sets a global mapping to Neovim, which allows you to increase the width (+5) of the main window.
         -- When `false`, the mapping is not created.
-        --- @type string
+        --- @type string | { mapping: string, value: number }
         widthUp = "<Leader>n=",
         -- Sets a global mapping to Neovim, which allows you to decrease the width (-5) of the main window.
         -- When `false`, the mapping is not created.
-        --- @type string
+        --- @type string | { mapping: string, value: number }
         widthDown = "<Leader>n-",
         -- Sets a global mapping to Neovim, which allows you to toggle the scratchpad feature.
         -- When `false`, the mapping is not created.

--- a/plugin/no-neck-pain.lua
+++ b/plugin/no-neck-pain.lua
@@ -24,11 +24,15 @@ else
     end, { desc = "Resizes the main centered window for the given argument.", nargs = 1 })
 
     vim.api.nvim_create_user_command("NoNeckPainWidthUp", function()
-        require("no-neck-pain").resize(_G.NoNeckPain.config.width + 5)
+        local increment = _G.NoNeckPain.config.mappings.widthUp.value or 5
+
+        require("no-neck-pain").resize(_G.NoNeckPain.config.width + increment)
     end, { desc = "Increase the width of the main window by 5." })
 
     vim.api.nvim_create_user_command("NoNeckPainWidthDown", function()
-        require("no-neck-pain").resize(_G.NoNeckPain.config.width - 5)
+        local decrement = _G.NoNeckPain.config.mappings.widthDown.value or 5
+
+        require("no-neck-pain").resize(_G.NoNeckPain.config.width - decrement)
     end, { desc = "Decrease the width of the main window by 5." })
 
     vim.api.nvim_create_user_command("NoNeckPainScratchPad", function()

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -83,6 +83,31 @@ T["commands"]["NoNeckPainWidthUp increases the width by 5"] = function()
     eq_global(child, "_G.NoNeckPain.config.width", 150)
 end
 
+T["commands"]["NoNeckPainWidthUp increases the width by N when mappings.widthUp is configured"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        mappings = {
+            widthUp = {mapping = "<Leader>k-", value = 12},
+        }
+    })]])
+
+    child.cmd("NoNeckPain")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 100)
+
+    child.cmd("NoNeckPainWidthUp")
+    child.cmd("NoNeckPainWidthUp")
+    child.cmd("NoNeckPainWidthUp")
+    child.cmd("NoNeckPainWidthUp")
+    child.cmd("NoNeckPainWidthUp")
+    child.cmd("NoNeckPainWidthUp")
+    child.cmd("NoNeckPainWidthUp")
+    child.cmd("NoNeckPainWidthUp")
+    child.cmd("NoNeckPainWidthUp")
+    child.cmd("NoNeckPainWidthUp")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 220)
+end
+
 T["commands"]["NoNeckPainWidthUp decreases the width by 5"] = function()
     child.cmd("NoNeckPain")
 
@@ -100,6 +125,31 @@ T["commands"]["NoNeckPainWidthUp decreases the width by 5"] = function()
     child.cmd("NoNeckPainWidthDown")
 
     eq_global(child, "_G.NoNeckPain.config.width", 50)
+end
+
+T["commands"]["NoNeckPainWidthUp decreases the width by N when mappings.widthDown is configured"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        mappings = {
+            widthDown = {mapping = "<Leader>k-", value = 8},
+        }
+    })]])
+
+    child.cmd("NoNeckPain")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 100)
+
+    child.cmd("NoNeckPainWidthDown")
+    child.cmd("NoNeckPainWidthDown")
+    child.cmd("NoNeckPainWidthDown")
+    child.cmd("NoNeckPainWidthDown")
+    child.cmd("NoNeckPainWidthDown")
+    child.cmd("NoNeckPainWidthDown")
+    child.cmd("NoNeckPainWidthDown")
+    child.cmd("NoNeckPainWidthDown")
+    child.cmd("NoNeckPainWidthDown")
+    child.cmd("NoNeckPainWidthDown")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 20)
 end
 
 return T

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -196,6 +196,31 @@ T["setup"]["increase the width with custom mapping and value"] = function()
     eq_global(child, "_G.NoNeckPain.config.width", 90)
 end
 
+
+T["setup"]["throws with wrong widthUp configuration"] = function()
+    helpers.expect.error(function()
+        child.lua([[ require('no-neck-pain').setup({
+                    mappings = {
+                        enabled = true,
+                        widthUp = { foo = bar },
+                    },
+                })
+            ]])
+    end)
+end
+
+T["setup"]["throws with wrong widthDown configuration"] = function()
+    helpers.expect.error(function()
+        child.lua([[ require('no-neck-pain').setup({
+                    mappings = {
+                        enabled = true,
+                        widthDown = { foo = bar },
+                    },
+                })
+            ]])
+    end)
+end
+
 T["setup"]["decrease the width with mapping"] = function()
     child.lua([[
     require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown="nn"}})

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -80,6 +80,32 @@ T["setup"]["overrides default values"] = function()
     })
 end
 
+T["setup"]["allow widthUp and widthDown to be configurable"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        mappings = {
+            enabled = true,
+            toggle = "<Leader>kz",
+            widthUp = {mapping = "<Leader>k-", value = 12},
+            widthDown = {mapping = "<Leader>k=", value = 99},
+            scratchPad = "<Leader>ks"
+        }
+    })]])
+
+    eq_config(child, "mappings", {
+        enabled = true,
+        scratchPad = "<Leader>ks",
+        toggle = "<Leader>kz",
+        widthDown = {
+            mapping = "<Leader>k=",
+            value = 99,
+        },
+        widthUp = {
+            mapping = "<Leader>k-",
+            value = 12,
+        },
+    })
+end
+
 T["setup"]["does not create mappings if false"] = function()
     child.lua([[require('no-neck-pain').setup({
         mappings = {
@@ -138,8 +164,8 @@ end
 
 T["setup"]["increase the width with mapping"] = function()
     child.lua([[
-        require('no-neck-pain').setup({width=50,mappings={enabled=true,widthUp="nn"}})
-        require('no-neck-pain').enable()
+    require('no-neck-pain').setup({width=50,mappings={enabled=true,widthUp="nn"}})
+    require('no-neck-pain').enable()
     ]])
 
     eq_global(child, "_G.NoNeckPain.config.width", 50)
@@ -153,10 +179,27 @@ T["setup"]["increase the width with mapping"] = function()
     eq_global(child, "_G.NoNeckPain.config.width", 70)
 end
 
+T["setup"]["increase the width with custom mapping and value"] = function()
+    child.lua([[
+    require('no-neck-pain').setup({width=50,mappings={enabled=true,widthUp={mapping="nn", value=10}}})
+    require('no-neck-pain').enable()
+    ]])
+
+    eq_global(child, "_G.NoNeckPain.config.width", 50)
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    child.lua("vim.api.nvim_input('nn')")
+    child.lua("vim.api.nvim_input('nn')")
+    child.lua("vim.api.nvim_input('nn')")
+    child.lua("vim.api.nvim_input('nn')")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 90)
+end
+
 T["setup"]["decrease the width with mapping"] = function()
     child.lua([[
-        require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown="nn"}})
-        require('no-neck-pain').enable()
+    require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown="nn"}})
+    require('no-neck-pain').enable()
     ]])
 
     eq_global(child, "_G.NoNeckPain.config.width", 50)
@@ -170,10 +213,27 @@ T["setup"]["decrease the width with mapping"] = function()
     eq_global(child, "_G.NoNeckPain.config.width", 30)
 end
 
+T["setup"]["decrease the width with custom mapping and value"] = function()
+    child.lua([[
+    require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown={mapping="nn",value=7}}})
+    require('no-neck-pain').enable()
+    ]])
+
+    eq_global(child, "_G.NoNeckPain.config.width", 50)
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    child.lua("vim.api.nvim_input('nn')")
+    child.lua("vim.api.nvim_input('nn')")
+    child.lua("vim.api.nvim_input('nn')")
+    child.lua("vim.api.nvim_input('nn')")
+
+    eq_global(child, "_G.NoNeckPain.config.width", 22)
+end
+
 T["setup"]["toggles scratchPad"] = function()
     child.lua([[
-        require('no-neck-pain').setup({width=50,mappings={enabled=true,scratchPad="ns"}})
-        require('no-neck-pain').enable()
+    require('no-neck-pain').setup({width=50,mappings={enabled=true,scratchPad="ns"}})
+    require('no-neck-pain').enable()
     ]])
 
     eq_global(child, "_G.NoNeckPain.config.buffers.scratchPad.enabled", false)


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/261

this pr allows the user to define a custom value for the widthUp and widthDown mapping, because the default value (5) might be too little for some screens