### PR TITLE
feat(integrations): skip redraw on every calls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: JohnnyMorganz/stylua-action@v2
+      - uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ $(addprefix test-, $(TESTFILES)): test-%:
 		-c "lua MiniTest.run_file('tests/test_$*.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 deps:
 	git clone --depth 1 https://github.com/nvim-lua/plenary.nvim deps/plenary
+	git clone --depth 1 https://github.com/nvim-neotest/nvim-nio deps/nvim-nio
 	git clone --depth 1 https://github.com/echasnovski/mini.nvim deps/mini.nvim
 	git clone --depth 1 https://github.com/nvim-treesitter/nvim-treesitter deps/nvim-treesitter
 	git clone --depth 1 https://github.com/nvim-treesitter/playground deps/playground

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -24,7 +24,7 @@ function NoNeckPain.toggleScratchPad()
         _G.NoNeckPain.config = C.options
     end
 
-    A.debounce("publicAPI_toggleScratchPad", M.toggleScratchPad)
+    M.toggleScratchPad()
 end
 
 --- Sets the config `width` to the given `width` value and resizes the NoNeckPain windows.
@@ -45,9 +45,7 @@ function NoNeckPain.resize(width)
         _G.NoNeckPain.config = vim.tbl_deep_extend("keep", { width = width }, _G.NoNeckPain.config)
     end
 
-    A.debounce("publicAPI_resize", function(scope)
-        M.init(scope, false)
-    end)
+    M.init("publicAPI_resize", false)
 end
 
 --- Toggles the config `${side}.enabled` and re-inits the plugin.
@@ -99,7 +97,7 @@ function NoNeckPain.setup(opts)
                     end
 
                     _G.NoNeckPain.config = C.defaults(opts)
