### PR TITLE
chore: save state consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .SUFFIXES:
 
-TESTFILES=options mappings API splits tabs integrations buffers colors autocmds scratchpad
+TESTFILES=options mappings API splits tabs integrations buffers colors autocmds scratchpad commands
 
 all:
 

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -370,9 +370,4 @@ Usage ~
 `require("no-neck-pain").setup()` (add `{}` with your |NoNeckPain.options| table)
 
 
-==============================================================================
-------------------------------------------------------------------------------
-Creates side buffers and set the tab state, focuses the `curr` window if required.
-
-
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -374,8 +374,5 @@ Usage ~
 ------------------------------------------------------------------------------
 Creates side buffers and set the tab state, focuses the `curr` window if required.
 
-------------------------------------------------------------------------------
-Disables the plugin for the given tab, clear highlight groups and autocmds, closes side buffers and resets the internal state.
-
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -1,5 +1,6 @@
 local M = require("no-neck-pain.main")
 local D = require("no-neck-pain.util.debug")
+local A = require("no-neck-pain.util.api")
 local cfg = require("no-neck-pain.config")
 
 local NoNeckPain = {}
@@ -10,7 +11,7 @@ function NoNeckPain.toggle()
         _G.NoNeckPain.config = cfg.options
     end
 
-    _G.NoNeckPain.state = M.toggle("publicAPI_toggle")
+    M.toggle("publicAPI_toggle")
 end
 
 --- Toggles the scratchPad feature of the plugin.
@@ -23,7 +24,7 @@ function NoNeckPain.toggleScratchPad()
         _G.NoNeckPain.config = cfg.options
     end
 
-    _G.NoNeckPain.state = M.toggleScratchPad()
+    M.toggleScratchPad()
 end
 
 --- Sets the config `width` to the given `width` value and resizes the NoNeckPain windows.
@@ -44,7 +45,7 @@ function NoNeckPain.resize(width)
         _G.NoNeckPain.config = vim.tbl_deep_extend("keep", { width = width }, _G.NoNeckPain.config)
     end
 
-    _G.NoNeckPain.state = M.init("publicAPI_resize", false)
+    M.init("publicAPI_resize", false)
 end
 
 --- Toggles the config `${side}.enabled` and re-inits the plugin.
@@ -55,7 +56,7 @@ function NoNeckPain.toggleSide(side)
         error("no-neck-pain.nvim must be enabled, run `NoNeckPain` first.")
     end
 
-    _G.NoNeckPain.state = M.toggleSide("publicAPI_toggleSide", side)
+    M.toggleSide("publicAPI_toggleSide", side)
 end
 
 --- Initializes the plugin, sets event listeners and internal state.
@@ -64,18 +65,12 @@ function NoNeckPain.enable()
         _G.NoNeckPain.config = cfg.options
     end
 
-    local state = M.enable("publicAPI_enable")
-
-    if state ~= nil then
-        _G.NoNeckPain.state = state
-    end
-
-    return state
+    M.enable("publicAPI_enable")
 end
 
 --- Disables the plugin, clear highlight groups and autocmds, closes side buffers and resets the internal state.
 function NoNeckPain.disable()
-    _G.NoNeckPain.state = M.disable("publicAPI_disable")
+    M.disable("publicAPI_disable")
 end
 
 -- setup NoNeckPain options and merge them with user provided ones.
@@ -117,7 +112,9 @@ function NoNeckPain.setup(opts)
                         return
                     end
 
-                    if NoNeckPain.enable() ~= nil then
+                    NoNeckPain.enable()
+
+                    if _G.NoNeckPain.state ~= nil then
                         vim.api.nvim_del_autocmd(p.id)
                     end
                 end)

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -16,7 +16,7 @@ function N.toggle(scope)
         return N.disable(scope)
     end
 
-    return N.enable(scope)
+    N.enable(scope)
 end
 
 --- Toggles the scratchPad feature of the plugin.
