### PR TITLE
fix: flickering because of debounce

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -69,7 +69,7 @@ function NoNeckPain.enable()
         _G.NoNeckPain.config = cfg.options
     end
 
-    A.debounce("publicAPI_enable", M.enable)
+    A.debounce("publicAPI_enable", M.enable, 10)
 end
 
 --- Disables the plugin, clear highlight groups and autocmds, closes side buffers and resets the internal state.

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -11,7 +11,7 @@ function NoNeckPain.toggle()
         _G.NoNeckPain.config = cfg.options
     end
 
-    M.toggle("publicAPI_toggle")
+    A.debounce("publicAPI_toggle", M.toggle)
 end
 
 --- Toggles the scratchPad feature of the plugin.
@@ -24,7 +24,7 @@ function NoNeckPain.toggleScratchPad()
         _G.NoNeckPain.config = cfg.options
     end
 
-    M.toggleScratchPad()
+    A.debounce("publicAPI_toggleScratchPad", M.toggleScratchPad)
 end
 
 --- Sets the config `width` to the given `width` value and resizes the NoNeckPain windows.
@@ -45,7 +45,9 @@ function NoNeckPain.resize(width)
         _G.NoNeckPain.config = vim.tbl_deep_extend("keep", { width = width }, _G.NoNeckPain.config)
     end
 
-    M.init("publicAPI_resize", false)
+    A.debounce("publicAPI_resize", function(scope)
+        M.init(scope, false)
+    end)
 end
 
 --- Toggles the config `${side}.enabled` and re-inits the plugin.
@@ -56,7 +58,9 @@ function NoNeckPain.toggleSide(side)
         error("no-neck-pain.nvim must be enabled, run `NoNeckPain` first.")
     end
 
-    M.toggleSide("publicAPI_toggleSide", side)
+    A.debounce("publicAPI_toggleSide", function(scope)
+        M.toggleSide(scope, side)
+    end)
 end
 
 --- Initializes the plugin, sets event listeners and internal state.
@@ -65,12 +69,12 @@ function NoNeckPain.enable()
         _G.NoNeckPain.config = cfg.options
     end
 
-    M.enable("publicAPI_enable")
+    A.debounce("publicAPI_enable", M.enable)
 end
 
 --- Disables the plugin, clear highlight groups and autocmds, closes side buffers and resets the internal state.
 function NoNeckPain.disable()
-    M.disable("publicAPI_disable")
+    A.debounce("publicAPI_disable", M.disable)
 end
 
 -- setup NoNeckPain options and merge them with user provided ones.
@@ -95,7 +99,7 @@ function NoNeckPain.setup(opts)
                     end
 
                     _G.NoNeckPain.config = cfg.defaults(opts)
