### PR TITLE
feat(api): support :bdelete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .SUFFIXES:
 
+TESTFILES=options mappings API splits tabs integrations buffers colors autocmds scratchpad
+
 all:
 
 test:
@@ -7,20 +9,10 @@ test:
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua MiniTest.run({ execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 
-test-integrations:
+$(addprefix test-, $(TESTFILES)): test-%:
 	nvim --version | head -n 1 && echo ''
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
-		-c "lua MiniTest.run_file('tests/test_integrations.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
-
-test-splits:
-	nvim --version | head -n 1 && echo ''
-	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
-		-c "lua MiniTest.run_file('tests/test_splits.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
-
-test-tabs:
-	nvim --version | head -n 1 && echo ''
-	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
-		-c "lua MiniTest.run_file('tests/test_tabs.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
+		-c "lua MiniTest.run_file('tests/test_$*.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 
 deps:
 	@mkdir -p deps

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -219,6 +219,10 @@ values:
       -- When `true`, disabling the plugin closes every other windows except the initially focused one.
       --- @type boolean
       killAllBuffersOnDisable = false,
+      -- When `true`, deleting the main no-neck-pain buffer with `:bd`, `:bdelete` does not disable the plugin, it fallbacks on the newly focused window and refreshes the state by re-creating side-windows if necessary.
+      -- note: the default value will change to `true` in the next major release (^2.x.y).
+      --- @type boolean
+      fallbackOnBufferDelete = false,
       -- Adds autocmd (@see `:h autocmd`) which aims at automatically enabling the plugin.
       --- @type table
       autocmds = {

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -217,10 +217,11 @@ values:
       --- @type boolean
       disableOnLastBuffer = false,
       -- When `true`, disabling the plugin closes every other windows except the initially focused one.
+      --- @usage: this parameter will be renamed `killAllWindowsOnDisable` in the next major release (^2.x.y).
       --- @type boolean
       killAllBuffersOnDisable = false,
       -- When `true`, deleting the main no-neck-pain buffer with `:bd`, `:bdelete` does not disable the plugin, it fallbacks on the newly focused window and refreshes the state by re-creating side-windows if necessary.
-      -- note: the default value will change to `true` in the next major release (^2.x.y).
+      --- @usage: the default value will change to `true` in the next major release (^2.x.y).
       --- @type boolean
       fallbackOnBufferDelete = false,
       -- Adds autocmd (@see `:h autocmd`) which aims at automatically enabling the plugin.

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -152,10 +152,11 @@ NoNeckPain.options = {
     --- @type boolean
     disableOnLastBuffer = false,
     -- When `true`, disabling the plugin closes every other windows except the initially focused one.
+    --- @usage: this parameter will be renamed `killAllWindowsOnDisable` in the next major release (^2.x.y).
     --- @type boolean
     killAllBuffersOnDisable = false,
     -- When `true`, deleting the main no-neck-pain buffer with `:bd`, `:bdelete` does not disable the plugin, it fallbacks on the newly focused window and refreshes the state by re-creating side-windows if necessary.
-    -- note: the default value will change to `true` in the next major release (^2.x.y).
+    --- @usage: the default value will change to `true` in the next major release (^2.x.y).
     --- @type boolean
     fallbackOnBufferDelete = false,
     -- Adds autocmd (@see `:h autocmd`) which aims at automatically enabling the plugin.

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -402,9 +402,7 @@ end
 function NoNeckPain.setup(options)
     NoNeckPain.options = NoNeckPain.defaults(options or {})
 
-    if vim.fn.has("nvim-0.9") == 0 then
-        NoNeckPain.options.hasNvim9 = false
-    end
+    NoNeckPain.options.hasNvim9 = vim.fn.has("nvim-0.9") == 1
 
     D.warnDeprecation(NoNeckPain.options)
 

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -402,6 +402,10 @@ end
 function NoNeckPain.setup(options)
     NoNeckPain.options = NoNeckPain.defaults(options or {})
 
+    if vim.fn.has("nvim-0.9") == 0 then
+        NoNeckPain.options.hasNvim9 = false
+    end
+
     D.warnDeprecation(NoNeckPain.options)
 
     registerMappings(NoNeckPain.options.mappings, {

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -154,6 +154,10 @@ NoNeckPain.options = {
     -- When `true`, disabling the plugin closes every other windows except the initially focused one.
     --- @type boolean
     killAllBuffersOnDisable = false,
+    -- When `true`, deleting the main no-neck-pain buffer with `:bd`, `:bdelete` does not disable the plugin, it fallbacks on the newly focused window and refreshes the state by re-creating side-windows if necessary.
+    -- note: the default value will change to `true` in the next major release (^2.x.y).
+    --- @type boolean
+    fallbackOnBufferDelete = false,
     -- Adds autocmd (@see `:h autocmd`) which aims at automatically enabling the plugin.
     --- @type table
     autocmds = {

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -8,6 +8,8 @@ local W = require("no-neck-pain.wins")
 local N = {}
 
 -- Toggle the plugin by calling the `enable`/`disable` methods respectively.
+--
+--- @param scope string: internal identifier for logging purposes.
 ---@private
 function N.toggle(scope)
     if S.hasTabs(S) and S.isActiveTabRegistered(S) then
@@ -81,6 +83,9 @@ end
 
 --- Creates side buffers and set the tab state, focuses the `curr` window if required.
 --
+--- @param scope string: internal identifier for logging purposes.
+--- @param goToCurr boolean?: whether we should re-focus the `curr` window.
+--- @param skipIntegrations boolean?: whether we should skip the integrations logic.
 --- @return table: the state of the plugin.
 ---@private
 function N.init(scope, goToCurr, skipIntegrations)
@@ -110,6 +115,8 @@ function N.init(scope, goToCurr, skipIntegrations)
 end
 
 --- Initializes the plugin, sets event listeners and internal state.
+---
+--- @param scope string: internal identifier for logging purposes.
 ---@private
 function N.enable(scope)
     if E.skipEnable() then
@@ -234,7 +241,7 @@ function N.enable(scope)
                 end
 
                 if S.hasSplits(S) then
-                    return D.log(p.event, "skip: splits are still active")
+                    return D.log(p.event, "skip quit logic: splits still active")
                 end
 
                 if
@@ -265,6 +272,8 @@ function N.enable(scope)
 
                     N.disable(string.format("%s:reset", p.event))
                     N.enable(string.format("%s:reset", p.event))
+
+                    vim.print(S.getSideID(S, "left"), vim.api.nvim_list_wins(), vim.api.nvim_get_current_win())
                 end
             end)
         end,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -272,12 +272,6 @@ function N.enable(scope)
 
                     N.disable(string.format("%s:reset", p.event))
                     N.enable(string.format("%s:reset", p.event))
-
-                    vim.print(
-                        S.getSideID(S, "left"),
-                        vim.api.nvim_list_wins(),
-                        vim.api.nvim_get_current_win()
-                    )
                 end
             end)
         end,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -255,7 +255,13 @@ function N.enable(scope)
                 -- if we still have a side valid but curr has been deleted (mostly because of a :bd),
                 -- we will fallback to the first valid side
                 if not S.isSideWinValid(S, "curr") then
-                    D.log(p.event, "curr has been closed, resetting state")
+                    if p.event == "QuitPre" then
+                        D.log(p.event, "one of the NNP side has been closed, disabling...")
+
+                        return N.disable(p.event)
+                    end
+
+                    D.log(p.event, "`curr` has been deleted, resetting state")
 
                     N.disable(string.format("%s:reset", p.event))
                     N.enable(string.format("%s:reset", p.event))

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -273,7 +273,11 @@ function N.enable(scope)
                     N.disable(string.format("%s:reset", p.event))
                     N.enable(string.format("%s:reset", p.event))
 
-                    vim.print(S.getSideID(S, "left"), vim.api.nvim_list_wins(), vim.api.nvim_get_current_win())
+                    vim.print(
+                        S.getSideID(S, "left"),
+                        vim.api.nvim_list_wins(),
+                        vim.api.nvim_get_current_win()
+                    )
                 end
             end)
         end,

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -281,7 +281,7 @@ end
 ---@return boolean
 ---@private
 function State:isSideWinValid(side)
-    local id = self.tabs[self.activeTab].wins.main[side]
+    local id = self.getSideID(self, side)
 
     return id ~= nil and vim.api.nvim_win_is_valid(id)
 end

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -164,11 +164,19 @@ function W.createSideBuffers(skipIntegrations)
                 local bufid = vim.api.nvim_win_get_buf(id)
 
                 for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
-                    vim.api.nvim_set_option_value(opt, val, { buf = bufid })
+                    if _G.NoNeckPain.config.hasNvim9 then
+                        vim.api.nvim_set_option_value(opt, val, { buf = bufid })
+                    else
+                        vim.api.nvim_buf_set_option(bufid, opt, val)
+                    end
                 end
 
                 for opt, val in pairs(_G.NoNeckPain.config.buffers[side].wo) do
-                    vim.api.nvim_set_option_value(opt, val, { win = id, scope = "local" })
+                    if _G.NoNeckPain.config.hasNvim9 then
+                        vim.api.nvim_set_option_value(opt, val, { win = id, scope = "local" })
+                    else
+                        vim.api.nvim_win_set_option(id, opt, val)
+                    end
                 end
 
                 if _G.NoNeckPain.config.buffers[side].scratchPad.enabled then

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -24,7 +24,7 @@ end
 ---
 ---@param scope string: the scope from where this function is called.
 ---@param id number: the id of the window.
----@param side "left"|"right": the side of the window being resized, used for logging only.
+---@param side "left"|"right": the side of the window being closed, used for logging only.
 ---@private
 function W.close(scope, id, side)
     D.log(scope, "closing %s window", side)
@@ -161,12 +161,14 @@ function W.createSideBuffers(skipIntegrations)
                     vim.api.nvim_buf_set_name(0, "no-neck-pain-" .. side)
                 end
 
+                local bufid = vim.api.nvim_win_get_buf(id)
+
                 for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
-                    vim.api.nvim_buf_set_option(0, opt, val)
+                    vim.api.nvim_set_option_value(opt, val, { buf = bufid })
                 end
 
                 for opt, val in pairs(_G.NoNeckPain.config.buffers[side].wo) do
-                    vim.api.nvim_win_set_option(id, opt, val)
+                    vim.api.nvim_set_option_value(opt, val, { win = id, scope = "local" })
                 end
 
                 if _G.NoNeckPain.config.buffers[side].scratchPad.enabled then

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -14,6 +14,10 @@ function Helpers.winsInTab(child, tab)
     return child.lua_get("vim.api.nvim_tabpage_list_wins(" .. tab .. ")")
 end
 
+function Helpers.listBuffers(child)
+    return child.lua_get("vim.api.nvim_list_bufs()")
+end
+
 local function errorMessage(str, pattern)
     return string.format("Pattern: %s\nObserved string: %s", vim.inspect(pattern), str)
 end

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -32,7 +32,7 @@ T["auto command"]["does not create side buffers window's width < options.width"]
     })
 end
 
-T["auto command"]["does not shift using when opening/closing float window"] = function()
+T["auto command"]["does not shift when opening/closing float window"] = function()
     child.set_size(5, 200)
     child.lua([[
         require('no-neck-pain').setup({width=50})

--- a/tests/test_options.lua
+++ b/tests/test_options.lua
@@ -1,0 +1,105 @@
+local helpers = dofile("tests/helpers.lua")
+
+local child = helpers.new_child_neovim()
+local eq = helpers.expect.equality
+local eq_state, eq_buf_width = helpers.expect.state_equality, helpers.expect.buf_width_equality
+
+local new_set = MiniTest.new_set
+
+local T = new_set({
+    hooks = {
+        -- This will be executed before every (even nested) case
+        pre_case = function()
+            -- Restart child process with custom 'init.lua' script
+            child.restart({ "-u", "scripts/minimal_init.lua" })
+        end,
+        -- This will be executed one after all tests from this set are finished
+        post_once = child.stop,
+    },
+})
+
+T["minSideBufferWidth"] = new_set()
+
+T["minSideBufferWidth"]["closes side buffer respecting the given value"] = function()
+    child.set_size(500, 500)
+    child.lua([[
+        require('no-neck-pain').setup({width=50})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq_state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
+
+    eq_buf_width(child, "tabs[1].wins.main.left", 15)
+    eq_buf_width(child, "tabs[1].wins.main.right", 15)
+
+    child.lua([[
+        require('no-neck-pain').disable()
+        require('no-neck-pain').setup({width=50, minSideBufferWidth=20})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq_state(child, "tabs[1].wins.main", { curr = 1000 })
+end
+
+T["killAllBuffersOnDisable"] = new_set()
+
+T["killAllBuffersOnDisable"]["closes every windows when disabling the plugin"] = function()
+    child.set_size(500, 500)
+    child.lua([[
+        require('no-neck-pain').setup({width=50,killAllBuffersOnDisable=true})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq_state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
+
+    eq(helpers.listBuffers(child), { 1, 2, 3 })
+    child.cmd("badd 1")
+    child.cmd("vsplit")
+    child.cmd("split")
+    eq(helpers.listBuffers(child), { 1, 2, 3, 4 })
+    eq(helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
+
+    child.lua([[
+        require('no-neck-pain').disable()
+    ]])
+
+    eq(helpers.listBuffers(child), { 1, 2, 3, 4 })
+    eq(helpers.winsInTab(child), { 1000 })
+end
+
+T["fallbackOnBufferDelete"] = new_set()
+
+T["fallbackOnBufferDelete"]["invoking :bd keeps nnp enabled"] = function()
+    child.set_size(500, 500)
+    child.lua([[
+        require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq_state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
+
+    child.cmd("badd 1")
+    child.cmd("bd")
+    child.loop.sleep(500)
+
+    eq_state(child, "tabs[1].wins.main", { curr = 1003, left = 1004, right = 1005 })
+end
+
+T["fallbackOnBufferDelete"]["still allows nvim to quit"] = function()
+    child.set_size(500, 500)
+    child.lua([[
+        require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true})
+        require('no-neck-pain').enable()
+    ]])
+
+    eq_state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
+
+    child.cmd("badd 1")
+    child.cmd("q")
+
+    helpers.expect.error(function()
+        eq_state(child, "tabs[1].wins.main", { curr = 1003, left = 1004, right = 1005 })
+    end)
+end
+
+return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/243 https://github.com/shortcuts/no-neck-pain.nvim/issues/280

because `:bd` closes the window the buffer is attached to, we need to provide a custom way to fallback to an other window. As of now, the solution is opt-in because it might not be perfect, but should still cover many use cases.

In order to use this feature, a user must set `fallbackOnBufferDelete = true`