### PR TITLE
feat(scratchPad): provide `pathToFile` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _Creates evenly sized empty buffers on each side of your focused buffer, which a
 - Multiple tabs support
 - [Highly customizable experience](https://github.com/shortcuts/no-neck-pain.nvim#configuration)
 - [Support split/vsplit windows](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#window-layout-support)
-- [Built-in scratchpad feature](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#side-buffer-as-scratch-pad)
+- [Built-in scratchPad feature](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#side-buffer-as-scratch-pad)
 - [Themed side buffers](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#custom-background-color)
 - Fully integrates with [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim), [nvim-tree.lua](https://github.com/nvim-tree/nvim-tree.lua), [undotree](https://github.com/mbbill/undotree), [tmux, and more!](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#window-layout-support)
 - Keep your workflow intact
@@ -183,7 +183,7 @@ require("no-neck-pain").setup({
         -- When `false`, the mapping is not created.
         --- @type string | { mapping: string, value: number }
         widthDown = "<Leader>n-",
-        -- Sets a global mapping to Neovim, which allows you to toggle the scratchpad feature.
+        -- Sets a global mapping to Neovim, which allows you to toggle the scratchPad feature.
         -- When `false`, the mapping is not created.
         --- @type string
         scratchPad = "<Leader>ns",
@@ -196,9 +196,9 @@ require("no-neck-pain").setup({
         --- @type boolean
         setNames = false,
         -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
-        -- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
-        --- see |NoNeckPain.bufferOptionsScratchpad|
-        scratchPad = NoNeckPain.bufferOptionsScratchpad,
+        -- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
+        --- see |NoNeckPain.bufferOptionsScratchPad|
+        scratchPad = NoNeckPain.bufferOptionsScratchPad,
         -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
         --- see |NoNeckPain.bufferOptionsColors|
         colors = NoNeckPain.bufferOptionsColors,
@@ -282,8 +282,8 @@ NoNeckPain.bufferOptions = {
     bo = NoNeckPain.bufferOptionsBo,
     --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
     wo = NoNeckPain.bufferOptionsWo,
-    --- @see NoNeckPain.bufferOptionsScratchpad `:h NoNeckPain.bufferOptionsScratchpad`
-    scratchPad = NoNeckPain.bufferOptionsScratchpad,
+    --- @see NoNeckPain.bufferOptionsScratchPad `:h NoNeckPain.bufferOptionsScratchPad`
+    scratchPad = NoNeckPain.bufferOptionsScratchPad,
 }
 
 NoNeckPain.bufferOptionsWo = {
@@ -320,29 +320,37 @@ NoNeckPain.bufferOptionsBo = {
     swapfile = false,
 }
 
---- NoNeckPain's scratchpad buffer options.
+--- NoNeckPain's scratchPad buffer options.
 ---
 --- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
---- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
+--- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
 ---
 ---@type table
 ---Default values:
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
-NoNeckPain.bufferOptionsScratchpad = {
+NoNeckPain.bufferOptionsScratchPad = {
     -- When `true`, automatically sets the following options to the side buffers:
     -- - `autowriteall`
     -- - `autoread`.
     --- @type boolean
     enabled = false,
     -- The name of the generated file. See `location` for more information.
+    -- /!\ deprecated /!\ use `pathToFile` instead.
     --- @type string
     --- @example: `no-neck-pain-left.norg`
+    --- @deprecated use `pathToFile` instead.
     fileName = "no-neck-pain",
     -- By default, files are saved at the same location as the current Neovim session.
     -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+    -- /!\ deprecated /!\ use `pathToFile` instead.
     --- @type string?
     --- @example: `no-neck-pain-left.norg`
+    --- @deprecated use `pathToFile` instead.
     location = nil,
+    -- The path to the file to save the scratchPad content to and load it in the buffer.
+    --- @type string?
+    --- @example: `~/notes.norg`
+    pathToFile = "",
 }
 
 NoNeckPain.bufferOptionsColors = {

--- a/README.md
+++ b/README.md
@@ -338,14 +338,14 @@ NoNeckPain.bufferOptionsScratchPad = {
     -- /!\ deprecated /!\ use `pathToFile` instead.
     --- @type string
     --- @example: `no-neck-pain-left.norg`
-    --- @deprecated use `pathToFile` instead.
+    --- @deprecated: use `pathToFile` instead.
     fileName = "no-neck-pain",
     -- By default, files are saved at the same location as the current Neovim session.
     -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
     -- /!\ deprecated /!\ use `pathToFile` instead.
     --- @type string?
     --- @example: `no-neck-pain-left.norg`
-    --- @deprecated use `pathToFile` instead.
+    --- @deprecated: use `pathToFile` instead.
     location = nil,
     -- The path to the file to save the scratchPad content to and load it in the buffer.
     --- @type string?

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -94,8 +94,8 @@ values:
 <
 
 ------------------------------------------------------------------------------
-                                            *NoNeckPain.bufferOptionsScratchpad*
-                      `NoNeckPain.bufferOptionsScratchpad`
+                                            *NoNeckPain.bufferOptionsScratchPad*
+                      `NoNeckPain.bufferOptionsScratchPad`
 NoNeckPain's scratchPad buffer options.
 
 Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
@@ -105,21 +105,29 @@ Type ~
 `(table)`
 values:
 >
-  NoNeckPain.bufferOptionsScratchpad = {
+  NoNeckPain.bufferOptionsScratchPad = {
       -- When `true`, automatically sets the following options to the side buffers:
       -- - `autowriteall`
       -- - `autoread`.
       --- @type boolean
       enabled = false,
       -- The name of the generated file. See `location` for more information.
+      -- /!\ deprecated /!\ use `pathToFile` instead.
       --- @type string
       --- @example: `no-neck-pain-left.norg`
+      --- @deprecated use `pathToFile` instead.
       fileName = "no-neck-pain",
       -- By default, files are saved at the same location as the current Neovim session.
       -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+      -- /!\ deprecated /!\ use `pathToFile` instead.
       --- @type string?
       --- @example: `no-neck-pain-left.norg`
+      --- @deprecated use `pathToFile` instead.
       location = nil,
+      -- The path to the file to save the scratchPad content to and load it in the buffer.
+      --- @type string?
+      --- @example: `~/notes.norg`
+      pathToFile = "",
   }
 
 <
@@ -186,8 +194,8 @@ values:
       bo = NoNeckPain.bufferOptionsBo,
       --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
       wo = NoNeckPain.bufferOptionsWo,
-      --- @see NoNeckPain.bufferOptionsScratchpad `:h NoNeckPain.bufferOptionsScratchpad`
-      scratchPad = NoNeckPain.bufferOptionsScratchpad,
+      --- @see NoNeckPain.bufferOptionsScratchPad `:h NoNeckPain.bufferOptionsScratchPad`
+      scratchPad = NoNeckPain.bufferOptionsScratchPad,
   }
 
 <
@@ -283,8 +291,8 @@ values:
           setNames = false,
           -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
           -- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
-          --- see |NoNeckPain.bufferOptionsScratchpad|
-          scratchPad = NoNeckPain.bufferOptionsScratchpad,
+          --- see |NoNeckPain.bufferOptionsScratchPad|
+          scratchPad = NoNeckPain.bufferOptionsScratchPad,
           -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
           --- see |NoNeckPain.bufferOptionsColors|
           colors = NoNeckPain.bufferOptionsColors,

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -115,14 +115,14 @@ values:
       -- /!\ deprecated /!\ use `pathToFile` instead.
       --- @type string
       --- @example: `no-neck-pain-left.norg`
-      --- @deprecated use `pathToFile` instead.
+      --- @deprecated: use `pathToFile` instead.
       fileName = "no-neck-pain",
       -- By default, files are saved at the same location as the current Neovim session.
       -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
       -- /!\ deprecated /!\ use `pathToFile` instead.
       --- @type string?
       --- @example: `no-neck-pain-left.norg`
-      --- @deprecated use `pathToFile` instead.
+      --- @deprecated: use `pathToFile` instead.
       location = nil,
       -- The path to the file to save the scratchPad content to and load it in the buffer.
       --- @type string?

--- a/doc/tags
+++ b/doc/tags
@@ -1,7 +1,7 @@
 NoNeckPain.bufferOptions	no-neck-pain.txt	/*NoNeckPain.bufferOptions*
 NoNeckPain.bufferOptionsBo	no-neck-pain.txt	/*NoNeckPain.bufferOptionsBo*
 NoNeckPain.bufferOptionsColors	no-neck-pain.txt	/*NoNeckPain.bufferOptionsColors*
-NoNeckPain.bufferOptionsScratchpad	no-neck-pain.txt	/*NoNeckPain.bufferOptionsScratchpad*
+NoNeckPain.bufferOptionsScratchPad	no-neck-pain.txt	/*NoNeckPain.bufferOptionsScratchPad*
 NoNeckPain.bufferOptionsWo	no-neck-pain.txt	/*NoNeckPain.bufferOptionsWo*
 NoNeckPain.disable()	no-neck-pain.txt	/*NoNeckPain.disable()*
 NoNeckPain.enable()	no-neck-pain.txt	/*NoNeckPain.enable()*

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -69,14 +69,14 @@ NoNeckPain.bufferOptionsScratchPad = {
     -- /!\ deprecated /!\ use `pathToFile` instead.
     --- @type string
     --- @example: `no-neck-pain-left.norg`
-    --- @deprecated use `pathToFile` instead.
+    --- @deprecated: use `pathToFile` instead.
     fileName = "no-neck-pain",
     -- By default, files are saved at the same location as the current Neovim session.
     -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
     -- /!\ deprecated /!\ use `pathToFile` instead.
     --- @type string?
     --- @example: `no-neck-pain-left.norg`
-    --- @deprecated use `pathToFile` instead.
+    --- @deprecated: use `pathToFile` instead.
     location = nil,
     -- The path to the file to save the scratchPad content to and load it in the buffer.
     --- @type string?

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -59,7 +59,7 @@ NoNeckPain.bufferOptionsBo = {
 ---@type table
 ---Default values:
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
-NoNeckPain.bufferOptionsScratchpad = {
+NoNeckPain.bufferOptionsScratchPad = {
     -- When `true`, automatically sets the following options to the side buffers:
     -- - `autowriteall`
     -- - `autoread`.
@@ -136,8 +136,8 @@ NoNeckPain.bufferOptions = {
     bo = NoNeckPain.bufferOptionsBo,
     --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
     wo = NoNeckPain.bufferOptionsWo,
-    --- @see NoNeckPain.bufferOptionsScratchpad `:h NoNeckPain.bufferOptionsScratchpad`
-    scratchPad = NoNeckPain.bufferOptionsScratchpad,
+    --- @see NoNeckPain.bufferOptionsScratchPad `:h NoNeckPain.bufferOptionsScratchPad`
+    scratchPad = NoNeckPain.bufferOptionsScratchPad,
 }
 
 --- NoNeckPain's plugin config.
@@ -227,8 +227,8 @@ NoNeckPain.options = {
         setNames = false,
         -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
         -- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
-        --- see |NoNeckPain.bufferOptionsScratchpad|
-        scratchPad = NoNeckPain.bufferOptionsScratchpad,
+        --- see |NoNeckPain.bufferOptionsScratchPad|
+        scratchPad = NoNeckPain.bufferOptionsScratchPad,
         -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
         --- see |NoNeckPain.bufferOptionsColors|
         colors = NoNeckPain.bufferOptionsColors,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -28,18 +28,24 @@ function N.toggleScratchPad()
 
     -- store the current win to later restore focus
     local currWin = vim.api.nvim_get_current_win()
+    local currState = S.getScratchpad(S)
+
+    -- save new state of the scratchpad and update tabs
+    S.setScratchpad(S, not currState)
 
     -- map over both sides and let the init method either setup or cleanup the side buffers
     for _, side in pairs(Co.SIDES) do
-        vim.fn.win_gotoid(S.getSideID(S, side))
-        W.initScratchPad(side, S.getScratchpad(S))
+        local id = S.getSideID(S, side)
+        if id ~= nil then
+            vim.fn.win_gotoid(id)
+
+            W.initScratchPad(side, currState)
+            W.initSideOptions(side, id)
+        end
     end
 
     -- restore focus
     vim.fn.win_gotoid(currWin)
-
-    -- save new state of the scratchpad and update tabs
-    S.setScratchpad(S, not S.tabs[S.activeTab].scratchPadEnabled)
 
     S.save(S)
 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -28,10 +28,10 @@ function N.toggleScratchPad()
 
     -- store the current win to later restore focus
     local currWin = vim.api.nvim_get_current_win()
-    local currState = S.getScratchpad(S)
+    local currState = S.getScratchPad(S)
 
-    -- save new state of the scratchpad and update tabs
-    S.setScratchpad(S, not currState)
+    -- save new state of the scratchPad and update tabs
+    S.setScratchPad(S, not currState)
 
     -- map over both sides and let the init method either setup or cleanup the side buffers
     for _, side in pairs(Co.SIDES) do
@@ -369,7 +369,7 @@ function N.enable(scope)
                         not S.hasTabs(S)
                         or not S.isActiveTabRegistered(S)
                         or E.skip()
-                        or S.getScratchpad(S)
+                        or S.getScratchPad(S)
                     then
                         return D.log(p.event, "skip")
                     end

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -486,19 +486,19 @@ function State:getTabSafe()
     return self.getTab(self)
 end
 
----Sets the given `bool` value to the active tab scratchpad.
+---Sets the given `bool` value to the active tab scratchPad.
 ---
----@param bool boolean: the value of the scratchpad.
+---@param bool boolean: the value of the scratchPad.
 ---@private
-function State:setScratchpad(bool)
+function State:setScratchPad(bool)
     self.tabs[self.activeTab].scratchPadEnabled = bool
 end
 
----Gets the scratchpad value for the active tab.
+---Gets the scratchPad value for the active tab.
 ---
----@return boolean: the value of the scratchpad.
+---@return boolean: the value of the scratchPad.
 ---@private
-function State:getScratchpad()
+function State:getScratchPad()
     return self.tabs[self.activeTab].scratchPadEnabled
 end
 

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -10,6 +10,19 @@ function A.getCurrentTab()
     return vim.api.nvim_get_current_tabpage() or 1
 end
 
+---Returns the number of keys in the given table
+---
+---@param tbl table: the table to count the keys.
+---@return number: the number of keys in the table.
+---@private
+function A.length(tbl)
+    local count = 0
+    for _ in pairs(tbl) do
+        count = count + 1
+    end
+    return count
+end
+
 ---Returns the name of the augroup for the given tab ID.
 ---
 ---@param id number?: the id of the tab.

--- a/lua/no-neck-pain/util/debug.lua
+++ b/lua/no-neck-pain/util/debug.lua
@@ -59,7 +59,11 @@ function D.warnDeprecation(options)
         then
             usesDeprecatedOption = true
             print(
-                string.format("[no-neck-pain.nvim] `%s` %s", name, string.format(notice, warning))
+                string.format(
+                    "[no-neck-pain.nvim] `buffers.%s` %s",
+                    name,
+                    string.format(notice, warning)
+                )
             )
         end
     end

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -123,7 +123,7 @@ function W.createSideBuffers(skipIntegrations)
 
                 if _G.NoNeckPain.config.buffers[side].scratchPad.enabled then
                     W.initScratchPad(side)
-                    S.setScratchpad(S, true)
+                    S.setScratchPad(S, true)
                 end
 
                 W.initSideOptions(side, id)

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -21,10 +21,10 @@ local function resize(id, width, side)
 end
 
 ---Initializes the given `side` with the options from the user given configuration.
----@param id number: the id of the window.
 ---@param side "left"|"right"|"split": the side of the window to initialize.
+---@param id number: the id of the window.
 ---@private
-local function initSideOptions(id, side)
+function W.initSideOptions(side, id)
     local bufid = vim.api.nvim_win_get_buf(id)
 
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
@@ -63,26 +63,16 @@ function W.initScratchPad(side, cleanup)
     -- cleanup is used when the `toggle` method disables the scratchPad, we then reinitialize it with the user-given configuration.
     if cleanup then
         vim.cmd("enew")
-        return initSideOptions(S.getSideID(S, side), side)
+        return W.initSideOptions(side, S.getSideID(S, side))
     end
 
-    local location = _G.NoNeckPain.config.buffers[side].scratchPad.location or ""
-
-    if location ~= "" and string.sub(location, -1) ~= "/" then
-        location = location .. "/"
-    end
-
-    location = string.format(
-        "%s%s-%s.%s",
-        location,
-        _G.NoNeckPain.config.buffers[side].scratchPad.fileName,
-        side,
-        _G.NoNeckPain.config.buffers[side].bo.filetype
+    D.log(
+        string.format("W.initScratchPad:%s", side),
+        "enabled with location %s",
+        _G.NoNeckPain.config.buffers[side].scratchPad.pathToFile
     )
 
-    D.log(string.format("W.initScratchPad:%s", side), "enabled with location %s", location)
-
-    vim.cmd(string.format("edit %s", location))
+    vim.cmd(string.format("edit %s", _G.NoNeckPain.config.buffers[side].scratchPad.pathToFile))
 
     vim.o.autowriteall = true
 end
@@ -136,7 +126,7 @@ function W.createSideBuffers(skipIntegrations)
                     S.setScratchpad(S, true)
                 end
 
-                initSideOptions(id, side)
+                W.initSideOptions(side, id)
             end
 
             local sideID = S.getSideID(S, side)

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -28,7 +28,13 @@ function W.initSideOptions(side, id)
     local bufid = vim.api.nvim_win_get_buf(id)
 
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
+        if S.getScratchPad(S) and opt == "filetype" then
+            goto continue
+        end
+
         A.setBufferOption(bufid, opt, val)
+
+        ::continue::
     end
 
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].wo) do

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -22,38 +22,38 @@ T["setup"]["does not create mappings by default"] = function()
     Helpers.expect.config(child, "mappings.enabled", false)
 
     -- toggle plugin state
-    child.lua("vim.api.nvim_input('<Leader>np')")
+    child.api.nvim_input("<Leader>np")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- decrease width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- increase width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- toggle scratchPad
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>ns')")
+    child.api.nvim_input("<Leader>ns")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 end
@@ -132,52 +132,52 @@ T["setup"]["does not create mappings if false"] = function()
     })
 
     -- toggle plugin state
-    child.lua("vim.api.nvim_input('<Leader>np')")
+    child.api.nvim_input("<Leader>np")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- decrease width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- increase width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- toggle scratchPad
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>ns')")
+    child.api.nvim_input("<Leader>ns")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- toggle left
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>nql')")
+    child.api.nvim_input("<Leader>nql")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- toggle right
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>nqr')")
+    child.api.nvim_input("<Leader>nqr")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 end
@@ -189,10 +189,10 @@ T["setup"]["increase the width with mapping"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 70)
 end
@@ -206,10 +206,10 @@ T["setup"]["increase the width with custom mapping and value"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 90)
 end
@@ -247,10 +247,10 @@ T["setup"]["decrease the width with mapping"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 30)
 end
@@ -264,10 +264,10 @@ T["setup"]["decrease the width with custom mapping and value"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 22)
 end

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -239,7 +239,7 @@ T["scratchPad"]["side buffer definition overrides global one"] = function()
     )
 end
 
-T["scratchPad"]["forwards the given filetype to the scratchpad"] = function()
+T["scratchPad"]["forwards the given filetype to the scratchPad"] = function()
     child.lua([[require('no-neck-pain').setup({
         width = 50,
         buffers = {


### PR DESCRIPTION
## 📃 Summary

The current API forces the user to define the path to their file in at most 3 fields: `location`, `fileName` and `filetype`, while this could be just behind a single option.

In this PR we provide a new field named `pathToFile` which aims at simplifying this definition, the old signature is still support until the next major and will be translated to the new one automatically.

This PR also fixes the problem of unresolved filetype, where a custom configuration would be required for the user to provide one.