-                    M.init("ColorScheme")
+                    A.debounce("ColorScheme", M.init)
                 end)
             end,
             group = "NoNeckPainAutocmd",

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -187,31 +187,30 @@ function N.enable(scope)
 
     vim.api.nvim_create_autocmd({ "WinEnter" }, {
         callback = function(p)
-            p.event = string.format("%s:splits", p.event)
-            A.debounce(p.event, function()
+            A.debounce(string.format("%s:splits", p.event), function(debounceScope)
                 if not S.hasTabs(S) or E.skip(S.getTab(S)) then
-                    return D.log(p.event, "skip split logic")
+                    return D.log(debounceScope, "skip split logic")
                 end
 
                 if S.checkSides(S, "and", false) then
-                    return D.log(p.event, "skip split logic: no side buffer")
+                    return D.log(debounceScope, "skip split logic: no side buffer")
                 end
 
                 if S.isSideTheActiveWin(S, "curr") then
-                    return D.log(p.event, "skip split logic: current win")
+                    return D.log(debounceScope, "skip split logic: current win")
                 end
 
                 -- an integration isn't considered as a split
-                local isSupportedIntegration = S.isSupportedIntegration(S, p.event, nil)
+                local isSupportedIntegration = S.isSupportedIntegration(S, debounceScope, nil)
                 if isSupportedIntegration then
-                    return D.log(p.event, "skip split logic: integration")
+                    return D.log(debounceScope, "skip split logic: integration")
                 end
 
                 local wins = S.getUnregisteredWins(S)
 
                 if #wins ~= 1 then
                     return D.log(
-                        p.event,
+                        debounceScope,
                         "skip split logic: no new or too many unregistered windows"
                     )
                 end
@@ -222,7 +221,7 @@ function N.enable(scope)
                 S.setSplit(S, { id = focusedWin, vertical = isVSplit })
 
                 if isVSplit then
-                    N.init(p.event)
+                    N.init(debounceScope)
                 end
             end)
         end,
@@ -331,25 +330,27 @@ function N.enable(scope)
 
     vim.api.nvim_create_autocmd({ "WinEnter", "WinClosed" }, {
         callback = function(p)
-            p.event = string.format("%s:integrations", p.event)
-            A.debounce(p.event, function()
+            A.debounce(string.format("%s:integrations", p.event), function(debounceScope)
                 if not S.hasTabs(S) or not S.isActiveTabRegistered(S) or E.skip(S.getTab(S)) then
-                    return D.log(p.event, "skip integrations logic")
+                    return D.log(debounceScope, "skip integrations logic")
                 end
 
                 if S.checkSides(S, "and", false) then
-                    return D.log(p.event, "skip integrations logic: no side buffer")
+                    return D.log(debounceScope, "skip integrations logic: no side buffer")
                 end
 
-                if vim.startswith(p.event, "WinClosed") and not S.hasIntegrations(S) then
-                    return D.log(p.event, "skip integrations logic: no registered integration")
+                if p.event == "WinClosed" and not S.hasIntegrations(S) then
+                    return D.log(
+                        debounceScope,
+                        "skip integrations logic: no registered integration"
+                    )
                 end
 
-                if vim.startswith(p.event, "WinEnter") and #S.getUnregisteredWins(S) == 0 then
-                    return D.log(p.event, "skip integrations logic: no new windows")
+                if p.event == "WinEnter" and #S.getUnregisteredWins(S) == 0 then
+                    return D.log(debounceScope, "skip integrations logic: no new windows")
                 end
 
-                N.init(p.event, false, true)
+                N.init(debounceScope, false, true)
             end)
         end,
         group = augroupName,

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -99,7 +99,7 @@ end
 ---@param callback function: to execute on completion
 ---@private
 function A.debounce(context, callback)
-    local timeout = 30
+    local timeout = 5
     -- all execution here is done in a synchronous context; no thread safety required
 
     A.debouncers[context] = A.debouncers[context] or {}
@@ -122,7 +122,7 @@ function A.debounce(context, callback)
 
         debouncer.executing = true
         vim.schedule(function()
-            callback()
+            callback(context)
             debouncer.executing = false
 
             -- no other timer waiting

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -95,12 +95,15 @@ end
 ---Invocation will be rescheduled while a callback is being executed.
 ---Caller must ensure that callback performs the same or functionally equivalent actions.
 ---
----@param context string: identifies the callback to debounce
----@param callback function: to execute on completion
+---@param context string: identifies the callback to debounce.
+---@param callback function: to execute on completion.
+---@param timeout number?: ms to wait for before execution.
 ---@private
-function A.debounce(context, callback)
-    local timeout = 2
+function A.debounce(context, callback, timeout)
+    timeout = timeout or 2
     -- all execution here is done in a synchronous context; no thread safety required
+
+    D.log(context, "debouncing with %d ms timeout", timeout)
 
     A.debouncers[context] = A.debouncers[context] or {}
     local debouncer = A.debouncers[context]
@@ -117,7 +120,7 @@ function A.debounce(context, callback)
 
         if debouncer.executing then
             D.log(context, "already running on debounce, rescheduling...")
-            return A.debounce(context, callback)
+            return A.debounce(context, callback, timeout)
         end
 
         debouncer.executing = true

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -99,7 +99,7 @@ end
 ---@param callback function: to execute on completion
 ---@private
 function A.debounce(context, callback)
-    local timeout = 5
+    local timeout = 2
     -- all execution here is done in a synchronous context; no thread safety required
 
     A.debouncers[context] = A.debouncers[context] or {}

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -4,13 +4,13 @@ local Helpers = {}
 -- Add extra expectations
 Helpers.expect = vim.deepcopy(MiniTest.expect)
 
-function Helpers.enablePlugin(child)
-    child.lua([[ require('no-neck-pain').enable() ]])
-    Helpers.wait()
+function Helpers.toggle(child)
+    child.cmd("NoNeckPain")
+    Helpers.wait(child)
 end
 
-function Helpers.wait()
-    vim.loop.sleep(5)
+function Helpers.wait(child)
+    child.loop.sleep(5)
 end
 
 function Helpers.currentWin(child)

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -10,7 +10,7 @@ function Helpers.toggle(child)
 end
 
 function Helpers.wait(child)
-    child.loop.sleep(5)
+    child.loop.sleep(10)
 end
 
 function Helpers.currentWin(child)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -200,6 +200,7 @@ end
 
 T["setup"]["starts the plugin on VimEnter"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
+    Helpers.wait(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "enabled", true)
@@ -210,10 +211,8 @@ end
 T["enable"] = MiniTest.new_set()
 
 T["enable"]["(single tab) sets state"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     -- state
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
@@ -241,10 +240,8 @@ T["enable"]["(single tab) sets state"] = function()
 end
 
 T["enable"]["(multiple tab) sets state"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     -- tab 1
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
@@ -271,7 +268,7 @@ T["enable"]["(multiple tab) sets state"] = function()
 
     -- tab 2
     child.cmd("tabnew")
-    child.lua([[ require('no-neck-pain').enable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 2)
@@ -297,7 +294,7 @@ end
 T["disable"] = MiniTest.new_set()
 
 T["disable"]["(single tab) resets state"] = function()
-    child.lua([[ require('no-neck-pain').enable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
 
@@ -306,7 +303,7 @@ T["disable"]["(single tab) resets state"] = function()
 
     Helpers.expect.state_type(child, "tabs", "table")
 
-    child.lua([[ require('no-neck-pain').disable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
 
@@ -317,7 +314,7 @@ T["disable"]["(single tab) resets state"] = function()
 end
 
 T["disable"]["(multiple tab) resets state"] = function()
-    child.lua([[ require('no-neck-pain').enable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
 
@@ -327,7 +324,7 @@ T["disable"]["(multiple tab) resets state"] = function()
     Helpers.expect.state_type(child, "tabs", "table")
 
     child.cmd("tabnew")
-    child.lua([[ require('no-neck-pain').enable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
 
@@ -337,7 +334,7 @@ T["disable"]["(multiple tab) resets state"] = function()
     Helpers.expect.state_type(child, "tabs", "table")
 
     -- disable tab 2
-    child.lua([[ require('no-neck-pain').disable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 2)
@@ -346,7 +343,7 @@ T["disable"]["(multiple tab) resets state"] = function()
 
     -- disable tab 1
     child.cmd("tabprevious")
-    child.lua([[ require('no-neck-pain').disable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "enabled", false)
     Helpers.expect.state(child, "activeTab", 1)

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -17,10 +17,8 @@ local T = MiniTest.new_set({
 T["auto command"] = MiniTest.new_set()
 
 T["auto command"]["does not create side buffers window's width < options.width"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=1000})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=1000}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1000 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -30,10 +28,8 @@ end
 
 T["auto command"]["does not shift when opening/closing float window"] = function()
     child.set_size(5, 200)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -194,30 +194,24 @@ end
 T["curr"] = MiniTest.new_set()
 
 T["curr"]["have the default width"] = function()
-    child.lua([[
-        require('no-neck-pain').setup()
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup() ]])
+    Helpers.toggle(child)
 
     -- need to know why the child isn't precise enough
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 80)
 end
 
 T["curr"]["have the width from the config"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     -- need to know why the child isn't precise enough
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
 end
 
 T["curr"]["closing `curr` window without any other window quits Neovim"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main.curr", 1000)
@@ -236,34 +230,30 @@ T["left/right"]["setNames doesn't throw when re-creating side buffers"] = functi
     child.lua([[require('no-neck-pain').setup({width=50, buffers={setNames=true}})]])
 
     -- enable
-    child.cmd([[NoNeckPain]])
+    Helpers.toggle(child)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
 
     -- toggle
-    child.cmd([[NoNeckPain]])
-    child.cmd([[NoNeckPain]])
+    Helpers.toggle(child)
+    Helpers.toggle(child)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
 end
 
 T["left/right"]["have the same width"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
 end
 
 T["left/right"]["only creates a `left` buffer when `right.enabled` is `false`"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50,buffers={right={enabled=false}}})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50,buffers={right={enabled=false}}}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -274,10 +264,8 @@ T["left/right"]["only creates a `left` buffer when `right.enabled` is `false`"] 
 end
 
 T["left/right"]["only creates a `right` buffer when `left.enabled` is `false`"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50,buffers={left={enabled=false}}})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50,buffers={left={enabled=false}}}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -288,10 +276,8 @@ T["left/right"]["only creates a `right` buffer when `left.enabled` is `false`"] 
 end
 
 T["left/right"]["closing the `left` buffer disables NNP"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -307,10 +293,8 @@ T["left/right"]["closing the `left` buffer disables NNP"] = function()
 end
 
 T["left/right"]["closing the `right` buffer disables NNP"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -119,8 +119,8 @@ T["setup"]["`common` options spreads it to `left` and `right` buffers"] = functi
                 text = "#ff0000",
             },
         }})
-        require('no-neck-pain').enable() 
     ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "enabled", true)
 
@@ -167,10 +167,8 @@ T["setup"]["(transparent) assert side buffers have the same colors as the main b
         highlight Normal ctermbg=none
         highlight NonText ctermbg=none
     ]])
-    child.lua([[
-        require('no-neck-pain').setup()
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup() ]])
+    Helpers.toggle(child)
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.curr)")
     local currbg = child.lua_get("vim.api.nvim_get_hl_by_name('Normal', true).background")
@@ -188,10 +186,8 @@ end
 
 T["setup"]["(normal) assert side buffers have the same colors as the main buffer"] = function()
     child.cmd([[colorscheme blue]])
-    child.lua([[
-        require('no-neck-pain').setup()
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup() ]])
+    Helpers.toggle(child)
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.curr)")
     local currbg = child.lua_get("vim.api.nvim_get_hl_by_name('Normal', true).background")
@@ -271,10 +267,10 @@ T["color"]["refreshes the stored color when changing colorscheme"] = function()
         highlight Normal ctermbg=none
         highlight NonText ctermbg=none
     ]])
-    child.lua([[
-        require('no-neck-pain').setup({ autocmds = { reloadOnColorSchemeChange=true } })
-        require('no-neck-pain').enable()
-    ]])
+    child.lua(
+        [[ require('no-neck-pain').setup({ autocmds = { reloadOnColorSchemeChange=true } }) ]]
+    )
+    Helpers.toggle(child)
 
     Helpers.expect.config(child, "buffers.colors", { blend = 0 })
 

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -17,15 +17,15 @@ local T = MiniTest.new_set({
 T["commands"] = MiniTest.new_set()
 
 T["commands"]["NoNeckPain toggles the plugin state"] = function()
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
     Helpers.expect.state(child, "enabled", true)
 
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
     Helpers.expect.state(child, "enabled", false)
 end
 
 T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = function()
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -33,6 +33,7 @@ T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = fu
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 80)
 
     child.cmd("NoNeckPainResize 20")
+    Helpers.wait(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 20)
 
@@ -47,7 +48,7 @@ T["commands"]["NoNeckPainResize throws with the plugin disabled"] = function()
 end
 
 T["commands"]["NoNeckPainResize does nothing with the same width"] = function()
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -63,7 +64,7 @@ T["commands"]["NoNeckPainResize does nothing with the same width"] = function()
 end
 
 T["commands"]["NoNeckPainWidthUp increases the width by 5"] = function()
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -89,7 +90,7 @@ T["commands"]["NoNeckPainWidthUp increases the width by N when mappings.widthUp 
         }
     })]])
 
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -108,7 +109,7 @@ T["commands"]["NoNeckPainWidthUp increases the width by N when mappings.widthUp 
 end
 
 T["commands"]["NoNeckPainWidthUp decreases the width by 5"] = function()
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -134,7 +135,7 @@ T["commands"]["NoNeckPainWidthUp decreases the width by N when mappings.widthDow
         }
     })]])
 
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -110,7 +110,7 @@ T["nvimdapui"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_nvimdapui.lua" })
     child.set_size(20, 100)
 
-    child.lua([[require('no-neck-pain').enable()]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -150,7 +150,7 @@ T["neotest"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_neotest.lua", "lua/no-neck-pain/main.lua" })
     child.set_size(20, 100)
 
-    child.lua([[require('no-neck-pain').enable()]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -184,7 +184,7 @@ T["NvimTree"]["keeps sides open"] = function()
 
     child.restart({ "-u", "scripts/init_with_nvimtree.lua", "foo" })
 
-    child.cmd([[NoNeckPain]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -223,7 +223,7 @@ T["neo-tree"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_neotree.lua", "foo" })
     child.set_size(5, 300)
 
-    child.cmd([[NoNeckPain]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -262,7 +262,7 @@ T["TSPlayground"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
     child.set_size(5, 300)
 
-    child.cmd([[NoNeckPain]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -278,13 +278,13 @@ T["TSPlayground"]["keeps sides open"] = function()
 
     Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 99)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 173)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
         id = 1004,
         open = "TSPlaygroundToggle",
-        width = 248,
+        width = 198,
     })
 end
 
@@ -301,8 +301,8 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
                 },
             },
         })
-        require('no-neck-pain').enable()
     ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
 

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -183,10 +183,8 @@ T["setup"]["does not create mappings if false"] = function()
 end
 
 T["setup"]["increase the width with mapping"] = function()
-    child.lua([[
-    require('no-neck-pain').setup({width=50,mappings={enabled=true,widthUp="nn"}})
-    require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50,mappings={enabled=true,widthUp="nn"}}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
@@ -200,10 +198,10 @@ T["setup"]["increase the width with mapping"] = function()
 end
 
 T["setup"]["increase the width with custom mapping and value"] = function()
-    child.lua([[
-    require('no-neck-pain').setup({width=50,mappings={enabled=true,widthUp={mapping="nn", value=10}}})
-    require('no-neck-pain').enable()
-    ]])
+    child.lua(
+        [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,widthUp={mapping="nn", value=10}}}) ]]
+    )
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
@@ -241,10 +239,10 @@ T["setup"]["throws with wrong widthDown configuration"] = function()
 end
 
 T["setup"]["decrease the width with mapping"] = function()
-    child.lua([[
-    require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown="nn"}})
-    require('no-neck-pain').enable()
-    ]])
+    child.lua(
+        [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown="nn"}}) ]]
+    )
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
@@ -258,10 +256,10 @@ T["setup"]["decrease the width with mapping"] = function()
 end
 
 T["setup"]["decrease the width with custom mapping and value"] = function()
-    child.lua([[
-    require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown={mapping="nn",value=7}}})
-    require('no-neck-pain').enable()
-    ]])
+    child.lua(
+        [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown={mapping="nn",value=7}}}) ]]
+    )
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
@@ -275,25 +273,26 @@ T["setup"]["decrease the width with custom mapping and value"] = function()
 end
 
 T["setup"]["toggles scratchPad"] = function()
