### PR TITLE
fix(tabs): prevent unsynchronized state on toggle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ test-splits:
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua MiniTest.run_file('tests/test_splits.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 
+test-tabs:
+	nvim --version | head -n 1 && echo ''
+	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
+		-c "lua MiniTest.run_file('tests/test_tabs.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
+
 deps:
 	@mkdir -p deps
 	git clone --depth 1 https://github.com/echasnovski/mini.nvim deps/mini.nvim

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -155,18 +155,30 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "TabLeave" }, {
         callback = function(p)
             vim.schedule(function()
-                -- if the left tab is not valid anymore, we can remove it from the state
-                if not S.isActiveTabValid(S) then
+                if
+                    S.isActiveTabRegistered(S) and not vim.api.nvim_tabpage_is_valid(S.activeTab)
+                then
                     S.refreshTabs(S, S.activeTab)
+                    D.log(p.event, "tab %d is now inactive", S.activeTab)
+                else
+                    D.log(p.event, "tab %d left", S.activeTab)
                 end
-
-                D.log(p.event, "leaving tab %d", S.activeTab)
-
-                S.setActiveTab(S, A.getCurrentTab())
             end)
         end,
         group = augroupName,
-        desc = "Refreshes the active tab state",
+        desc = "Removes potentially inactive tabs from the state",
+    })
+
+    vim.api.nvim_create_autocmd({ "TabEnter" }, {
+        callback = function(p)
+            vim.schedule(function()
+                S.setActiveTab(S, A.getCurrentTab())
+
+                D.log(p.event, "tab %d entered", S.activeTab)
+            end)
+        end,
+        group = augroupName,
+        desc = "Keeps track of the currently active tab",
     })
 
     vim.api.nvim_create_autocmd({ "WinEnter" }, {

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -32,7 +32,7 @@ function State:refreshTabs(id)
 
     for _, tab in pairs(self.tabs) do
         if tab.id ~= id and vim.api.nvim_tabpage_is_valid(tab.id) then
-            table.insert(refreshedTabs, tab)
+            refreshedTabs[tab.id] = tab
         end
     end
 

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -528,4 +528,74 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     })
 end
 
+T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
+    child.lua([[require('no-neck-pain').setup({width=50})]])
+    eq_type_global(child, "_G.NoNeckPain.config", "table")
+    eq_type_global(child, "_G.NoNeckPain.state", "nil")
+
+    eq(child.api.nvim_get_current_tabpage(), 1)
+    child.cmd("badd 1")
+
+    child.cmd("tabnew")
+    eq(child.api.nvim_get_current_tabpage(), 2)
+    child.cmd("badd 2")
+
+    eq_type_global(child, "_G.NoNeckPain.state", "nil")
+    child.cmd("NoNeckPain")
+    eq(child.api.nvim_get_current_tabpage(), 2)
+    eq_type_global(child, "_G.NoNeckPain.state", "table")
+    eq_state(child, "enabled", true)
+    eq_state(child, "tabs[1]", vim.NIL)
+    eq_state(child, "activeTab", 2)
+    eq_state(child, "tabs[2]", {
+        id = 2,
+        layers = {
+            split = 1,
+            vsplit = 1,
+        },
+        scratchPadEnabled = false,
+        wins = {
+            integrations = Co.integrations,
+            main = {
+                curr = 1001,
+                left = 1002,
+                right = 1003,
+            },
+        },
+    })
+
+    child.cmd("tabprevious")
+    eq(child.api.nvim_get_current_tabpage(), 1)
+    eq_type_global(child, "_G.NoNeckPain.state", "table")
+    eq_state(child, "enabled", true)
+    eq_state(child, "tabs[1]", vim.NIL)
+    eq_state(child, "activeTab", 1)
+
+    child.cmd("tabnext")
+    eq_type_global(child, "_G.NoNeckPain.state", "table")
+    eq(child.api.nvim_get_current_tabpage(), 2)
+    eq_state(child, "activeTab", 2)
+    eq_state(child, "enabled", true)
+    eq_state(child, "tabs[1]", vim.NIL)
+    eq_state(child, "tabs[2]", {
+        id = 2,
+        layers = {
+            split = 1,
+            vsplit = 1,
+        },
+        scratchPadEnabled = false,
+        wins = {
+            integrations = Co.integrations,
+            main = {
+                curr = 1001,
+                left = 1002,
+                right = 1003,
+            },
+        },
+    })
+
+    child.cmd("NoNeckPain")
+    eq_state(child, "tabs", vim.NIL)
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/273

the state doesn't really know which tab is the active one since we edit the state **before** leaving a tab.

this PR focuses on splitting concerns by handling the inactive tab cleanup at the `TabLeave` event time, while updating the active tab state at the `TabEnter` event level.

also fixes the refresh tab method which was messing up the order of the map by shifting everything at the first position