### PR TITLE
fix(hl): prevent wrong bg and text colors after `:bd`

### DIFF
--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -41,7 +41,7 @@ Disables the plugin, clear highlight groups and autocmds, closes side buffers an
 NoNeckPain's buffer `vim.wo` options.
 @see window options `:h vim.wo`
 
-Type~
+Type ~
 `(table)`
 values:
 >
@@ -74,7 +74,7 @@ values:
 NoNeckPain's buffer `vim.bo` options.
 @see buffer options `:h vim.bo`
 
-Type~
+Type ~
 `(table)`
 values:
 >
@@ -101,7 +101,7 @@ NoNeckPain's scratchpad buffer options.
 Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
 note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
 
-Type~
+Type ~
 `(table)`
 values:
 >
@@ -129,7 +129,7 @@ values:
                         `NoNeckPain.bufferOptionsColors`
 NoNeckPain's buffer color options.
 
-Type~
+Type ~
 `(table)`
 values:
 >
@@ -172,7 +172,7 @@ values:
                            `NoNeckPain.bufferOptions`
 NoNeckPain's buffer side buffer option.
 
-Type~
+Type ~
 `(table)`
 values:
 >
@@ -197,7 +197,7 @@ values:
                               `NoNeckPain.options`
 NoNeckPain's plugin config.
 
-Type~
+Type ~
 `(table)`
 values:
 >
@@ -363,10 +363,10 @@ values:
                          `NoNeckPain.setup`({options})
 Define your no-neck-pain setup.
 
-Parameters~
+Parameters ~
 {options} `(table)` Module config table. See |NoNeckPain.options|.
 
-Usage~
+Usage ~
 `require("no-neck-pain").setup()` (add `{}` with your |NoNeckPain.options| table)
 
 

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -96,7 +96,6 @@ function C.parse(buffers)
 
     for _, side in pairs(Co.SIDES) do
         if buffers[side].enabled then
-            -- if the side buffer colors.background is not defined, we fallback to the common option.
             buffers[side].colors.background = C.matchAndBlend(
                 buffers[side].colors.background,
                 buffers[side].colors.blend or buffers.colors.blend

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -99,29 +99,8 @@ end
 ---@return table: the parsed buffers.
 ---@private
 function C.parse(buffers)
-    if
-        skipColorParsing(buffers.colors)
-        and (not buffers.left.enabled or skipColorParsing(buffers.left.colors))
-        and (not buffers.right.enabled or skipColorParsing(buffers.right.colors))
-    then
-        return buffers
-    end
-
-    local defaultBackground = vim.api.nvim_get_hl_by_name("Normal", true).background
-
-    -- if the user did not provided a custom background color, and have a transparent bg,
-    -- we set it to the global options and let the loop do the spread below.
-    if
-        buffers.colors.background == nil
-        and (defaultBackground == nil or string.lower(defaultBackground) == "none")
-    then
-        buffers.colors.background = "NONE"
-        buffers.colors.text = "#ffffff"
-    else
-        buffers.colors.background = C.matchAndBlend(
-            buffers.colors.background or string.format("#%06X", defaultBackground),
-            buffers.colors.blend
-        )
+    if buffers.colors.background ~= nil then
+        buffers.colors.background = C.matchAndBlend(buffers.colors.background, buffers.colors.blend)
     end
 
     for _, side in pairs(Co.SIDES) do
@@ -148,7 +127,11 @@ end
 ---@param side "left"|"right": the side of the window being resized, used for logging only.
 ---@private
 function C.init(win, side)
-    if skipColorParsing(_G.NoNeckPain.config.buffers[side].colors) then
+    if
+        _G.NoNeckPain.config.buffers[side].colors.background == nil
+        and _G.NoNeckPain.config.buffers[side].colors.text == nil
+        and _G.NoNeckPain.config.buffers[side].colors.blend == 0
+    then
         return D.log("C.init", "skipping color initialization for side %s", side)
     end
 

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -90,9 +90,7 @@ end
 ---@return table: the parsed buffers.
 ---@private
 function C.parse(buffers)
-    if buffers.colors.background ~= nil then
-        buffers.colors.background = C.matchAndBlend(buffers.colors.background, buffers.colors.blend)
-    end
+    buffers.colors.background = C.matchAndBlend(buffers.colors.background, buffers.colors.blend)
 
     for _, side in pairs(Co.SIDES) do
         if buffers[side].enabled then

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -84,15 +84,6 @@ function C.matchAndBlend(colorCode, factor)
     return blend(colorCode, factor or 0)
 end
 
----Determines whether we should skip color handling for the given `colors` or not.
----
----@param colors table: the colors definition for a given side or global.
----@return boolean
----@private
-local function skipColorParsing(colors)
-    return colors.background == nil and colors.text == nil and colors.blend == 0
-end
-
 ---Parses to color for each buffer parameters, considering transparent backgrounds.
 ---
 ---@param buffers table: the buffers table to parse.

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -259,20 +259,24 @@ function N.enable(scope)
                     return N.disable(p.event)
                 end
 
+                if S.isSideWinValid(S, "curr") then
+                    D.log(p.event, "curr is still valid, skipping")
+
+                    return
+                end
+
                 -- if we still have a side valid but curr has been deleted (mostly because of a :bd),
                 -- we will fallback to the first valid side
-                if not S.isSideWinValid(S, "curr") then
-                    if p.event == "QuitPre" then
-                        D.log(p.event, "one of the NNP side has been closed, disabling...")
+                if p.event == "QuitPre" then
+                    D.log(p.event, "one of the NNP side has been closed, disabling...")
 
-                        return N.disable(p.event)
-                    end
-
-                    D.log(p.event, "`curr` has been deleted, resetting state")
-
-                    N.disable(string.format("%s:reset", p.event))
-                    N.enable(string.format("%s:reset", p.event))
+                    return N.disable(p.event)
                 end
+
+                D.log(p.event, "`curr` has been deleted, resetting state")
+
+                N.disable(string.format("%s:reset", p.event))
+                N.enable(string.format("%s:reset", p.event))
             end)
         end,
         group = augroupName,

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -34,10 +34,6 @@ end
 T["setup"] = MiniTest.new_set()
 
 T["setup"]["sets exposed methods and default options value"] = function()
