### PR TITLE
fix(scratchPas): set default options at config init

### DIFF
--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -322,6 +322,12 @@ function NoNeckPain.defaults(options)
                 options.buffers[side].bo.filetype = "norg"
             end
 
+            options.buffers[side].bo.bufhidden = ""
+            options.buffers[side].bo.buftype = ""
+            options.buffers[side].bo.buflisted = false
+            options.buffers[side].bo.autoread = true
+            options.buffers[side].wo.conceallevel = 2
+
             if options.buffers[side].scratchPad.location ~= nil then
                 assert(
                     type(options.buffers[side].scratchPad.location) == "string",

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -87,11 +87,6 @@ function W.initScratchPad(side, cleanup)
         vim.api.nvim_buf_set_name(0, location)
     end
 
-    A.setBufferOption(0, "bufhidden", "")
-    A.setBufferOption(0, "buftype", "")
-    A.setBufferOption(0, "buflisted", false)
-    A.setBufferOption(0, "autoread", true)
-    A.setWindowOption(0, "conceallevel", 2)
     vim.o.autowriteall = true
 end
 
@@ -138,12 +133,13 @@ function W.createSideBuffers(skipIntegrations)
                 end
 
                 S.setSideID(S, id, side)
-                initSideOptions(id, side)
 
                 if _G.NoNeckPain.config.buffers[side].scratchPad.enabled then
                     W.initScratchPad(side)
                     S.setScratchpad(S, true)
                 end
+
+                initSideOptions(id, side)
             end
 
             local sideID = S.getSideID(S, side)

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -210,7 +210,7 @@ T["scratchPad"]["forwards the given filetype to the scratchpad"] = function()
                 enabled = true
             },
             bo = {
-                filetype = "md"
+                filetype = "custom"
             },
         },
     })]])
@@ -219,10 +219,10 @@ T["scratchPad"]["forwards the given filetype to the scratchpad"] = function()
     eq(helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.lua("vim.fn.win_gotoid(1001)")
-    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "markdown")
+    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "custom")
 
     child.lua("vim.fn.win_gotoid(1002)")
-    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "markdown")
+    eq(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "custom")
 end
 
 return T


### PR DESCRIPTION
## 📃 Summary

The fix from commit [fdbd8bf](https://github.com/shortcuts/no-neck-pain.nvim/commit/fdbd8bf4790389fd9d97aa1b14c6c5488bfb5c87) wasn't actually fixing the issue. After some debugging I believe this approach is the most correct i.e.: in case user wants to use scratch pad - update the default config values instead of overwriting them manually in the function.

## 📸 Preview

n/a