### PR TITLE
feat(api): add autocmd to skip entering side buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ require("no-neck-pain").setup({
         -- When `true`, reloads the plugin configuration after a colorscheme change.
         --- @type boolean
         reloadOnColorSchemeChange = false,
+        -- When `true`, entering one of no-neck-pain side buffer will automatically skip it and go to the next available buffer.
+        --- @type boolean
+        skipEnteringNoNeckPainBuffer = false,
     },
     -- Creates mappings for you to easily interact with the exposed commands.
     --- @type table

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -239,6 +239,9 @@ values:
           -- When `true`, reloads the plugin configuration after a colorscheme change.
           --- @type boolean
           reloadOnColorSchemeChange = false,
+          -- When `true`, entering one of no-neck-pain side buffer will automatically skip it and go to the next available buffer.
+          --- @type boolean
+          skipEnteringNoNeckPainBuffer = false,
       },
       -- Creates mappings for you to easily interact with the exposed commands.
       --- @type table

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -174,6 +174,9 @@ NoNeckPain.options = {
         -- When `true`, reloads the plugin configuration after a colorscheme change.
         --- @type boolean
         reloadOnColorSchemeChange = false,
+        -- When `true`, entering one of no-neck-pain side buffer will automatically skip it and go to the next available buffer.
+        --- @type boolean
+        skipEnteringNoNeckPainBuffer = false,
     },
     -- Creates mappings for you to easily interact with the exposed commands.
     --- @type table

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -48,6 +48,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
         enableOnVimEnter = false,
         enableOnTabEnter = false,
         reloadOnColorSchemeChange = false,
+        skipEnteringNoNeckPainBuffer = false,
     })
 
     Helpers.expect.config(child, "mappings", {
@@ -156,6 +157,7 @@ T["setup"]["overrides default values"] = function()
             enableOnVimEnter = true,
             enableOnTabEnter = true,
             reloadOnColorSchemeChange = true,
+            skipEnteringNoNeckPainBuffer = true,
         },
         debug = true,
         disableOnLastBuffer = true,
@@ -171,6 +173,7 @@ T["setup"]["overrides default values"] = function()
         enableOnVimEnter = true,
         enableOnTabEnter = true,
         reloadOnColorSchemeChange = true,
+        skipEnteringNoNeckPainBuffer = true,
     })
 end
 

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -68,4 +68,46 @@ T["auto command"]["does not shift when opening/closing float window"] = function
     Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
 end
 
+T["skipEnteringNoNeckPainBuffer"] = MiniTest.new_set()
+
+T["skipEnteringNoNeckPainBuffer"]["goes to new valid buffer when entering side"] = function()
+    child.set_size(5, 200)
+    child.lua([[ require('no-neck-pain').setup({width=50, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]])
+    Helpers.toggle(child)
+
+    Helpers.expect.config(child, "autocmds.skipEnteringNoNeckPainBuffer", true)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
+
+    child.fn.win_gotoid(1001)
+    Helpers.wait(child)
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
+
+    child.fn.win_gotoid(1002)
+    Helpers.wait(child)
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
+
+    child.cmd("split")
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
+
+    child.fn.win_gotoid(1000)
+    Helpers.wait(child)
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
+
+    child.fn.win_gotoid(1003)
+    Helpers.wait(child)
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
+
+    child.fn.win_gotoid(1001)
+    Helpers.wait(child)
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
+
+    child.fn.win_gotoid(1002)
+    Helpers.wait(child)
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

close https://github.com/shortcuts/no-neck-pain.nvim/issues/306

add a new `autocmds` option named `skipEnteringNoNeckPainBuffer` (went super explicit to let the user know it only triggers on no-neck-pain buffers) which, when `true`, skips entering a side buffer until it finds a valid one in the list of opened windows.

The option defaults to `false`