### PR TITLE
feat(theme): add StatusLine and StatusLineNC highlights to the group

### DIFF
--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -168,6 +168,8 @@ function C.init(win, side)
             SignColumn = backgroundGroup,
             Cursor = backgroundGroup,
             LineNr = backgroundGroup,
+            StatusLine = backgroundGroup,
+            StatusLineNC = backgroundGroup,
         })
     end
 


### PR DESCRIPTION
## 📃 Summary

add `StatusLine` and `StatusLineNC` highlights

## 📸 Preview

### before
<img width="1381" alt="Screenshot 2024-01-25 at 10 30 12" src="https://github.com/shortcuts/no-neck-pain.nvim/assets/26097838/5826a677-93bc-423c-82e1-34e1f25a8868">

### after
<img width="1381" alt="Screenshot 2024-01-25 at 10 30 30" src="https://github.com/shortcuts/no-neck-pain.nvim/assets/26097838/7d2f5e90-1813-4373-86d6-d9cd7a79868d">
