### PR TITLE
fix(toggleScratchPad): set buffer/window options on toggle

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -31,8 +31,12 @@ function N.toggleScratchPad()
 
     -- map over both sides and let the init method either setup or cleanup the side buffers
     for _, side in pairs(Co.SIDES) do
-        vim.fn.win_gotoid(S.getSideID(S, side))
-        W.initScratchPad(side, S.getScratchpad(S))
+        local id = S.getSideID(S, side)
+        if id ~= nil then
+            vim.fn.win_gotoid(id)
+            W.initScratchPad(side, S.getScratchpad(S))
+            W.initSideOptions(side, id)
+        end
     end
 
     -- restore focus

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -21,10 +21,10 @@ local function resize(id, width, side)
 end
 
 ---Initializes the given `side` with the options from the user given configuration.
----@param id number: the id of the window.
 ---@param side "left"|"right"|"split": the side of the window to initialize.
+---@param id number: the id of the window.
 ---@private
-local function initSideOptions(id, side)
+function W.initSideOptions(side, id)
     local bufid = vim.api.nvim_win_get_buf(id)
 
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
@@ -63,7 +63,7 @@ function W.initScratchPad(side, cleanup)
     -- cleanup is used when the `toggle` method disables the scratchPad, we then reinitialize it with the user-given configuration.
     if cleanup then
         vim.cmd("enew")
-        return initSideOptions(S.getSideID(S, side), side)
+        return W.initSideOptions(side, S.getSideID(S, side))
     end
 
     local location = _G.NoNeckPain.config.buffers[side].scratchPad.location or ""
@@ -136,7 +136,7 @@ function W.createSideBuffers(skipIntegrations)
                     S.setScratchpad(S, true)
                 end
 
-                initSideOptions(id, side)
+                W.initSideOptions(side, id)
             end
 
             local sideID = S.getSideID(S, side)

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -22,38 +22,38 @@ T["setup"]["does not create mappings by default"] = function()
     Helpers.expect.config(child, "mappings.enabled", false)
 
     -- toggle plugin state
-    child.lua("vim.api.nvim_input('<Leader>np')")
+    child.api.nvim_input('<Leader>np')
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- decrease width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- increase width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- toggle scratchPad
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>ns')")
+    child.api.nvim_input('<Leader>ns')
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 end
@@ -132,52 +132,52 @@ T["setup"]["does not create mappings if false"] = function()
     })
 
     -- toggle plugin state
-    child.lua("vim.api.nvim_input('<Leader>np')")
+    child.api.nvim_input('<Leader>np')
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- decrease width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
+    child.api.nvim_input('<Leader>n-')
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- increase width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
+    child.api.nvim_input('<Leader>n+')
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- toggle scratchPad
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>ns')")
+    child.api.nvim_input('<Leader>ns')
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- toggle left
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>nql')")
+    child.api.nvim_input('<Leader>nql')
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- toggle right
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>nqr')")
+    child.api.nvim_input('<Leader>nqr')
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 end
@@ -189,10 +189,10 @@ T["setup"]["increase the width with mapping"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 70)
 end
@@ -206,10 +206,10 @@ T["setup"]["increase the width with custom mapping and value"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 90)
 end
@@ -247,10 +247,11 @@ T["setup"]["decrease the width with mapping"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 30)
 end
@@ -264,10 +265,10 @@ T["setup"]["decrease the width with custom mapping and value"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
+    child.api.nvim_input('nn')
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 22)
 end

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -262,6 +262,14 @@ T["scratchPad"]["toggling the scratchPad sets the buffer/window options"] = func
 
     child.fn.win_gotoid(1002)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)
+
+    child.api.nvim_input('foo')
+
+    child.fn.win_gotoid(1001)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)
+
+    child.fn.win_gotoid(1002)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)
 end
 
 return T

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -240,11 +240,28 @@ T["scratchPad"]["forwards the given filetype to the scratchpad"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.fn.win_gotoid(1001)")
+    child.fn.win_gotoid(1001)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "custom")
 
-    child.lua("vim.fn.win_gotoid(1002)")
+    child.fn.win_gotoid(1002)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "custom")
+end
+
+T["scratchPad"]["toggling the scratchPad sets the buffer/window options"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        width = 50,
+        buffers = { scratchPad = { enabled = false }, },
+        mappings = { scratchPad = "foo" },
+    })]])
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    child.fn.win_gotoid(1001)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)
+
+    child.fn.win_gotoid(1002)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)
 end
 
 return T


### PR DESCRIPTION
## 📃 Summary

toggling the scratchPad doesn't apply the buffer options, this should do it properly