### PR TITLE
fix(tabs): prevent unsynced state in tab switchs

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -218,12 +218,12 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "QuitPre", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(nil) then
+                if E.skip(nil) or not S.isActiveTabRegistered(S) then
                     return
                 end
 
                 -- if we are not in split view, we check if we killed one of the main buffers (curr, left, right) to disable NNP
-                if not S.hasSplits(S) and not W.stateWinsActive(S.getTab(S), false) then
+                if not S.hasSplits(S) and not W.stateWinsActive(p.event, false) then
                     D.log(p.event, "one of the NNP main buffers have been closed, disabling...")
 
                     return N.disable(p.event)
@@ -252,7 +252,7 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(nil) or not S.hasSplits(S) or W.stateWinsActive(S.getTab(S), true) then
+                if E.skip(nil) or not S.hasSplits(S) or W.stateWinsActive(p.event, true) then
                     return
                 end
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -223,7 +223,7 @@ function N.enable(scope)
                 end
 
                 -- if we are not in split view, we check if we killed one of the main buffers (curr, left, right) to disable NNP
-                if not S.hasSplits(S) and not W.stateWinsActive(p.event, false) then
+                if not S.hasSplits(S) and not W.stateWinsActive(false) then
                     D.log(p.event, "one of the NNP main buffers have been closed, disabling...")
 
                     return N.disable(p.event)
@@ -252,7 +252,7 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(nil) or not S.hasSplits(S) or W.stateWinsActive(p.event, true) then
+                if E.skip(nil) or not S.hasSplits(S) or W.stateWinsActive(true) then
                     return
                 end
 

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -238,7 +238,7 @@ end
 ---@return boolean
 ---@private
 function State:isActiveTabValid()
-    return vim.api.nvim_tabpage_is_valid(self.activeTab)
+    return self.isActiveTabRegistered(self) and vim.api.nvim_tabpage_is_valid(self.activeTab)
 end
 
 ---Whether the `activeTab` is registered in the state or not.

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -294,30 +294,23 @@ end
 
 ---Determine if the tab wins are still active and valid.
 ---
----@param scope string: the method that called this one.
 ---@param checkSplits boolean: whether splits state should be considered or not.
 ---@return boolean: whether all windows are active and valid or not.
 ---@private
-function W.stateWinsActive(scope, checkSplits)
+function W.stateWinsActive(checkSplits)
     if not S.isActiveTabValid(S) then
-        D.log(scope, "active tab not valid")
-
         return false
     end
 
     local tab = S.getTabSafe(S)
 
     if tab == nil then
-        D.log(scope, "tab is nil")
-
         return false
     end
 
     if tab.wins.main ~= nil then
         for _, side in pairs(tab.wins.main) do
             if not vim.api.nvim_win_is_valid(side) then
-                D.log(scope, "main not valid anymore")
-
                 return false
             end
         end
@@ -326,8 +319,6 @@ function W.stateWinsActive(scope, checkSplits)
     if checkSplits and tab.wins.splits ~= nil then
         for _, split in pairs(tab.wins.splits) do
             if not vim.api.nvim_win_is_valid(split.id) then
-                D.log(scope, "split not valid anymore")
-
                 return false
             end
         end

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -294,25 +294,42 @@ end
 
 ---Determine if the tab wins are still active and valid.
 ---
----@param tab table: the table where the tab information are stored.
+---@param scope string: the method that called this one.
 ---@param checkSplits boolean: whether splits state should be considered or not.
 ---@return boolean: whether all windows are active and valid or not.
 ---@private
-function W.stateWinsActive(tab, checkSplits)
-    if not vim.api.nvim_tabpage_is_valid(tab.id) then
+function W.stateWinsActive(scope, checkSplits)
+    if not S.isActiveTabValid(S) then
+        D.log(scope, "active tab not valid")
+
         return false
     end
 
-    local wins = vim.api.nvim_tabpage_list_wins(tab.id)
-    local swins = tab.wins.main
+    local tab = S.getTabSafe(S)
 
-    if checkSplits and tab.wins.splits ~= nil then
-        swins = S.getRegisteredWins(S)
+    if tab == nil then
+        D.log(scope, "tab is nil")
+
+        return false
     end
 