-    child.lua([[
-    require('no-neck-pain').setup({width=50,mappings={enabled=true,scratchPad="ns"}})
-    require('no-neck-pain').enable()
-    ]])
+    child.lua(
+        [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,scratchPad="ns"}}) ]]
+    )
+    Helpers.toggle(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.scratchPad.enabled", false)
     Helpers.expect.global(child, "_G.NoNeckPain.state.tabs[1].scratchPadEnabled", false)
 
-    child.lua("vim.api.nvim_input('ns')")
+    child.api.nvim_input('ns')
+    Helpers.wait(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.scratchPad.enabled", false)
     Helpers.expect.global(child, "_G.NoNeckPain.state.tabs[1].scratchPadEnabled", true)
 end
 
 T["setup"]["toggle sides and disable if none"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50,mappings={enabled=true,toggleLeftSide="nl",toggleRightSide="nr"}})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua(
+        [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,toggleLeftSide="nl",toggleRightSide="nr"}}) ]]
+    )
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -301,28 +300,36 @@ T["setup"]["toggle sides and disable if none"] = function()
         right = 1002,
     })
 
-    child.lua("vim.api.nvim_input('nl')")
+    child.api.nvim_input('nl')
+    Helpers.wait(child)
+
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = nil,
         right = 1002,
     })
 
