### PR TITLE
fix(scratchPad): properly forward buffer/window options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ test-nightly:
 	./nightly/nvim-macos/bin/nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua MiniTest.run({ execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 
+test-0.8.3:
+	~/.local/share/bob/nvim-bin/nvim --version | head -n 1 && echo ''
+	~/.local/share/bob/nvim-bin/nvim --headless --noplugin -u ./scripts/minimal_init.lua \
+		-c "lua MiniTest.run({ execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
+
 $(addprefix test-, $(TESTFILES)): test-%:
 	nvim --version | head -n 1 && echo ''
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -378,14 +378,4 @@ Creates side buffers and set the tab state, focuses the `curr` window if require
 Disables the plugin for the given tab, clear highlight groups and autocmds, closes side buffers and resets the internal state.
 
 
-==============================================================================
-------------------------------------------------------------------------------
-                                                             *initSideOptions()*
-                        `initSideOptions`({id}, {side})
-the given `side` with the options from the user given configuration.
-Parameters ~
-{id} `(number:)` the id of the window.
-{side} "left"|"right"|"split": the side of the window to initialize.
-
-
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -96,10 +96,10 @@ values:
 ------------------------------------------------------------------------------
                                             *NoNeckPain.bufferOptionsScratchpad*
                       `NoNeckPain.bufferOptionsScratchpad`
-NoNeckPain's scratchpad buffer options.
+NoNeckPain's scratchPad buffer options.
 
 Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
-note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
+note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
 
 Type ~
 `(table)`
@@ -266,7 +266,7 @@ values:
           -- When `false`, the mapping is not created.
           --- @type string | { mapping: string, value: number }
           widthDown = "<Leader>n-",
-          -- Sets a global mapping to Neovim, which allows you to toggle the scratchpad feature.
+          -- Sets a global mapping to Neovim, which allows you to toggle the scratchPad feature.
           -- When `false`, the mapping is not created.
           --- @type string
           scratchPad = "<Leader>ns",
@@ -279,7 +279,7 @@ values:
           --- @type boolean
           setNames = false,
           -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
-          -- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
+          -- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
           --- see |NoNeckPain.bufferOptionsScratchpad|
           scratchPad = NoNeckPain.bufferOptionsScratchpad,
           -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
@@ -376,6 +376,16 @@ Creates side buffers and set the tab state, focuses the `curr` window if require
 
 ------------------------------------------------------------------------------
 Disables the plugin for the given tab, clear highlight groups and autocmds, closes side buffers and resets the internal state.
+
+
+==============================================================================
+------------------------------------------------------------------------------
+                                                             *initSideOptions()*
+                        `initSideOptions`({id}, {side})
+the given `side` with the options from the user given configuration.
+Parameters ~
+{id} `(number:)` the id of the window.
+{side} "left"|"right"|"split": the side of the window to initialize.
 
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/tags
+++ b/doc/tags
@@ -11,3 +11,4 @@ NoNeckPain.setup()	no-neck-pain.txt	/*NoNeckPain.setup()*
 NoNeckPain.toggle()	no-neck-pain.txt	/*NoNeckPain.toggle()*
 NoNeckPain.toggleScratchPad()	no-neck-pain.txt	/*NoNeckPain.toggleScratchPad()*
 NoNeckPain.toggleSide()	no-neck-pain.txt	/*NoNeckPain.toggleSide()*
+initSideOptions()	no-neck-pain.txt	/*initSideOptions()*

--- a/doc/tags
+++ b/doc/tags
@@ -11,4 +11,3 @@ NoNeckPain.setup()	no-neck-pain.txt	/*NoNeckPain.setup()*
 NoNeckPain.toggle()	no-neck-pain.txt	/*NoNeckPain.toggle()*
 NoNeckPain.toggleScratchPad()	no-neck-pain.txt	/*NoNeckPain.toggleScratchPad()*
 NoNeckPain.toggleSide()	no-neck-pain.txt	/*NoNeckPain.toggleSide()*
-initSideOptions()	no-neck-pain.txt	/*initSideOptions()*

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -1,6 +1,7 @@
+local A = require("no-neck-pain.util.api")
 local Co = require("no-neck-pain.util.constants")
-local S = require("no-neck-pain.state")
 local D = require("no-neck-pain.util.debug")
+local S = require("no-neck-pain.state")
 
 local C = {}
 
@@ -176,7 +177,7 @@ function C.init(win, side)
         table.insert(stringGroups, string.format("%s:%s", hl, group))
     end
 
-    vim.api.nvim_win_set_option(win, "winhl", table.concat(stringGroups, ","))
+    A.setWindowOption(win, "winhl", table.concat(stringGroups, ","))
 end
 
 return C

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -50,10 +50,10 @@ NoNeckPain.bufferOptionsBo = {
     swapfile = false,
 }
 
---- NoNeckPain's scratchpad buffer options.
+--- NoNeckPain's scratchPad buffer options.
 ---
 --- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
---- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
+--- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
 ---
 ---@type table
 ---Default values:
@@ -201,7 +201,7 @@ NoNeckPain.options = {
         -- When `false`, the mapping is not created.
         --- @type string | { mapping: string, value: number }
         widthDown = "<Leader>n-",
-        -- Sets a global mapping to Neovim, which allows you to toggle the scratchpad feature.
+        -- Sets a global mapping to Neovim, which allows you to toggle the scratchPad feature.
         -- When `false`, the mapping is not created.
         --- @type string
         scratchPad = "<Leader>ns",
@@ -214,7 +214,7 @@ NoNeckPain.options = {
         --- @type boolean
         setNames = false,
         -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
-        -- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
+        -- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
         --- see |NoNeckPain.bufferOptionsScratchpad|
         scratchPad = NoNeckPain.bufferOptionsScratchpad,
         -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
@@ -315,13 +315,19 @@ function NoNeckPain.defaults(options)
         options.buffers[side].scratchPad =
             tde(options.buffers[side].scratchPad, options.buffers.scratchPad)
 
-        -- if the user wants scratchpads, but did not provided a custom filetype, we default to `norg`.
-        if
-            options.buffers[side].scratchPad.enabled
-            and (options.buffers[side].bo == nil or options.buffers[side].bo.filetype == nil)
-        then
-            options.buffers[side].bo = options.buffers[side].bo or {}
-            options.buffers[side].bo.filetype = "norg"
+        if options.buffers[side].scratchPad.enabled then
+            -- if the user wants scratchPads, but did not provided a custom filetype, we default to `norg`.
+            if options.buffers[side].bo == nil or options.buffers[side].bo.filetype == nil then
+                options.buffers[side].bo = options.buffers[side].bo or {}
+                options.buffers[side].bo.filetype = "norg"
+            end
+
+            if options.buffers[side].scratchPad.location ~= nil then
+                assert(
+                    type(options.buffers[side].scratchPad.location) == "string",
+                    "`scratchPad.location` must be nil or a string."
+                )
+            end
         end
     end
 

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -53,6 +53,34 @@ function A.isRelativeWindow(win)
     return false
 end
 
+---Sets buffer option with backward compatibility (nvim <9).
+---
+---@param id number: the id of the buffer.
+---@param opt string: the opt name.
+---@param val string|number|boolean: the opt value.
+---@private
+function A.setBufferOption(id, opt, val)
+    if _G.NoNeckPain.config.hasNvim9 then
+        vim.api.nvim_set_option_value(opt, val, { buf = id })
+    else
+        vim.api.nvim_buf_set_option(id, opt, val)
+    end
+end
+
+---Sets window option with backward compatibility (nvim <9).
+---
+---@param id number: the id of the window.
+---@param opt string: the opt name.
+---@param val string|number: the opt value.
+---@private
+function A.setWindowOption(id, opt, val)
+    if _G.NoNeckPain.config.hasNvim9 then
+        vim.api.nvim_set_option_value(opt, val, { win = id, scope = "local" })
+    else
+        vim.api.nvim_win_set_option(id, opt, val)
+    end
+end
+
 local function timer_stop_close(timer)
     if timer:is_active() then
         timer:stop()

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -23,6 +23,7 @@ end
 ---Initializes the given `side` with the options from the user given configuration.
 ---@param id number: the id of the window.
 ---@param side "left"|"right"|"split": the side of the window to initialize.
+---@private
 local function initSideOptions(id, side)
     local bufid = vim.api.nvim_win_get_buf(id)
 

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -91,7 +91,7 @@ function W.initScratchPad(side, cleanup)
     A.setBufferOption(0, "buftype", "")
     A.setBufferOption(0, "buflisted", false)
     A.setBufferOption(0, "autoread", true)
-    A.setBufferOption(0, "conceallevel", 2)
+    A.setWindowOption(0, "conceallevel", 2)
     vim.o.autowriteall = true
 end
 

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -89,10 +89,16 @@ function W.initScratchPad(side, cleanup)
         vim.api.nvim_buf_set_name(0, location)
     end
 
-    vim.api.nvim_buf_set_option(0, "bufhidden", "")
-    vim.api.nvim_buf_set_option(0, "buftype", "")
-    vim.api.nvim_buf_set_option(0, "buflisted", false)
-    vim.api.nvim_buf_set_option(0, "autoread", true)
+    vim.api.nvim_set_option_value("bufhidden",    "",      { scope="local" })
+    vim.api.nvim_set_option_value("buftype",      "",      { scope="local" })
+    vim.api.nvim_set_option_value("buflisted",    false,   { scope="local" })
+    vim.api.nvim_set_option_value("autoread",     true,    { scope="local" })
+    vim.api.nvim_set_option_value(
+        "filetype",
+        _G.NoNeckPain.config.buffers[side].bo.filetype,
+        { scope="local" }
+    )
+    vim.api.nvim_set_option_value("conceallevel", 2,       { scope="local" })
     vim.o.autowriteall = true
 end
 

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -182,7 +182,6 @@ T["NvimTree"]["keeps sides open"] = function()
     end
 
     child.restart({ "-u", "scripts/init_with_nvimtree.lua", "foo" })
-    child.set_size(5, 300)
 
     child.cmd([[NoNeckPain]])
 

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -175,7 +175,7 @@ end
 T["NvimTree"] = MiniTest.new_set()
 
 T["NvimTree"]["keeps sides open"] = function()
-    if child.fn.has("nvim-0.8") == 0 then
+    if child.fn.has("nvim-0.9") == 0 then
         MiniTest.skip("NvimTree doesn't support version below 8")
 
         return

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -202,4 +202,27 @@ T["scratchPad"]["throws with invalid location"] = function()
     end)
 end
 
+T["scratchPad"]["forwards the given filetype to the scratchpad"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        width = 50,
+        buffers = {
+            scratchPad = {
+                enabled = true
+            },
+            bo = {
+                filetype = "nnp"
+            },
+        },
+    })]])
+    child.lua([[require('no-neck-pain').enable()]])
+
+    eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    child.lua("vim.fn.win_gotoid(1001)")
+    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "nnp")
+
+    child.lua("vim.fn.win_gotoid(1002)")
+    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "nnp")
+end
+
 return T

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -193,4 +193,13 @@ T["scratchPad"]["side buffer definition overrides global one"] = function()
     )
 end
 
+T["scratchPad"]["throws with invalid location"] = function()
+    helpers.expect.error(function()
+        child.lua(
+            [[require('no-neck-pain').setup({buffers = { scratchPad = { enabled = true, location = 10 }}})]]
+        )
+        child.lua([[require('no-neck-pain').enable()]])
+    end)
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

The buffer and window options are not properly forward to the scratchPad when setting it as `enabled`. We now change the order of definition in order to prevent overwriting them.