### PR TITLE
fix(autocmds): clear after debounce

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -85,6 +85,7 @@ function NoNeckPain.setup(opts)
         or _G.NoNeckPain.config.autocmds.reloadOnColorSchemeChange
     then
         vim.api.nvim_create_augroup("NoNeckPainAutocmd", { clear = true })
+        vim.api.nvim_create_augroup("NoNeckPainVimEnterAutocmd", { clear = true })
     end
 
     if _G.NoNeckPain.config.autocmds.reloadOnColorSchemeChange then
@@ -108,7 +109,7 @@ function NoNeckPain.setup(opts)
     if _G.NoNeckPain.config.autocmds.enableOnVimEnter then
         vim.api.nvim_create_autocmd({ "BufEnter" }, {
             pattern = "*",
-            callback = function(p)
+            callback = function()
                 vim.schedule(function()
                     if _G.NoNeckPain.state ~= nil and _G.NoNeckPain.state.enabled then
                         return
@@ -116,9 +117,11 @@ function NoNeckPain.setup(opts)
 
                     NoNeckPain.enable()
 
-                    if _G.NoNeckPain.state ~= nil then
-                        vim.api.nvim_del_autocmd(p.id)
-                    end
+                    A.debounce("enableOnVimEnter", function()
+                        if _G.NoNeckPain.state ~= nil then
+                            pcall(vim.api.nvim_del_augroup_by_name, "NoNeckPainVimEnterAutocmd")
+                        end
+                    end, 20)
                 end)
             end,
             group = "NoNeckPainAutocmd",

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -359,7 +359,12 @@ function N.enable(scope)
             callback = function(p)
                 vim.schedule(function()
                     p.event = string.format("%s:skipEnteringNoNeckPainBuffer", p.event)
-                    if not S.hasTabs(S) or not S.isActiveTabRegistered(S) or E.skip() or S.hasScratchPadEnabled(S) then
+                    if
+                        not S.hasTabs(S)
+                        or not S.isActiveTabRegistered(S)
+                        or E.skip()
+                        or S.hasScratchPadEnabled(S)
+                    then
                         return D.log(p.event, "skip")
                     end
 
@@ -458,6 +463,8 @@ function N.disable(scope)
     end
 
     if S.refreshTabs(S) == 0 then
+        pcall(vim.api.nvim_del_augroup_by_name, "NoNeckPainVimEnterAutocmd")
+
         D.log(scope, "no more active tabs left, reinitializing state")
 
         S.init(S)

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -26,6 +26,16 @@ T["auto command"]["does not create side buffers window's width < options.width"]
     })
 end
 
+T["auto command"]["disabling clears VimEnter autocmd"] = function()
+    child.restart({ "-u", "scripts/init_auto_open.lua" })
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(
+        child.api.nvim_get_autocmds({ group = "NoNeckPainVimEnterAutocmd" }),
+        {}
+    )
+end
+
 T["auto command"]["does not shift when opening/closing float window"] = function()
     child.set_size(5, 200)
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])


### PR DESCRIPTION
## 📃 Summary

since debouncing has been globally introduced, the autocmd clear wasn't kicking in anymore as the state was still nil, we know wait 20ms before clearing