-    child.lua("vim.api.nvim_input('nl')")
+    child.api.nvim_input('nl')
+    Helpers.wait(child)
+
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1003,
         right = 1002,
     })
 
-    child.lua("vim.api.nvim_input('nr')")
+    child.api.nvim_input('nr')
+    Helpers.wait(child)
+
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1003,
         right = nil,
     })
 
-    child.lua("vim.api.nvim_input('nl')")
+    child.api.nvim_input('nl')
+    Helpers.wait(child)
+
     Helpers.expect.state(child, "enabled", false)
 end
 

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -281,7 +281,7 @@ T["setup"]["toggles scratchPad"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.scratchPad.enabled", false)
     Helpers.expect.global(child, "_G.NoNeckPain.state.tabs[1].scratchPadEnabled", false)
 
-    child.api.nvim_input('ns')
+    child.api.nvim_input("ns")
     Helpers.wait(child)
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.scratchPad.enabled", false)
@@ -300,7 +300,7 @@ T["setup"]["toggle sides and disable if none"] = function()
         right = 1002,
     })
 
-    child.api.nvim_input('nl')
+    child.api.nvim_input("nl")
     Helpers.wait(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -309,7 +309,7 @@ T["setup"]["toggle sides and disable if none"] = function()
         right = 1002,
     })
 
