### PR TITLE
fix(tabs): prevent wrong activeTab index

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -116,10 +116,9 @@ function N.enable(scope)
         return nil
     end
 
-    D.log(scope, "calling enable for tab %d", S.activeTab)
+    D.log(scope, "calling enable for tab %d", A.getCurrentTab())
 
-    -- register the new tab.
-    S.setTab(S, S.activeTab)
+    S.setTab(S, A.getCurrentTab())
 
     local augroupName = A.getAugroupName(S.activeTab)
     vim.api.nvim_create_augroup(augroupName, { clear = true })
@@ -141,7 +140,7 @@ function N.enable(scope)
                 local tab = S.getTab(S)
 
                 if tab ~= nil then
-                    if vim.api.nvim_get_current_tabpage() ~= tab.id then
+                    if A.getCurrentTab() ~= tab.id then
                         return
                     end
                 end
@@ -161,9 +160,9 @@ function N.enable(scope)
                     S.refreshTabs(S, S.activeTab)
                 end
 
-                S.setActiveTab(S, vim.api.nvim_get_current_tabpage())
+                D.log(p.event, "leaving tab %d", S.activeTab)
 
-                D.log(p.event, "new tab page registered %d", S.activeTab)
+                S.setActiveTab(S, A.getCurrentTab())
             end)
         end,
         group = augroupName,

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -2,22 +2,15 @@ local A = require("no-neck-pain.util.api")
 local C = require("no-neck-pain.util.constants")
 local D = require("no-neck-pain.util.debug")
 
-local State = { enabled = false, activeTab = 1, tabs = nil }
+local State = { enabled = false, activeTab = A.getCurrentTab(), tabs = nil }
 
 ---Sets the state to its original value.
 ---
 ---@private
 function State:init()
     self.enabled = false
-    self.activeTab = 1
+    self.activeTab = A.getCurrentTab()
     self.tabs = nil
-end
-
----Sets the state integrations to its original value.
----
----@private
-function State:initIntegrations()
-    self.tabs[self.activeTab].wins.integrations = vim.deepcopy(C.integrations)
 end
 
 ---Sets the state splits to its original value.
@@ -33,7 +26,7 @@ end
 ---@return number: the total `tabs` in the state.
 ---@private
 function State:refreshTabs(id)
-    id = id or vim.api.nvim_get_current_tabpage()
+    id = id or A.getCurrentTab()
 
     local refreshedTabs = {}
 
@@ -390,28 +383,24 @@ end
 
 ---Gets the tab with the given `id` from the state.
 ---
----@param id number?: the id of the tab to get, fallbacks to the currently active one when `nil`.
 ---@return table: the `tab` information.
 ---@private
-function State:getTab(id)
-    id = id or self.activeTab or vim.api.nvim_get_current_tabpage()
+function State:getTab()
+    local id = self.activeTab or A.getCurrentTab()
 
     return self.tabs[id]
 end
 
 ---Gets the tab with the given `id` from the state, safely returns nil if we are not sure it exists.
 ---
----@param id number?: the id of the tab to get, fallbacks to the currently active one when `nil`.
 ---@return table?: the `tab` information, or `nil` if it's not found.
 ---@private
-function State:getTabSafe(id)
+function State:getTabSafe()
     if not self.hasTabs(self) then
         return nil
     end
 
-    id = id or self.activeTab or vim.api.nvim_get_current_tabpage()
-
-    return self.tabs[id]
+    return self.getTab(self)
 end
 
 ---Sets the given `bool` value to the active tab scratchpad.
@@ -437,6 +426,8 @@ end
 function State:setTab(id)
     self.tabs = self.tabs or {}
 
+    D.log("setTab", "registered new tab %d", id)
+
     self.tabs[id] = {
         id = id,
         scratchPadEnabled = false,
@@ -451,10 +442,10 @@ function State:setTab(id)
                 right = nil,
             },
             splits = nil,
+            integrations = vim.deepcopy(C.integrations),
         },
     }
-
-    self.tabs[id].wins.integrations = self.initIntegrations(self)
+    self.activeTab = id
 end
 
 ---Sets the `layers` of the currently active tab.

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -2,6 +2,14 @@ local D = require("no-neck-pain.util.debug")
 
 local A = { debouncers = {} }
 
+---Returns the current tab page or 1 if it's nil.
+---
+---@return number: the tabpage id.
+---@private
+function A.getCurrentTab()
+    return vim.api.nvim_get_current_tabpage() or 1
+end
+
 ---Returns the name of the augroup for the given tab ID.
 ---
 ---@param id number?: the id of the tab.

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -21,7 +21,7 @@ function E.skip(tab)
     end
 
     if tab ~= nil then
-        if vim.api.nvim_get_current_tabpage() ~= tab.id then
+        if A.getCurrentTab() ~= tab.id then
             return true
         end
 


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/268 (again)

we were relying on a default (and wrong) initial `activeTab` value which was set to 1. While working properly when enabling on the tab 1, then the others, it broke when we were initializing the plugin at a tab index other than 1.

we now rely on an helper than ensures the `activeTab` comes from the neovim state and not hardcoded.