### PR TITLE
fix(integrations): faster debounce and resize padding

### DIFF
--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -335,6 +335,14 @@ function State:hasIntegrations()
     return false
 end
 
+---Whether the user wants both sides to be opened or not.
+---
+---@return boolean
+---@private
+function State:wantsSides()
+    return _G.NoNeckPain.config.buffers.left.enabled and _G.NoNeckPain.config.buffers.right.enabled
+end
+
 ---Returns the ID of the given `side`.
 ---
 ---@param side "left"|"right"|"curr": the side of the window.

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -99,7 +99,7 @@ end
 ---@param callback function: to execute on completion
 ---@private
 function A.debounce(context, callback)
-    local timeout = 50
+    local timeout = 30
     -- all execution here is done in a synchronous context; no thread safety required
 
     A.debouncers[context] = A.debouncers[context] or {}
@@ -115,16 +115,13 @@ function A.debounce(context, callback)
     timer:start(timeout, 0, function()
         timer_stop_close(timer)
 
-        -- reschedule when callback is running
         if debouncer.executing then
-            D.log(context, "already running on debounce, skipping")
+            D.log(context, "already running on debounce, rescheduling...")
             return A.debounce(context, callback)
         end
 
-        -- callback at a safe time
         debouncer.executing = true
         vim.schedule(function()
-            D.log(context, "running on debounce")
             callback()
             debouncer.executing = false
 

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -247,9 +247,8 @@ function W.getPadding(side)
 
     for name, tree in pairs(tab.wins.integrations) do
         if
-            tree ~= nil
-            and tree.id ~= nil
-            and side == _G.NoNeckPain.config.integrations[name].position
+            tree.id ~= nil
+            and (not S.wantsSides(S) or side == _G.NoNeckPain.config.integrations[name].position)
         then
             D.log(
                 "W.getPadding",


### PR DESCRIPTION
## 📃 Summary

contributes to https://github.com/shortcuts/no-neck-pain.nvim/issues/258

we can reduce the debounce to 30ms without impacting TSPlayground, 5ms works for any other integrations but needs more investigation

also fix an issue where toggling a `right` integration with only a `left` padding enabled doesn't resize the split, and vice-versa