-    child.api.nvim_input('nl')
+    child.api.nvim_input("nl")
     Helpers.wait(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -318,7 +318,7 @@ T["setup"]["toggle sides and disable if none"] = function()
         right = 1002,
     })
 
-    child.api.nvim_input('nr')
+    child.api.nvim_input("nr")
     Helpers.wait(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -327,7 +327,7 @@ T["setup"]["toggle sides and disable if none"] = function()
         right = nil,
     })
 
-    child.api.nvim_input('nl')
+    child.api.nvim_input("nl")
     Helpers.wait(child)
 
     Helpers.expect.state(child, "enabled", false)

--- a/tests/test_options.lua
+++ b/tests/test_options.lua
@@ -18,10 +18,8 @@ T["minSideBufferWidth"] = MiniTest.new_set()
 
 T["minSideBufferWidth"]["closes side buffer respecting the given value"] = function()
     child.set_size(500, 500)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
 
@@ -31,8 +29,8 @@ T["minSideBufferWidth"]["closes side buffer respecting the given value"] = funct
     child.lua([[
         require('no-neck-pain').disable()
         require('no-neck-pain').setup({width=50, minSideBufferWidth=20})
-        require('no-neck-pain').enable()
     ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000 })
 end
@@ -41,10 +39,8 @@ T["killAllBuffersOnDisable"] = MiniTest.new_set()
 
 T["killAllBuffersOnDisable"]["closes every windows when disabling the plugin"] = function()
     child.set_size(500, 500)
-    child.lua([[
-        require('no-neck-pain').setup({width=50,killAllBuffersOnDisable=true})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50,killAllBuffersOnDisable=true}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
 
@@ -55,9 +51,7 @@ T["killAllBuffersOnDisable"]["closes every windows when disabling the plugin"] =
     Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3, 4 })
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
 
-    child.lua([[
-        require('no-neck-pain').disable()
-    ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3, 4 })
     Helpers.expect.equality(Helpers.winsInTab(child), { 1000 })
@@ -67,10 +61,8 @@ T["fallbackOnBufferDelete"] = MiniTest.new_set()
 
 T["fallbackOnBufferDelete"]["invoking :bd keeps nnp enabled"] = function()
     child.set_size(500, 500)
-    child.lua([[
-        require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
 
@@ -83,10 +75,8 @@ end
 
 T["fallbackOnBufferDelete"]["still allows nvim to quit"] = function()
     child.set_size(500, 500)
-    child.lua([[
-        require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
 

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -56,8 +56,7 @@ T["scratchPad"]["default to `norg` fileType"] = function()
             }
         },
     })]])
-    child.lua([[require('no-neck-pain').enable()]])
-
+    Helpers.toggle(child)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     local cwd = child.lua_get("vim.fn.getcwd()")
@@ -102,7 +101,7 @@ T["scratchPad"]["override of filetype is reflected to the buffer"] = function()
             }
         },
     })]])