-                    A.debounce("ColorScheme", M.init)
+                    M.init("ColorScheme")
                 end)
             end,
             group = "NoNeckPainAutocmd",

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -187,30 +187,30 @@ function N.enable(scope)
 
     vim.api.nvim_create_autocmd({ "WinEnter" }, {
         callback = function(p)
-            A.debounce(string.format("%s:splits", p.event), function(debounceScope)
+            vim.schedule(function()
                 if not S.hasTabs(S) or E.skip(S.getTab(S)) then
-                    return D.log(debounceScope, "skip split logic")
+                    return D.log(p.event, "skip split logic")
                 end
 
                 if S.checkSides(S, "and", false) then
-                    return D.log(debounceScope, "skip split logic: no side buffer")
+                    return D.log(p.event, "skip split logic: no side buffer")
                 end
 
                 if S.isSideTheActiveWin(S, "curr") then
-                    return D.log(debounceScope, "skip split logic: current win")
+                    return D.log(p.event, "skip split logic: current win")
                 end
 
                 -- an integration isn't considered as a split
-                local isSupportedIntegration = S.isSupportedIntegration(S, debounceScope, nil)
+                local isSupportedIntegration = S.isSupportedIntegration(S, p.event, nil)
                 if isSupportedIntegration then
-                    return D.log(debounceScope, "skip split logic: integration")
+                    return D.log(p.event, "skip split logic: integration")
                 end
 
                 local wins = S.getUnregisteredWins(S)
 
                 if #wins ~= 1 then
                     return D.log(
-                        debounceScope,
+                        p.event,
                         "skip split logic: no new or too many unregistered windows"
                     )
                 end
@@ -221,7 +221,7 @@ function N.enable(scope)
                 S.setSplit(S, { id = focusedWin, vertical = isVSplit })
 
                 if isVSplit then
-                    N.init(debounceScope)
+                    N.init(p.event)
                 end
             end)
         end,
@@ -330,27 +330,24 @@ function N.enable(scope)
 
     vim.api.nvim_create_autocmd({ "WinEnter", "WinClosed" }, {
         callback = function(p)
-            A.debounce(string.format("%s:integrations", p.event), function(debounceScope)
+            vim.schedule(function()
                 if not S.hasTabs(S) or not S.isActiveTabRegistered(S) or E.skip(S.getTab(S)) then
-                    return D.log(debounceScope, "skip integrations logic")
+                    return D.log(p.event, "skip integrations logic")
                 end
 
                 if S.wantsSides(S) and S.checkSides(S, "and", false) then
-                    return D.log(debounceScope, "skip integrations logic: no side buffer")
+                    return D.log(p.event, "skip integrations logic: no side buffer")
                 end
 
                 if p.event == "WinClosed" and not S.hasIntegrations(S) then
-                    return D.log(
-                        debounceScope,
-                        "skip integrations logic: no registered integration"
-                    )
+                    return D.log(p.event, "skip integrations logic: no registered integration")
                 end
 
                 if p.event == "WinEnter" and #S.getUnregisteredWins(S) == 0 then
-                    return D.log(debounceScope, "skip integrations logic: no new windows")
+                    return D.log(p.event, "skip integrations logic: no new windows")
                 end
 
-                N.init(debounceScope, false, true)
+                N.init(p.event, false, true)
             end)
         end,
         group = augroupName,

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -72,22 +72,29 @@ function State:closeIntegration()
 
     for name, opts in pairs(self.tabs[self.activeTab].wins.integrations) do
         if opts.id ~= nil and opts.close ~= nil then
+            local scope = string.format("closeIntegration:%s", name)
             -- if this integration doesn't belong to any side we don't have to
             -- close it to redraw side buffers
             local side = _G.NoNeckPain.config.integrations[name].position
             if side ~= "left" and side ~= "right" then
+                D.log(scope, "skipped because not a side integration")
+
                 goto continue
             end
 
             -- first element in the current wins list means it's the far left one,
             -- if the integration is already at this spot then we don't have to close anything
             if side == "left" and wins[1] == self.tabs[self.activeTab].wins.main[side] then
+                D.log(scope, "skipped because already at the far left side")
+
                 goto continue
             end
 
             -- last element in the current wins list means it's the far right one,
             -- if the integration is already at this spot then we don't have to close anything
             if side == "right" and wins[#wins] == self.tabs[self.activeTab].wins.main[side] then
+                D.log(scope, "skipped because already at the far right side")
+
                 goto continue
             end
 

--- a/scripts/init_with_neotest.lua
+++ b/scripts/init_with_neotest.lua
@@ -2,6 +2,7 @@ vim.cmd([[let &rtp.=','.getcwd()]])
 
 vim.cmd("set rtp+=deps/mini.nvim")
 vim.cmd("set rtp+=deps/plenary")
+vim.cmd("set rtp+=deps/nvim-nio")
 vim.cmd("set rtp+=deps/fixcursorhold")
 vim.cmd("set rtp+=deps/neotest")
 

--- a/scripts/init_with_nvimdapui.lua
+++ b/scripts/init_with_nvimdapui.lua
@@ -1,6 +1,7 @@
 vim.cmd([[let &rtp.=','.getcwd()]])
 
 vim.cmd("set rtp+=deps/mini.nvim")
+vim.cmd("set rtp+=deps/nvim-nio")
 vim.cmd("set rtp+=deps/nvimdap")
 vim.cmd("set rtp+=deps/nvimdapui")
 

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -82,8 +82,7 @@ T["commands"]["NoNeckPainWidthUp increases the width by 5"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 150)
 end
 
-T["commands"]["NoNeckPainWidthUp increases the width by N when mappings.widthUp is configured"] = function(
-)
+T["commands"]["NoNeckPainWidthUp increases the width by N when mappings.widthUp is configured"] = function()
     child.lua([[require('no-neck-pain').setup({
         mappings = {
             widthUp = {mapping = "<Leader>k-", value = 12},
@@ -127,8 +126,7 @@ T["commands"]["NoNeckPainWidthUp decreases the width by 5"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
 end
 
-T["commands"]["NoNeckPainWidthUp decreases the width by N when mappings.widthDown is configured"] = function(
-)
+T["commands"]["NoNeckPainWidthUp decreases the width by N when mappings.widthDown is configured"] = function()
     child.lua([[require('no-neck-pain').setup({
         mappings = {
             widthDown = {mapping = "<Leader>k-", value = 8},

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -284,7 +284,7 @@ T["TSPlayground"]["keeps sides open"] = function()
         fileTypePattern = "tsplayground",
         id = 1004,
         open = "TSPlaygroundToggle",
-        width = 198,
+        width = 346,
     })
 
     Helpers.expect.state(child, "tabs[1].wins.main", {


### PR DESCRIPTION
## 📃 Summary

close https://github.com/shortcuts/no-neck-pain.nvim/issues/258

An integration will always try to open their window on the further side of the screen, so we can actually on force no-neck-pain to close/reopen the integration at the first start (when side buffer don't exist yet)

_this solution is a bit more complicated but safest_