@@ -41,20 +41,19 @@ function N.toggleScratchPad()
     -- save new state of the scratchpad and update tabs
     S.setScratchpad(S, not S.tabs[S.activeTab].scratchPadEnabled)
 
-    return S
+    S.save(S)
 end
 
 --- Toggles the config `${side}.enabled` and re-inits the plugin.
 ---
 --- @param scope string: internal identifier for logging purposes.
 --- @param side "left" | "right": the side to toggle.
---- @return table: the state of the plugin.
 ---@private
 function N.toggleSide(scope, side)
     if not S.isActiveTabRegistered(S) then
         D.log(scope, "skipped because the current tab is not registered")
 
-        return S
+        return S.save(S)
     end
 
     _G.NoNeckPain.config = vim.tbl_deep_extend(
@@ -78,7 +77,7 @@ function N.toggleSide(scope, side)
         return N.disable(scope)
     end
 
-    return N.init(scope)
+    N.init(scope)
 end
 
 --- Creates side buffers and set the tab state, focuses the `curr` window if required.
@@ -86,7 +85,6 @@ end
 --- @param scope string: internal identifier for logging purposes.
 --- @param goToCurr boolean?: whether we should re-focus the `curr` window.
 --- @param skipIntegrations boolean?: whether we should skip the integrations logic.
---- @return table: the state of the plugin.
 ---@private
 function N.init(scope, goToCurr, skipIntegrations)
     if not S.isActiveTabRegistered(S) then
@@ -111,7 +109,7 @@ function N.init(scope, goToCurr, skipIntegrations)
         vim.fn.win_gotoid(S.getSideID(S, "curr"))
     end
 
-    return S
+    S.save(S)
 end
 
 --- Initializes the plugin, sets event listeners and internal state.
@@ -359,12 +357,10 @@ function N.enable(scope)
         desc = "Resize to apply on WinEnter/Closed of an integration",
     })
 
-    return S
+    S.save(S)
 end
 
 --- Disables the plugin for the given tab, clear highlight groups and autocmds, closes side buffers and resets the internal state.
---
---- @return table: the state of the plugin.
 ---@private
 function N.disable(scope)
     D.log(scope, "calling disable for tab %d", S.activeTab)
@@ -427,7 +423,7 @@ function N.disable(scope)
         S.init(S)
     end
 
-    return S
+    S.save(S)
 end
 
 return N

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -81,7 +81,6 @@ function N.toggleSide(scope, side)
 end
 
 --- Creates side buffers and set the tab state, focuses the `curr` window if required.
---
 --- @param scope string: internal identifier for logging purposes.
 --- @param goToCurr boolean?: whether we should re-focus the `curr` window.
 --- @param skipIntegrations boolean?: whether we should skip the integrations logic.

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -13,6 +13,13 @@ function State:init()
     self.tabs = nil
 end
 
+---Saves the state in the global _G.NoNeckPain.state object.
+---
+---@private
+function State:save()
+    _G.NoNeckPain.state = self
+end
+
 ---Sets the state splits to its original value.
 ---
 ---@private

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -2,7 +2,10 @@ local helpers = dofile("tests/helpers.lua")
 
 local child = helpers.new_child_neovim()
 local eq, eq_config, eq_state, eq_buf_width =
-    helpers.expect.equality, helpers.expect.config_equality, helpers.expect.state_equality, helpers.expect.buf_width_equality
+    helpers.expect.equality,
+    helpers.expect.config_equality,
+    helpers.expect.state_equality,
+    helpers.expect.buf_width_equality
 
 local T = MiniTest.new_set({
     hooks = {


### PR DESCRIPTION
## 📃 Summary

saving state after important executions prevent inconsistencies when accessing it, this will also allowing introducing debouncing at any time of the plugin toggling, which might help for https://github.com/shortcuts/no-neck-pain.nvim/issues/221 and https://github.com/shortcuts/no-neck-pain.nvim/issues/227