-    child.lua([[require('no-neck-pain').enable()]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -146,7 +145,7 @@ T["scratchPad"]["side buffer can have their own definition"] = function()
             }
         },
     })]])
-    child.lua([[require('no-neck-pain').enable()]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -189,7 +188,7 @@ T["scratchPad"]["side buffer definition overrides global one"] = function()
             },
         },
     })]])
-    child.lua([[require('no-neck-pain').enable()]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -221,7 +220,7 @@ T["scratchPad"]["throws with invalid location"] = function()
         child.lua(
             [[require('no-neck-pain').setup({buffers = { scratchPad = { enabled = true, location = 10 }}})]]
         )
-        child.lua([[require('no-neck-pain').enable()]])
+        Helpers.toggle(child)
     end)
 end
 
@@ -237,7 +236,7 @@ T["scratchPad"]["forwards the given filetype to the scratchpad"] = function()
             },
         },
     })]])
-    child.lua([[require('no-neck-pain').enable()]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -18,10 +18,8 @@ T["split"] = MiniTest.new_set()
 
 T["split"]["only one side buffer, closing help doesn't close NNP"] = function()
     child.set_size(500, 500)
-    child.lua([[
-        require('no-neck-pain').setup({width=50, buffers={right={enabled=false}}})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50, buffers={right={enabled=false}}}) ]])
+    Helpers.toggle(child)
 
     child.cmd("h")
     child.loop.sleep(50)
