### PR TITLE
fix(autocmds): better state check for scratchpads

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -363,7 +363,7 @@ function N.enable(scope)
                         not S.hasTabs(S)
                         or not S.isActiveTabRegistered(S)
                         or E.skip()
-                        or S.hasScratchPadEnabled(S)
+                        or S.getScratchpad(S)
                     then
                         return D.log(p.event, "skip")
                     end

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -502,17 +502,6 @@ function State:getScratchpad()
     return self.tabs[self.activeTab].scratchPadEnabled
 end
 
----Whether the scratchPad feature is enabled or not.
----
----@return boolean: the config value of the scratchPad
----@private
-function State:hasScratchPadEnabled()
-    return _G.NoNeckPain.config.buffers.scratchPad.enabled
-        or _G.NoNeckPain.config.buffers.left.scratchPad.enabled
-        or _G.NoNeckPain.config.buffers.right.scratchPad.enabled
-        or self.getScratchpad(self)
-end
-
 ---Register a new `tab` with the given `id` in the state.
 ---
 ---@param id number: the id of the tab.

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -80,12 +80,9 @@ function W.initScratchPad(side, cleanup)
         _G.NoNeckPain.config.buffers[side].bo.filetype
     )
 
-    -- we edit the file if it exists, otherwise we create it
-    if vim.fn.filereadable(location) then
-        vim.cmd(string.format("edit %s", location))
-    else
-        vim.api.nvim_buf_set_name(0, location)
-    end
+    D.log(string.format("W.initScratchPad:%s", side), "enabled with location %s", location)
+
+    vim.cmd(string.format("edit %s", location))
 
     vim.o.autowriteall = true
 end


### PR DESCRIPTION
## 📃 Summary

we should check for the current state of the scratchPad instead of the configuration value, so that we don't end up with unsync'd conditions