### PR TITLE
fix(autocmds): wrong registered group

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -124,7 +124,7 @@ function NoNeckPain.setup(opts)
                     end, 20)
                 end)
             end,
-            group = "NoNeckPainAutocmd",
+            group = "NoNeckPainVimEnterAutocmd",
             desc = "Triggers until it finds the correct moment/buffer to enable the plugin.",
         })
     end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -347,8 +347,17 @@ function N.enable(scope)
                     return D.log(s, "no registered integration")
                 end
 
-                if p.event == "WinEnter" and #S.getUnregisteredWins(S) == 0 then
+                local unregistered = S.getUnregisteredWins(S)
+                if p.event == "WinEnter" and #unregistered == 0 then
                     return D.log(s, "no new windows")
+                end
+
+                if
+                    p.event == "WinEnter"
+                    and #unregistered == 1
+                    and not S.isSupportedIntegration(S, s, unregistered[1])
+                then
+                    return D.log(s, "encountered a new window, not an integration")
                 end
 
                 N.init(s, false, true)

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -29,11 +29,12 @@ end
 T["auto command"]["disabling clears VimEnter autocmd"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
     Helpers.toggle(child)
+    Helpers.wait(child)
 
-    Helpers.expect.equality(
-        child.api.nvim_get_autocmds({ group = "NoNeckPainVimEnterAutocmd" }),
-        {}
-    )
+    -- errors because it doesn't exist
+    Helpers.expect.error(function()
+        child.api.nvim_get_autocmds({ group = "NoNeckPainVimEnterAutocmd" })
+    end)
 end
 
 T["auto command"]["does not shift when opening/closing float window"] = function()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -70,7 +70,7 @@ T["setup"]["overrides default values"] = function()
         outline = {
             position = "right",
             reopen = true,
-        }
+        },
     })
 end
 


### PR DESCRIPTION
## 📃 Summary

on vim enter, the group for auto-enabling wasn't cleared, meaning the plugin would re-enable everytime a new buffer was entered