@@ -40,10 +38,8 @@ end
 
 T["split"]["closing `curr` makes `split` the new `curr`"] = function()
     child.set_size(200, 200)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     child.cmd("split")
     child.loop.sleep(50)
@@ -65,10 +61,8 @@ end
 
 T["split"]["keeps side buffers"] = function()
     child.set_size(200, 200)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     child.cmd("split")
     child.loop.sleep(50)
@@ -91,10 +85,8 @@ end
 
 T["split"]["keeps correct focus"] = function()
     child.set_size(300, 300)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.currentWin(child), 1000)
 
@@ -126,20 +118,16 @@ T["vsplit"]["does not create side buffers when there's not enough space"] = func
 
     Helpers.expect.equality(Helpers.winsInTab(child, 1), { 1003, 1002, 1001, 1000 })
 
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1002, 1001, 1000 })
 end
 
 T["vsplit"]["corretly size splits when opening helper with side buffers open"] = function()
     child.set_size(150, 150)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     child.cmd("vsplit")
     child.loop.sleep(50)
@@ -164,20 +152,16 @@ T["vsplit"]["correctly position side buffers when there's enough space"] = funct
 
     Helpers.expect.equality(Helpers.winsInTab(child, 1), { 1001, 1000 })
 
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1002, 1001, 1000, 1003 })
 end
 
 T["vsplit"]["preserve vsplit width when having side buffers"] = function()
     child.set_size(500, 500)
