### PR TITLE
feat(scratchPad): provide `pathToFile` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,19 +334,6 @@ NoNeckPain.bufferOptionsScratchPad = {
     -- - `autoread`.
     --- @type boolean
     enabled = false,
-    -- The name of the generated file. See `location` for more information.
-    -- /!\ deprecated /!\ use `pathToFile` instead.
-    --- @type string
-    --- @example: `no-neck-pain-left.norg`
-    --- @deprecated: use `pathToFile` instead.
-    fileName = "no-neck-pain",
-    -- By default, files are saved at the same location as the current Neovim session.
-    -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
-    -- /!\ deprecated /!\ use `pathToFile` instead.
-    --- @type string?
-    --- @example: `no-neck-pain-left.norg`
-    --- @deprecated: use `pathToFile` instead.
-    location = nil,
     -- The path to the file to save the scratchPad content to and load it in the buffer.
     --- @type string?
     --- @example: `~/notes.norg`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _Creates evenly sized empty buffers on each side of your focused buffer, which a
 - Multiple tabs support
 - [Highly customizable experience](https://github.com/shortcuts/no-neck-pain.nvim#configuration)
 - [Support split/vsplit windows](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#window-layout-support)
-- [Built-in scratchpad feature](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#side-buffer-as-scratch-pad)
+- [Built-in scratchPad feature](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#side-buffer-as-scratch-pad)
 - [Themed side buffers](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#custom-background-color)
 - Fully integrates with [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim), [nvim-tree.lua](https://github.com/nvim-tree/nvim-tree.lua), [undotree](https://github.com/mbbill/undotree), [tmux, and more!](https://github.com/shortcuts/no-neck-pain.nvim/wiki/Showcase#window-layout-support)
 - Keep your workflow intact
@@ -183,7 +183,7 @@ require("no-neck-pain").setup({
         -- When `false`, the mapping is not created.
         --- @type string | { mapping: string, value: number }
         widthDown = "<Leader>n-",
-        -- Sets a global mapping to Neovim, which allows you to toggle the scratchpad feature.
+        -- Sets a global mapping to Neovim, which allows you to toggle the scratchPad feature.
         -- When `false`, the mapping is not created.
         --- @type string
         scratchPad = "<Leader>ns",
@@ -196,9 +196,9 @@ require("no-neck-pain").setup({
         --- @type boolean
         setNames = false,
         -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
-        -- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
-        --- see |NoNeckPain.bufferOptionsScratchpad|
-        scratchPad = NoNeckPain.bufferOptionsScratchpad,
+        -- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
+        --- see |NoNeckPain.bufferOptionsScratchPad|
+        scratchPad = NoNeckPain.bufferOptionsScratchPad,
         -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
         --- see |NoNeckPain.bufferOptionsColors|
         colors = NoNeckPain.bufferOptionsColors,
@@ -282,8 +282,8 @@ NoNeckPain.bufferOptions = {
     bo = NoNeckPain.bufferOptionsBo,
     --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
     wo = NoNeckPain.bufferOptionsWo,
-    --- @see NoNeckPain.bufferOptionsScratchpad `:h NoNeckPain.bufferOptionsScratchpad`
-    scratchPad = NoNeckPain.bufferOptionsScratchpad,
+    --- @see NoNeckPain.bufferOptionsScratchPad `:h NoNeckPain.bufferOptionsScratchPad`
+    scratchPad = NoNeckPain.bufferOptionsScratchPad,
 }
 
 NoNeckPain.bufferOptionsWo = {
@@ -320,29 +320,37 @@ NoNeckPain.bufferOptionsBo = {
     swapfile = false,
 }
 
---- NoNeckPain's scratchpad buffer options.
+--- NoNeckPain's scratchPad buffer options.
 ---
 --- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
---- note: quitting an unsaved scratchpad buffer is non-blocking, and the content is still saved.
+--- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
 ---
 ---@type table
 ---Default values:
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
-NoNeckPain.bufferOptionsScratchpad = {
+NoNeckPain.bufferOptionsScratchPad = {
     -- When `true`, automatically sets the following options to the side buffers:
     -- - `autowriteall`
     -- - `autoread`.
     --- @type boolean
     enabled = false,
     -- The name of the generated file. See `location` for more information.
+    -- /!\ deprecated /!\ use `pathToFile` instead.
     --- @type string
     --- @example: `no-neck-pain-left.norg`
+    --- @deprecated: use `pathToFile` instead.
     fileName = "no-neck-pain",
     -- By default, files are saved at the same location as the current Neovim session.
     -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+    -- /!\ deprecated /!\ use `pathToFile` instead.
     --- @type string?
     --- @example: `no-neck-pain-left.norg`
+    --- @deprecated: use `pathToFile` instead.
     location = nil,
+    -- The path to the file to save the scratchPad content to and load it in the buffer.
+    --- @type string?
+    --- @example: `~/notes.norg`
+    pathToFile = "",
 }
 
 NoNeckPain.bufferOptionsColors = {

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -94,8 +94,8 @@ values:
 <
 
 ------------------------------------------------------------------------------
-                                            *NoNeckPain.bufferOptionsScratchpad*
-                      `NoNeckPain.bufferOptionsScratchpad`
+                                            *NoNeckPain.bufferOptionsScratchPad*
+                      `NoNeckPain.bufferOptionsScratchPad`
 NoNeckPain's scratchPad buffer options.
 
 Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
@@ -105,21 +105,29 @@ Type ~
 `(table)`
 values:
 >
-  NoNeckPain.bufferOptionsScratchpad = {
+  NoNeckPain.bufferOptionsScratchPad = {
       -- When `true`, automatically sets the following options to the side buffers:
       -- - `autowriteall`
       -- - `autoread`.
       --- @type boolean
       enabled = false,
       -- The name of the generated file. See `location` for more information.
+      -- /!\ deprecated /!\ use `pathToFile` instead.
       --- @type string
       --- @example: `no-neck-pain-left.norg`
+      --- @deprecated: use `pathToFile` instead.
       fileName = "no-neck-pain",
       -- By default, files are saved at the same location as the current Neovim session.
       -- note: filetype is defaulted to `norg` (https://github.com/nvim-neorg/neorg), but can be changed in `buffers.bo.filetype` or |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
+      -- /!\ deprecated /!\ use `pathToFile` instead.
       --- @type string?
       --- @example: `no-neck-pain-left.norg`
+      --- @deprecated: use `pathToFile` instead.
       location = nil,
+      -- The path to the file to save the scratchPad content to and load it in the buffer.
+      --- @type string?
+      --- @example: `~/notes.norg`
+      pathToFile = "",
   }
 
 <
@@ -186,8 +194,8 @@ values:
       bo = NoNeckPain.bufferOptionsBo,
       --- @see NoNeckPain.bufferOptionsWo `:h NoNeckPain.bufferOptionsWo`
       wo = NoNeckPain.bufferOptionsWo,
-      --- @see NoNeckPain.bufferOptionsScratchpad `:h NoNeckPain.bufferOptionsScratchpad`
-      scratchPad = NoNeckPain.bufferOptionsScratchpad,
+      --- @see NoNeckPain.bufferOptionsScratchPad `:h NoNeckPain.bufferOptionsScratchPad`
+      scratchPad = NoNeckPain.bufferOptionsScratchPad,
   }
 
 <
@@ -283,8 +291,8 @@ values:
           setNames = false,
           -- Leverages the side buffers as notepads, which work like any Neovim buffer and automatically saves its content at the given `location`.
           -- note: quitting an unsaved scratchPad buffer is non-blocking, and the content is still saved.
-          --- see |NoNeckPain.bufferOptionsScratchpad|
-          scratchPad = NoNeckPain.bufferOptionsScratchpad,
+          --- see |NoNeckPain.bufferOptionsScratchPad|
+          scratchPad = NoNeckPain.bufferOptionsScratchPad,
           -- colors to apply to both side buffers, for buffer scopped options @see |NoNeckPain.bufferOptions|
           --- see |NoNeckPain.bufferOptionsColors|
           colors = NoNeckPain.bufferOptionsColors,

--- a/doc/tags
+++ b/doc/tags
@@ -1,7 +1,7 @@
 NoNeckPain.bufferOptions	no-neck-pain.txt	/*NoNeckPain.bufferOptions*
 NoNeckPain.bufferOptionsBo	no-neck-pain.txt	/*NoNeckPain.bufferOptionsBo*
 NoNeckPain.bufferOptionsColors	no-neck-pain.txt	/*NoNeckPain.bufferOptionsColors*
-NoNeckPain.bufferOptionsScratchpad	no-neck-pain.txt	/*NoNeckPain.bufferOptionsScratchpad*
+NoNeckPain.bufferOptionsScratchPad	no-neck-pain.txt	/*NoNeckPain.bufferOptionsScratchPad*
 NoNeckPain.bufferOptionsWo	no-neck-pain.txt	/*NoNeckPain.bufferOptionsWo*
 NoNeckPain.disable()	no-neck-pain.txt	/*NoNeckPain.disable()*
 NoNeckPain.enable()	no-neck-pain.txt	/*NoNeckPain.enable()*

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -28,18 +28,25 @@ function N.toggleScratchPad()
 
     -- store the current win to later restore focus
     local currWin = vim.api.nvim_get_current_win()
+    local currentState = S.tabs[S.activeTab].scratchPadEnabled
+
+    -- save new state of the scratchPad and update tabs
+    S.setScratchPad(S, not currentState)
 
     -- map over both sides and let the init method either setup or cleanup the side buffers
     for _, side in pairs(Co.SIDES) do
-        vim.fn.win_gotoid(S.getSideID(S, side))
-        W.initScratchPad(side, S.getScratchpad(S))
+        local id = S.getSideID(S, side)
+        if id ~= nil then
+            vim.fn.win_gotoid(id)
+            W.initScratchPad(side, id, currentState)
+            if not currentState then
+                W.initSideOptions(side, id)
+            end
+        end
     end
 
     -- restore focus
     vim.fn.win_gotoid(currWin)
-
-    -- save new state of the scratchpad and update tabs
-    S.setScratchpad(S, not S.tabs[S.activeTab].scratchPadEnabled)
 
     S.save(S)
 end
@@ -363,7 +370,7 @@ function N.enable(scope)
                         not S.hasTabs(S)
                         or not S.isActiveTabRegistered(S)
                         or E.skip()
-                        or S.getScratchpad(S)
+                        or S.getScratchPad(S)
                     then
                         return D.log(p.event, "skip")
                     end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -39,9 +39,6 @@ function N.toggleScratchPad()
         if id ~= nil then
             vim.fn.win_gotoid(id)
             W.initScratchPad(side, id, currentState)
-            if not currentState then
-                W.initSideOptions(side, id)
-            end
         end
     end
 

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -486,19 +486,19 @@ function State:getTabSafe()
     return self.getTab(self)
 end
 
----Sets the given `bool` value to the active tab scratchpad.
+---Sets the given `bool` value to the active tab scratchPad.
 ---
----@param bool boolean: the value of the scratchpad.
+---@param bool boolean: the value of the scratchPad.
 ---@private
-function State:setScratchpad(bool)
+function State:setScratchPad(bool)
     self.tabs[self.activeTab].scratchPadEnabled = bool
 end
 
----Gets the scratchpad value for the active tab.
+---Gets the scratchPad value for the active tab.
 ---
----@return boolean: the value of the scratchpad.
+---@return boolean: the value of the scratchPad.
 ---@private
-function State:getScratchpad()
+function State:getScratchPad()
     return self.tabs[self.activeTab].scratchPadEnabled
 end
 

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -10,6 +10,23 @@ function A.getCurrentTab()
     return vim.api.nvim_get_current_tabpage() or 1
 end
 
+---Returns the number of keys in the given table
+---
+---@param tbl table: the table to count the keys.
+---@return number: the number of keys in the table.
+---@private
+function A.length(tbl)
+    local count = 0
+    for _ in pairs(tbl) do
+        count = count + 1
+    end
+    return count
+end
+
+function A.tde(t1, t2)
+    return vim.deepcopy(vim.tbl_deep_extend("keep", t1 or {}, t2 or {}))
+end
+
 ---Returns the name of the augroup for the given tab ID.
 ---
 ---@param id number?: the id of the tab.

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -21,10 +21,10 @@ local function resize(id, width, side)
 end
 
 ---Initializes the given `side` with the options from the user given configuration.
----@param id number: the id of the window.
 ---@param side "left"|"right"|"split": the side of the window to initialize.
+---@param id number: the id of the window.
 ---@private
-local function initSideOptions(id, side)
+function W.initSideOptions(side, id)
     local bufid = vim.api.nvim_win_get_buf(id)
 
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
@@ -53,9 +53,10 @@ end
 ---Sets options to the side buffers to toggle the scratchPad.
 ---
 ---@param side "left"|"right": the side of the window being resized, used for logging only.
+---@param id number: the side window ID.
 ---@param cleanup boolean?: cleanup the given buffer
 ---@private
-function W.initScratchPad(side, cleanup)
+function W.initScratchPad(side, id, cleanup)
     if not _G.NoNeckPain.config.buffers[side].enabled then
         return
     end
@@ -63,26 +64,24 @@ function W.initScratchPad(side, cleanup)
     -- cleanup is used when the `toggle` method disables the scratchPad, we then reinitialize it with the user-given configuration.
     if cleanup then
         vim.cmd("enew")
-        return initSideOptions(S.getSideID(S, side), side)
+        return W.initSideOptions(side, id)
     end
 
-    local location = _G.NoNeckPain.config.buffers[side].scratchPad.location or ""
+    local bufID = vim.api.nvim_win_get_buf(id)
 
-    if location ~= "" and string.sub(location, -1) ~= "/" then
-        location = location .. "/"
-    end
+    A.setBufferOption(bufID, "bufhidden", "")
+    A.setBufferOption(bufID, "buftype", "")
+    A.setBufferOption(bufID, "buflisted", false)
+    A.setBufferOption(bufID, "autoread", true)
+    A.setWindowOption(id, "conceallevel", 2)
 
-    location = string.format(
-        "%s%s-%s.%s",
-        location,
-        _G.NoNeckPain.config.buffers[side].scratchPad.fileName,
-        side,
-        _G.NoNeckPain.config.buffers[side].bo.filetype
+    D.log(
+        string.format("W.initScratchPad:%s", side),
+        "enabled with location %s",
+        _G.NoNeckPain.config.buffers[side].scratchPad.pathToFile
     )
 
-    D.log(string.format("W.initScratchPad:%s", side), "enabled with location %s", location)
-
-    vim.cmd(string.format("edit %s", location))
+    vim.cmd(string.format("edit %s", _G.NoNeckPain.config.buffers[side].scratchPad.pathToFile))
 
     vim.o.autowriteall = true
 end
@@ -132,11 +131,11 @@ function W.createSideBuffers(skipIntegrations)
                 S.setSideID(S, id, side)
 
                 if _G.NoNeckPain.config.buffers[side].scratchPad.enabled then
-                    W.initScratchPad(side)
-                    S.setScratchpad(S, true)
+                    W.initScratchPad(side, id)
+                    S.setScratchPad(S, true)
                 end
 
-                initSideOptions(id, side)
+                W.initSideOptions(side, id)
             end
 
             local sideID = S.getSideID(S, side)

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -133,7 +133,8 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     )
     Helpers.toggle(child)
 
-    Helpers.expect.config(child, "buffers.scratchPad.enabled", true)
+    Helpers.expect.config(child, "buffers.left.scratchPad.enabled", true)
+    Helpers.expect.config(child, "buffers.right.scratchPad.enabled", true)
     Helpers.expect.config(child, "autocmds.skipEnteringNoNeckPainBuffer", true)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
@@ -151,8 +152,8 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     )
     Helpers.toggle(child)
 
-    Helpers.expect.config(child, "buffers.scratchPad.enabled", false)
     Helpers.expect.config(child, "buffers.left.scratchPad.enabled", true)
+    Helpers.expect.config(child, "buffers.right.scratchPad.enabled", false)
     Helpers.expect.config(child, "autocmds.skipEnteringNoNeckPainBuffer", true)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
@@ -170,7 +171,6 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     )
     Helpers.toggle(child)
 
-    Helpers.expect.config(child, "buffers.scratchPad.enabled", false)
     Helpers.expect.config(child, "buffers.left.scratchPad.enabled", false)
     Helpers.expect.config(child, "buffers.right.scratchPad.enabled", true)
     Helpers.expect.config(child, "autocmds.skipEnteringNoNeckPainBuffer", true)

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -22,38 +22,38 @@ T["setup"]["does not create mappings by default"] = function()
     Helpers.expect.config(child, "mappings.enabled", false)
 
     -- toggle plugin state
-    child.lua("vim.api.nvim_input('<Leader>np')")
+    child.api.nvim_input("<Leader>np")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- decrease width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- increase width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- toggle scratchPad
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>ns')")
+    child.api.nvim_input("<Leader>ns")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 end
@@ -132,52 +132,52 @@ T["setup"]["does not create mappings if false"] = function()
     })
 
     -- toggle plugin state
-    child.lua("vim.api.nvim_input('<Leader>np')")
+    child.api.nvim_input("<Leader>np")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- decrease width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
-    child.lua("vim.api.nvim_input('<Leader>n-')")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
+    child.api.nvim_input("<Leader>n-")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- increase width
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
-    child.lua("vim.api.nvim_input('<Leader>n+')")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
+    child.api.nvim_input("<Leader>n+")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
     -- toggle scratchPad
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>ns')")
+    child.api.nvim_input("<Leader>ns")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- toggle left
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>nql')")
+    child.api.nvim_input("<Leader>nql")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
     -- toggle right
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 
-    child.lua("vim.api.nvim_input('<Leader>nqr')")
+    child.api.nvim_input("<Leader>nqr")
 
     Helpers.expect.global(child, "_G.NoNeckPain.state", vim.NIL)
 end
@@ -189,10 +189,10 @@ T["setup"]["increase the width with mapping"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 70)
 end
@@ -206,10 +206,10 @@ T["setup"]["increase the width with custom mapping and value"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 90)
 end
@@ -247,10 +247,10 @@ T["setup"]["decrease the width with mapping"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 30)
 end
@@ -264,10 +264,10 @@ T["setup"]["decrease the width with custom mapping and value"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
-    child.lua("vim.api.nvim_input('nn')")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
+    child.api.nvim_input("nn")
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 22)
 end
@@ -278,13 +278,15 @@ T["setup"]["toggles scratchPad"] = function()
     )
     Helpers.toggle(child)
 
-    Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.scratchPad.enabled", false)
+    Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.left.scratchPad.enabled", false)
+    Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.right.scratchPad.enabled", false)
     Helpers.expect.global(child, "_G.NoNeckPain.state.tabs[1].scratchPadEnabled", false)
 
     child.api.nvim_input("ns")
     Helpers.wait(child)
 
-    Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.scratchPad.enabled", false)
+    Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.left.scratchPad.enabled", false)
+    Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.right.scratchPad.enabled", false)
     Helpers.expect.global(child, "_G.NoNeckPain.state.tabs[1].scratchPadEnabled", true)
 end
 

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -233,13 +233,13 @@ T["scratchPad"]["forwards the given filetype to the scratchPad"] = function()
     child.lua([[require('no-neck-pain').setup({
         width = 50,
         buffers = {
+            bo = {
+                filetype = "custom"
+            },
             scratchPad = {
                 enabled = true,
                 pathToFile = "foo.custom"
             },
-            bo = {
-                filetype = "custom"
-            }
         },
     })]])
     Helpers.toggle(child)

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -21,27 +21,41 @@ T["setup"]["overrides default values"] = function()
         buffers = {
             scratchPad = {
                 enabled = true,
-                location = "~/Documents",
+                pathToFile = "~/Documents/foo.md"
             }
         },
     })]])
 
-    Helpers.expect.config(child, "buffers.scratchPad", {
-        enabled = true,
-        fileName = "no-neck-pain",
-        location = "~/Documents",
-    })
-
     Helpers.expect.config(child, "buffers.left.scratchPad", {
         enabled = true,
-        fileName = "no-neck-pain",
-        location = "~/Documents",
+        pathToFile = "~/Documents/foo.md",
     })
 
     Helpers.expect.config(child, "buffers.right.scratchPad", {
         enabled = true,
-        fileName = "no-neck-pain",
-        location = "~/Documents",
+        pathToFile = "~/Documents/foo.md",
+    })
+end
+
+T["setup"]["converts deprecate options to pathToFile"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        buffers = {
+            scratchPad = {
+                enabled = true,
+                fileName = "foo",
+                location = "~/bar"
+            }
+        },
+    })]])
+
+    Helpers.expect.config(child, "buffers.left.scratchPad", {
+        enabled = true,
+        pathToFile = "~/bar/foo-left.norg",
+    })
+
+    Helpers.expect.config(child, "buffers.right.scratchPad", {
+        enabled = true,
+        pathToFile = "~/bar/foo-right.norg",
     })
 end
 
@@ -215,36 +229,53 @@ T["scratchPad"]["side buffer definition overrides global one"] = function()
     )
 end
 
-T["scratchPad"]["throws with invalid location"] = function()
-    Helpers.expect.error(function()
-        child.lua(
-            [[require('no-neck-pain').setup({buffers = { scratchPad = { enabled = true, location = 10 }}})]]
-        )
-        Helpers.toggle(child)
-    end)
-end
-
-T["scratchPad"]["forwards the given filetype to the scratchpad"] = function()
+T["scratchPad"]["forwards the given filetype to the scratchPad"] = function()
     child.lua([[require('no-neck-pain').setup({
         width = 50,
         buffers = {
             scratchPad = {
-                enabled = true
+                enabled = true,
+                pathToFile = "foo.custom"
             },
             bo = {
                 filetype = "custom"
-            },
+            }
         },
     })]])
     Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
-    child.lua("vim.fn.win_gotoid(1001)")
+    child.fn.win_gotoid(1001)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "custom")
 
-    child.lua("vim.fn.win_gotoid(1002)")
+    child.fn.win_gotoid(1002)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'filetype')"), "custom")
+end
+
+T["scratchPad"]["toggling the scratchPad sets the buffer/window options"] = function()
+    child.lua([[require('no-neck-pain').setup({
+        width = 50,
+        buffers = { scratchPad = { enabled = false }, },
+        mappings = { scratchPad = "foo" },
+    })]])
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    child.fn.win_gotoid(1001)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)
+
+    child.fn.win_gotoid(1002)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)
+
+    child.api.nvim_input("foo")
+
+    child.fn.win_gotoid(1001)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)
+
+    child.fn.win_gotoid(1002)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)
 end
 
 return T


### PR DESCRIPTION
## 📃 Summary

It's hard to compose a scratchpad file location today, it requires 3 props to determine the full `pathToFile` and the custom filetype doesn't work everytime.

The idea is to propose a single property that does it all, which will deprecate all the other options in the next major

before, in order to define custom buffers
```lua
buffers = {
    left = {
        bo = {
            filetype = "custom"
        },
        scratchPad = {
            enabled = true,
            fileName = "notes",
            location = "~/Documents"
        },
    },
    right = {
        bo = {
            filetype = "md"
        },
        scratchPad = {
            enabled = true,
            fileName = "foo",
            location = "./bar/baz"
        },
    },
},
```

now
```lua
buffers = {
    left = {
        bo = {
            filetype = "custom"
        },
        scratchPad = {
            enabled = true,
            pathToFile = "~/Documents/notes.custom"
        },
    },
    right = {
        scratchPad = {
            enabled = true,
            pathToFile = "./bar/baz/foo.md"
        },
    },
},
```