### PR TITLE
fix: buffer options order

### DIFF
--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -137,14 +137,13 @@ function W.createSideBuffers(skipIntegrations)
                     vim.api.nvim_buf_set_name(0, "no-neck-pain-" .. side)
                 end
 
+                S.setSideID(S, id, side)
+                initSideOptions(id, side)
+
                 if _G.NoNeckPain.config.buffers[side].scratchPad.enabled then
                     W.initScratchPad(side)
                     S.setScratchpad(S, true)
                 end
-
-                initSideOptions(id, side)
-
-                S.setSideID(S, id, side)
             end
 
             local sideID = S.getSideID(S, side)

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -210,7 +210,7 @@ T["scratchPad"]["forwards the given filetype to the scratchpad"] = function()
                 enabled = true
             },
             bo = {
-                filetype = "nnp"
+                filetype = "md"
             },
         },
     })]])
@@ -219,10 +219,10 @@ T["scratchPad"]["forwards the given filetype to the scratchpad"] = function()
     eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.lua("vim.fn.win_gotoid(1001)")
-    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "nnp")
+    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "markdown")
 
     child.lua("vim.fn.win_gotoid(1002)")
-    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "nnp")
+    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "markdown")
 end
 
 return T


### PR DESCRIPTION
## 📃 Summary

The default and/or user defined buffer/window options override the scratchPad options, which makes the buffer uneditable when it's enabled

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/295