### PR TITLE
fix(hl): prevent global highlights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 deps
 **.DS_Store
 .luarc.json
+nightly

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ test:
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua MiniTest.run({ execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 
+test-nightly:
+	./nightly/nvim-macos/bin/nvim --version | head -n 1 && echo ''
+	./nightly/nvim-macos/bin/nvim --headless --noplugin -u ./scripts/minimal_init.lua \
+		-c "lua MiniTest.run({ execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
+
 $(addprefix test-, $(TESTFILES)): test-%:
 	nvim --version | head -n 1 && echo ''
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
@@ -38,4 +43,4 @@ documentation:
 documentation-ci: deps documentation
 
 lint:
-	stylua . -g '*.lua' -g '!deps/'
+	stylua . -g '*.lua' -g '!deps/' -g '!nightly/'

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -141,7 +141,7 @@ end
 ---@private
 function C.init(win, side)
     -- init namespace for the current tab
-    local id, name = S.setNamespace(S, side)
+    local id, _ = S.setNamespace(S, side)
     local bufnr = vim.api.nvim_win_get_buf(win)
 
     -- create groups to assign them to the namespace

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -140,39 +140,39 @@ end
 ---@param side "left"|"right": the side of the window being resized, used for logging only.
 ---@private
 function C.init(win, side)
+    -- init namespace for the current tab
+    local id, name = S.setNamespace(S, side)
+    local bufnr = vim.api.nvim_win_get_buf(win)
+
+    -- create groups to assign them to the namespace
     local backgroundGroup = string.format("NoNeckPain_background_tab_%s_side_%s", S.activeTab, side)
     local textGroup = string.format("NoNeckPain_text_tab_%s_side_%s", S.activeTab, side)
 
-    -- clear groups
-    vim.cmd(string.format("highlight! clear %s NONE", backgroundGroup))
-    vim.cmd(string.format("highlight! clear %s NONE", textGroup))
-
-    -- create group for background
     vim.cmd(
         string.format(
-            "highlight! %s guifg=%s guibg=%s",
+            "hi! %s guifg=%s guibg=%s",
             backgroundGroup,
             _G.NoNeckPain.config.buffers[side].colors.background,
             _G.NoNeckPain.config.buffers[side].colors.background
         )
     )
-
-    -- create group for text
     vim.cmd(
         string.format(
-            "highlight! %s guifg=%s guibg=%s",
+            "hi! %s guifg=%s guibg=%s",
             textGroup,
             _G.NoNeckPain.config.buffers[side].colors.text,
             _G.NoNeckPain.config.buffers[side].colors.background
         )
     )
 
-    local groups = {
-        Normal = textGroup,
-        NormalNC = textGroup,
-    }
+    -- assign groups to the namespace
+    vim.api.nvim_buf_add_highlight(bufnr, id, backgroundGroup, 0, 0, -1)
+    vim.api.nvim_buf_add_highlight(bufnr, id, textGroup, 0, 0, -1)
 
-    -- on transparent backgrounds we don't set those two to prevent white lines.
+    -- link nnp and neovim hl groups
+    local groups = { Normal = textGroup, NormalNC = textGroup }
+
+    -- we only set those for non transparent backgrouns to prevent white lines.
     if _G.NoNeckPain.config.buffers[side].colors.background ~= "NONE" then
         groups = vim.tbl_extend("keep", groups, {
             WinSeparator = backgroundGroup,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -384,22 +384,14 @@ function N.disable(scope)
 
     -- determine if we should quit vim or just close the window
     for _, side in pairs(Co.SIDES) do
-        vim.cmd(
-            string.format(
-                "highlight! clear NoNeckPain_background_tab_%s_side_%s NONE",
-                S.activeTab,
-                side
-            )
-        )
-        vim.cmd(
-            string.format("highlight! clear NoNeckPain_text_tab_%s_side_%s NONE", S.activeTab, side)
-        )
-
         if S.isSideRegistered(S, side) then
             local activeWins = vim.api.nvim_tabpage_list_wins(S.activeTab)
             local haveOtherWins = false
-
             local sideID = S.getSideID(S, side)
+
+            if S.isSideWinValid(S, side) then
+                S.removeNamespace(S, vim.api.nvim_win_get_buf(sideID), side)
+            end
 
             -- if we have other wins active and usable, we won't quit vim
             for _, activeWin in pairs(activeWins) do

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -360,6 +360,43 @@ function State:setEnabled()
     self.enabled = true
 end
 
+---Creates a namespace for the given `side` and stores it in the state.
+---
+---@param side "left"|"right": the side.
+--
+---@return number: the created namespace id.
+---@return string: the name of the created namespace.
+---@private
+function State:setNamespace(side)
+    if self.namespaces == nil then
+        self.namespaces = {}
+    end
+
+    local name = string.format("NoNeckPain_tab_%s_side_%s", self.activeTab, side)
+    local id = vim.api.nvim_create_namespace(name)
+
+    self.namespaces[side] = id
+
+    return id, name
+end
+
+---Clears the given `side` namespace and resets its state value.
+---
+---@param bufnr number: the buffer number.
+---@param side "left"|"right": the side.
+---@private
+function State:removeNamespace(bufnr, side)
+    if self.namespaces == nil or self.namespaces[side] == nil then
+        return
+    end
+
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+        return
+    end
+
+    vim.api.nvim_buf_clear_namespace(bufnr, self.namespaces[side], 0, -1)
+end
+
 ---Sets the active tab.
 ---@param id number: the id of the active tab.
 ---

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -363,7 +363,6 @@ end
 ---Creates a namespace for the given `side` and stores it in the state.
 ---
 ---@param side "left"|"right": the side.
---
 ---@return number: the created namespace id.
 ---@return string: the name of the created namespace.
 ---@private

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -146,6 +146,12 @@ T["setup"]["`common` options spreads it to `left` and `right` buffers"] = functi
 end
 
 T["setup"]["supports transparent bgs"] = function()
+    child.cmd([[
+        highlight Normal guibg=none
+        highlight NonText guibg=none
+        highlight Normal ctermbg=none
+        highlight NonText ctermbg=none
+    ]])
     child.lua([[require('no-neck-pain').setup()]])
 
     eq_config(child, "buffers.colors", {
@@ -229,13 +235,15 @@ T["color"]["buffers: throws with wrong background value"] = function()
 end
 
 T["color"]["refreshes the stored color when changing colorscheme"] = function()
+    child.cmd([[
+        highlight Normal guibg=none
+        highlight NonText guibg=none
+        highlight Normal ctermbg=none
+        highlight NonText ctermbg=none
+    ]])
     child.lua([[
-    require('no-neck-pain').setup({
-        autocmds = {
-            reloadOnColorSchemeChange=true,
-        },
-    })
-    require('no-neck-pain').enable()
+        require('no-neck-pain').setup({ autocmds = { reloadOnColorSchemeChange=true } })
+        require('no-neck-pain').enable()
     ]])
 
     eq_config(child, "buffers.colors", {


### PR DESCRIPTION
## 📃 Summary

Add namespaces to highlight groups and use local scopes in order to prevent impacting other buffers