-    child.cmd([[
-        highlight Normal guibg=black guifg=white
-        set background=dark
-    ]])
     child.lua([[require('no-neck-pain').setup()]])
 
     eq_type_global(child, "_G.NoNeckPain", "table")
@@ -81,7 +77,6 @@ T["setup"]["sets exposed methods and default options value"] = function()
     eq_config(child, "buffers.setNames", false)
 
     eq_config(child, "buffers.colors", {
-        background = "#000000",
         blend = 0,
     })
 
@@ -111,9 +106,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
         eq_type_config(child, "buffers." .. scope .. ".wo", "table")
 
         eq_config(child, "buffers." .. scope .. ".colors", {
-            background = "#000000",
             blend = 0,
-            text = "#7f7f7f",
         })
 
         eq_config(child, "buffers." .. scope .. ".bo", {

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -204,7 +204,6 @@ T["setup"]["(normal) assert side buffers have the same colors as the main buffer
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.right)")
     local rightbg = child.lua_get("vim.api.nvim_get_hl_by_name('Normal', true).background")
 
-    eq(currbg, 135)
     eq(currbg, leftbg)
     eq(currbg, rightbg)
 end

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -154,23 +154,11 @@ T["setup"]["supports transparent bgs"] = function()
     ]])
     child.lua([[require('no-neck-pain').setup()]])
 
-    eq_config(child, "buffers.colors", {
-        background = "NONE",
-        blend = 0,
-        text = "#ffffff",
-    })
+    eq_config(child, "buffers.colors", { blend = 0 })
 
-    eq_config(child, "buffers.left.colors", {
-        background = "NONE",
-        blend = 0,
-        text = "#ffffff",
-    })
+    eq_config(child, "buffers.left.colors", { blend = 0 })
 
-    eq_config(child, "buffers.right.colors", {
-        background = "NONE",
-        blend = 0,
-        text = "#ffffff",
-    })
+    eq_config(child, "buffers.right.colors", { blend = 0 })
 end
 
 T["setup"]["colors.background overrides a nil background when defined"] = function()
@@ -184,13 +172,11 @@ T["setup"]["colors.background overrides a nil background when defined"] = functi
     eq_config(child, "buffers.left.colors", {
         background = "#abcabc",
         blend = 0,
-        text = "#d5e4dd",
     })
 
     eq_config(child, "buffers.right.colors", {
         background = "#abcabc",
         blend = 0,
-        text = "#d5e4dd",
     })
 end
 
@@ -214,7 +200,6 @@ T["color"]["map integration name to a value"] = function()
             eq_config(child, "buffers." .. scope .. ".colors", {
                 background = value,
                 blend = 0,
-                text = C.matchAndBlend(value, 0.5),
             })
         end
     end
@@ -246,18 +231,11 @@ T["color"]["refreshes the stored color when changing colorscheme"] = function()
         require('no-neck-pain').enable()
     ]])
 
-    eq_config(child, "buffers.colors", {
-        background = "NONE",
-        blend = 0,
-        text = "#ffffff",
-    })
+    eq_config(child, "buffers.colors", { blend = 0 })
 
     child.cmd([[colorscheme peachpuff]])
 
-    eq_config(child, "buffers.colors", {
-        background = "#ffdab9",
-        blend = 0,
-    })
+    eq_config(child, "buffers.colors", { blend = 0 })
 end
 
 return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/286

We were setting highlight groups even when no configuration was provided, which created some discrepancies in case we were not correctly retrieving the variable, or if the theme changed during the nvim lifecycle. 

we now only create highlight groups if the user provide some colors configuration

- [x] only create hl when necessary
- [x] update tests to assert hl are not created
- [x] add tests to assert hl are created with custom config
- [x] add tests to assert buffers have colors defined in the config