-    child.lua([[
-        require('no-neck-pain').setup({width=50,buffers={right={enabled=false}}})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50,buffers={right={enabled=false}}}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
 
@@ -191,10 +175,8 @@ end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
     child.set_size(400, 400)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     child.cmd("vsplit")
     child.loop.sleep(50)
@@ -220,10 +202,8 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
 end
 
 T["vsplit"]["hides side buffers"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     child.cmd("vsplit")
     child.loop.sleep(50)
@@ -248,10 +228,8 @@ end
 
 T["vsplit"]["many vsplit leave side buffers open as long as there's space for it"] = function()
     child.set_size(100, 100)
-    child.lua([[
-        require('no-neck-pain').setup({width=50}) 
-        require('no-neck-pain').enable() 
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -275,10 +253,8 @@ end
 
 T["vsplit"]["keeps correct focus"] = function()
     child.set_size(200, 200)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.currentWin(child), 1000)
 
@@ -299,7 +275,7 @@ T["vsplit/split"]["state is correctly sync'd even after many changes"] = functio
 
     Helpers.expect.equality(Helpers.winsInTab(child, 1), { 1000 })
 
-    child.lua([[ require('no-neck-pain').enable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -330,10 +306,8 @@ end
 
 T["vsplit/split"]["closing side buffers because of splits restores focus"] = function()
     child.set_size(100, 100)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable() 
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -357,10 +331,8 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
 end
 
 T["vsplit/split"]["closing help page doens't break layout"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable() 
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
@@ -380,10 +352,8 @@ end
 
 T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     child.set_size(50, 500)
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable() 
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.equality(Helpers.currentWin(child), 1000)

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -18,10 +18,8 @@ local T = MiniTest.new_set({
 T["tabs"] = MiniTest.new_set()
 
 T["tabs"]["keeps the active tab in state"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.state(child, "activeTab", 1)
 
@@ -31,10 +29,8 @@ T["tabs"]["keeps the active tab in state"] = function()
 end
 
 T["tabs"]["new tab doesn't have side buffers"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "activeTab", 1)
@@ -45,10 +41,8 @@ T["tabs"]["new tab doesn't have side buffers"] = function()
 end
 
 T["tabs"]["side buffers coexist on many tabs"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     -- tab 1
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
@@ -56,14 +50,14 @@ T["tabs"]["side buffers coexist on many tabs"] = function()
 
     -- tab 2
     child.cmd("tabnew")
-    child.lua([[ require('no-neck-pain').enable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
     Helpers.expect.state(child, "activeTab", 2)
 
     -- tab 3
     child.cmd("tabnew")
-    child.lua([[ require('no-neck-pain').enable() ]])
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1007, 1006, 1008 })
     Helpers.expect.state(child, "activeTab", 3)
@@ -74,10 +68,8 @@ T["tabs"]["side buffers coexist on many tabs"] = function()
 end
 
 T["tabs"]["previous tab kept side buffers if enabled"] = function()
-    child.lua([[
-        require('no-neck-pain').setup({width=50})
-        require('no-neck-pain').enable()
-    ]])
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
 
     -- tab 1
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
@@ -99,6 +91,7 @@ T["TabNewEntered"] = MiniTest.new_set()
 
 T["TabNewEntered"]["starts the plugin on new tab"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
+    Helpers.wait(child)
 
     Helpers.expect.state(child, "enabled", true)
 
@@ -109,6 +102,8 @@ T["TabNewEntered"]["starts the plugin on new tab"] = function()
 
     -- tab 2
     child.cmd("tabnew")
+    Helpers.wait(child)
+
     Helpers.expect.state(child, "activeTab", 2)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
@@ -118,6 +113,7 @@ end
 
 T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
+    Helpers.wait(child)
 
     Helpers.expect.state(child, "enabled", true)
 
@@ -128,11 +124,12 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
 
     -- tab 2
     child.cmd("tabnew")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 2)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
 
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
     Helpers.expect.state(child, "activeTab", 2)
@@ -154,18 +151,22 @@ T["tabnew/tabclose"] = MiniTest.new_set()
 
 T["tabnew/tabclose"]["opening and closing tabs does not throw any error"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
+    Helpers.wait(child)
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 2)
 
     child.cmd("tabclose")
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
+    Helpers.wait(child)
     child.cmd("tabnew")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 4)
 
     child.cmd("tabclose")
@@ -177,6 +178,7 @@ end
 
 T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
+    Helpers.wait(child)
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 1)
@@ -200,6 +202,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     })
 
     child.cmd("tabnew")
+    Helpers.wait(child)
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
@@ -258,6 +261,7 @@ end
 
 T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
+    Helpers.wait(child)
 
     child.cmd("badd 1")
     Helpers.expect.state(child, "enabled", true)
@@ -282,6 +286,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     })
 
     child.cmd("tabnew")
+    Helpers.wait(child)
     child.cmd("badd 2")
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 2)
@@ -320,7 +325,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
     })
 
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
@@ -340,7 +345,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
     })
 
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
@@ -430,7 +435,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     child.cmd("badd 2")
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "nil")
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.state(child, "enabled", true)
@@ -460,7 +465,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     Helpers.expect.state(child, "tabs[1]", vim.NIL)
     Helpers.expect.state(child, "activeTab", 1)
 
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
     Helpers.expect.state(child, "tabs[1]", {
         id = 1,
         layers = {
@@ -539,7 +544,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     child.cmd("badd 2")
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "nil")
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.state(child, "enabled", true)
@@ -592,7 +597,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
         },
     })
 
-    child.cmd("NoNeckPain")
+    Helpers.toggle(child)
     Helpers.expect.state(child, "tabs", vim.NIL)
 end
 


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/258

we had to introduce debounce because `TSPlaygroundToggle` outcome being inconsistent due to `nvim-treesitter/playground` closing/creating many buffers at start up, but if instead we debounce just by a few (2) milliseconds each step of the `NoNeckPain` lifecycle, we can prevent flickering and state inconsistencies

this also fixes NvimTree race conditions with NoNeckPain!!