-    for _, swin in pairs(swins) do
-        if not vim.tbl_contains(wins, swin) then
-            return false
+    if tab.wins.main ~= nil then
+        for _, side in pairs(tab.wins.main) do
+            if not vim.api.nvim_win_is_valid(side) then
+                D.log(scope, "main not valid anymore")
+
+                return false
+            end
+        end
+    end
+
+    if checkSplits and tab.wins.splits ~= nil then
+        for _, split in pairs(tab.wins.splits) do
+            if not vim.api.nvim_win_is_valid(split.id) then
+                D.log(scope, "split not valid anymore")
+
+                return false
+            end
         end
     end
 

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -257,4 +257,165 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     })
 end
 
+T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
+    child.restart({ "-u", "scripts/init_auto_open.lua" })
+
+    child.cmd("badd 1")
+    eq_state(child, "enabled", true)
+    eq_state(child, "activeTab", 1)
+    eq_state(child, "tabs", {
+        {
+            id = 1,
+            layers = {
+                split = 1,
+                vsplit = 1,
+            },
+            scratchPadEnabled = false,
+            wins = {
+                integrations = Co.integrations,
+                main = {
+                    curr = 1000,
+                    left = 1001,
+                    right = 1002,
+                },
+            },
+        },
+    })
+
+    child.cmd("tabnew")
+    child.cmd("badd 2")
+    eq_state(child, "enabled", true)
+    eq_state(child, "activeTab", 2)
+    eq_state(child, "tabs", {
+        {
+            id = 1,
+            layers = {
+                split = 1,
+                vsplit = 1,
+            },
+            scratchPadEnabled = false,
+            wins = {
+                integrations = Co.integrations,
+                main = {
+                    curr = 1000,
+                    left = 1001,
+                    right = 1002,
+                },
+            },
+        },
+        {
+            id = 2,
+            layers = {
+                split = 1,
+                vsplit = 1,
+            },
+            scratchPadEnabled = false,
+            wins = {
+                integrations = Co.integrations,
+                main = {
+                    curr = 1003,
+                    left = 1004,
+                    right = 1005,
+                },
+            },
+        },
+    })
+
+    child.cmd("NoNeckPain")
+    eq_state(child, "tabs", {
+        {
+            id = 1,
+            layers = {
+                split = 1,
+                vsplit = 1,
+            },
+            scratchPadEnabled = false,
+            wins = {
+                integrations = Co.integrations,
+                main = {
+                    curr = 1000,
+                    left = 1001,
+                    right = 1002,
+                },
+            },
+        },
+    })
+
+    child.cmd("NoNeckPain")
+    eq_state(child, "tabs", {
+        {
+            id = 1,
+            layers = {
+                split = 1,
+                vsplit = 1,
+            },
+            scratchPadEnabled = false,
+            wins = {
+                integrations = Co.integrations,
+                main = {
+                    curr = 1000,
+                    left = 1001,
+                    right = 1002,
+                },
+            },
+        },
+        {
+            id = 2,
+            layers = {
+                split = 1,
+                vsplit = 1,
+            },
+            scratchPadEnabled = false,
+            wins = {
+                integrations = Co.integrations,
+                main = {
+                    curr = 1003,
+                    left = 1006,
+                    right = 1007,
+                },
+            },
+        },
+    })
+
+    child.cmd("tabprevious")
+    eq_state(child, "activeTab", 1)
+    eq_state(child, "tabs", {
+        {
+            id = 1,
+            layers = {
+                split = 1,
+                vsplit = 1,
+            },
+            scratchPadEnabled = false,
+            wins = {
+                integrations = Co.integrations,
+                main = {
+                    curr = 1000,
+                    left = 1001,
+                    right = 1002,
+                },
+            },
+        },
+        {
+            id = 2,
+            layers = {
+                split = 1,
+                vsplit = 1,
+            },
+            scratchPadEnabled = false,
+            wins = {
+                integrations = Co.integrations,
+                main = {
+                    curr = 1003,
+                    left = 1006,
+                    right = 1007,
+                },
+            },
+        },
+    })
+
+    child.cmd("tabprevious")
+    eq_state(child, "activeTab", 2)
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/268

this pr tries to prevent unsynced state when adding/removing/switching tabs