### PR TITLE
fix(layout): broken layout with top or bottom windows

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -132,7 +132,6 @@ function N.enable(scope)
     vim.api.nvim_create_augroup(augroupName, { clear = true })
 
     S.setSideID(S, vim.api.nvim_get_current_win(), "curr")
-    S.refreshLayers(S)
 
     N.init(scope, true)
 
@@ -210,19 +209,12 @@ function N.enable(scope)
                     return D.log(p.event, "on an integration")
                 end
 
-                local wins = S.getUnregisteredWins(S)
-
-                if #wins ~= 1 then
-                    return D.log(p.event, "no new or too many unregistered windows")
-                end
-
-                S.refreshLayers(S)
                 -- TODO: find a way to skip this ui refresh
                 N.init(p.event)
             end)
         end,
         group = augroupName,
-        desc = "WinEnter covers the layers refreshing",
+        desc = "WinEnter covers the vsplits refreshing",
     })
 
     vim.api.nvim_create_autocmd({ "QuitPre", "BufDelete" }, {
@@ -233,7 +225,7 @@ function N.enable(scope)
                     return
                 end
 
-                if S.hasLayers(S) then
+                if S.hasVSplits(S) then
                     return D.log(s, "splits still active")
                 end
 
@@ -279,11 +271,11 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
-                if E.skip(nil) or not S.hasLayers(S) or W.stateWinsActive() then
+                if E.skip(nil) or not S.hasVSplits(S) or W.stateWinsActive() then
                     return
                 end
 
-                S.refreshLayers(S)
+                S.refreshVSplits(S)
 
                 -- we keep track if curr have been closed because if it's the case,
                 -- the focus will be on a side buffer which is wrong
@@ -292,7 +284,7 @@ function N.enable(scope)
                 -- if curr is not valid anymore, we focus the first valid split and remove it from the state
                 if not vim.api.nvim_win_is_valid(S.getSideID(S, "curr")) then
                     -- if neither curr and splits are remaining valids, we just disable
-                    if not S.hasLayers(S) then
+                    if not S.hasVSplits(S) then
                         return N.disable(p.event)
                     end
 
@@ -308,7 +300,7 @@ function N.enable(scope)
                 end
 
                 -- we only restore focus on curr if there's no split left
-                N.init(p.event, haveCloseCurr or not S.hasLayers(S))
+                N.init(p.event, haveCloseCurr or not S.hasVSplits(S))
             end)
         end,
         group = augroupName,

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -36,20 +36,19 @@ function A.getAugroupName(id)
     return string.format("NoNeckPain-%d", id)
 end
 
----returns the width and height of a given window
+---returns the width a given window if valid.
 ---
----@param win number?: the win number, defaults to 0 if nil
----@return number: the width of the window
----@return number: the height of the window
+---@param win number?: the win number, defaults to 0 if nil.
+---@return number: the width of the window.
 ---@private
-function A.getWidthAndHeight(win)
+function A.getWidth(win)
     win = win or 0
 
     if win ~= 0 and not vim.api.nvim_win_is_valid(win) then
         win = 0
     end
 
-    return vim.api.nvim_win_get_width(win), vim.api.nvim_win_get_height(win)
+    return vim.api.nvim_win_get_width(win)
 end
 
 ---Determines if the given `win` or the current window is relative.

--- a/lua/no-neck-pain/util/debug.lua
+++ b/lua/no-neck-pain/util/debug.lua
@@ -21,6 +21,15 @@ function D.log(scope, str, ...)
     )
 end
 
+---same as `log` but intended for no scope usage.
+---
+---@param str string: the formatted string.
+---@param ... any: the arguments of the formatted string.
+---@private
+function D.print(str, ...)
+    return D.log("<<<<<<<<<DEBUG>>>>>>>>>", str, ...)
+end
+
 ---analyzes the user provided `setup` parameters and sends a message if they use a deprecated option, then gives the new option to use.
 ---
 ---@param options table: the options provided by the user.

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -109,6 +109,7 @@ end
 function W.createSideBuffers(skipIntegrations)
     -- before creating side buffers, we determine if we should consider externals
     S.refreshIntegrations(S, "createSideBuffers")
+    S.refreshVSplits(S)
 
     local wins = {
         left = { cmd = "topleft vnew", padding = 0 },
@@ -210,12 +211,12 @@ function W.getPadding(side)
     local tab = S.getTab(S)
 
     -- we need to see if there's enough space left to have side buffers
-    local occupied = _G.NoNeckPain.config.width * tab.layers.vsplit
+    local occupied = _G.NoNeckPain.config.width * tab.wins.vsplits
 
     -- if there's no space left according to the config width,
     -- then we don't have to create side buffers.
     if occupied >= width then
-        D.log(side, "%d vsplits - no space left to create side buffers", tab.layers.vsplit)
+        D.log(side, "%d vsplits - no space left to create side buffers", tab.wins.vsplits)
 
         return 0
     end
@@ -224,7 +225,7 @@ function W.getPadding(side)
         side,
         "%d currently with %d vsplits - computing integrations width",
         occupied,
-        tab.layers.vsplit
+        tab.wins.vsplits
     )
 
     -- now we need to determine how much we should substract from the remaining padding
@@ -244,12 +245,13 @@ function W.getPadding(side)
                 tree.width
             )
 
+            -- TODO: do not store width, get it at runtime instead.
             paddingToSubstract = paddingToSubstract + tree.width
         end
     end
 
     return math.floor(
-        (width - paddingToSubstract - (_G.NoNeckPain.config.width * tab.layers.vsplit)) / 2
+        (width - paddingToSubstract - (_G.NoNeckPain.config.width * (tab.wins.vsplits - 2))) / 2
     )
 end
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -239,8 +239,6 @@ T["enable"]["(single tab) sets state"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
-
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
     Helpers.expect.state(child, "tabs[1].wins.integrations", Co.INTEGRATIONS)
@@ -267,8 +265,6 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
-
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
     Helpers.expect.state(child, "tabs[1].wins.integrations", Co.INTEGRATIONS)
@@ -291,8 +287,6 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1004,
         right = 1005,
     })
-    Helpers.expect.state(child, "tabs[2].wins.splits", vim.NIL)
-
     Helpers.expect.state_type(child, "tabs[2].wins.integrations", "table")
 
     Helpers.expect.state(child, "tabs[2].wins.integrations", Co.INTEGRATIONS)

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -137,8 +137,6 @@ T["nvimdapui"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
-
     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimDAPUI", {
         close = "lua require('dapui').close()",
         fileTypePattern = "dap",
@@ -166,8 +164,6 @@ T["neotest"]["keeps sides open"] = function()
     child.lua([[require('neotest').summary.open()]])
     vim.loop.sleep(50)
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
-
     Helpers.expect.state(child, "tabs[1].wins.integrations.neotest", {
         close = "lua require('neotest').summary.close()",
         fileTypePattern = "neotest",
@@ -194,8 +190,6 @@ T["outline"]["keeps sides open"] = function()
 
     child.cmd("Outline")
     vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.outline", {
         close = "Outline",
@@ -239,8 +233,6 @@ T["NvimTree"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
-
     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimTree", {
         close = "NvimTreeClose",
         fileTypePattern = "nvimtree",
@@ -278,8 +270,6 @@ T["neo-tree"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
-
     Helpers.expect.state(child, "tabs[1].wins.integrations.NeoTree", {
         close = "Neotree close",
         fileTypePattern = "neo-tree",
@@ -308,8 +298,6 @@ T["TSPlayground"]["keeps sides open"] = function()
 
     child.cmd("TSPlaygroundToggle")
     vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 173)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
@@ -369,8 +357,6 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
     child.cmd("TSPlaygroundToggle")
     vim.loop.sleep(50)
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
-
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 149)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
@@ -387,8 +373,6 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
 
     child.cmd("TSPlaygroundToggle")
     vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",

--- a/tests/test_options.lua
+++ b/tests/test_options.lua
@@ -48,6 +48,7 @@ T["killAllBuffersOnDisable"]["closes every windows when disabling the plugin"] =
     child.cmd("badd 1")
     child.cmd("vsplit")
     child.cmd("split")
+    child.loop.sleep(500)
     Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3, 4 })
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
 

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -83,6 +83,30 @@ T["split"]["keeps side buffers"] = function()
     Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
 end
 
+T["split"]["qf list keeps both buffer and is well positionned"] = function()
+    child.set_size(200, 200)
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    child.cmd("copen")
+    child.loop.sleep(50)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+    Helpers.expect.state(child, "tabs[1].wins.splits[1003]", { id = 1003, vertical = false })
+end
+
 T["split"]["keeps correct focus"] = function()
     child.set_size(300, 300)
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -185,13 +185,10 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1000,
                     left = 1001,
@@ -206,13 +203,10 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1000,
                     left = 1001,
@@ -222,13 +216,10 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
         },
         {
             id = 2,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1003,
                     left = 1004,
@@ -242,13 +233,10 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1000,
                     left = 1001,
@@ -269,13 +257,10 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1000,
                     left = 1001,
@@ -293,13 +278,10 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1000,
                     left = 1001,
@@ -309,13 +291,10 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
         {
             id = 2,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1003,
                     left = 1004,
@@ -329,13 +308,10 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1000,
                     left = 1001,
@@ -349,13 +325,10 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1000,
                     left = 1001,
@@ -365,13 +338,10 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
         {
             id = 2,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1003,
                     left = 1006,
@@ -386,13 +356,10 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1000,
                     left = 1001,
@@ -402,13 +369,10 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
         {
             id = 2,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
+                splits = 1,
                 main = {
                     curr = 1003,
                     left = 1006,
@@ -443,13 +407,10 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
+            splits = 1,
             main = {
                 curr = 1001,
                 left = 1002,
@@ -468,10 +429,6 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     Helpers.toggle(child)
     Helpers.expect.state(child, "tabs[1]", {
         id = 1,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = {
@@ -511,6 +468,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                     open = "Outline",
                 },
             },
+            splits = 1,
             main = {
                 curr = 1000,
                 left = 1004,
@@ -520,13 +478,10 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     })
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
+            splits = 1,
             main = {
                 curr = 1001,
                 left = 1002,
@@ -557,13 +512,10 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
+            splits = 1,
             main = {
                 curr = 1001,
                 left = 1002,
@@ -587,13 +539,10 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     Helpers.expect.state(child, "tabs[1]", vim.NIL)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
+            splits = 1,
             main = {
                 curr = 1001,
                 left = 1002,


### PR DESCRIPTION
## 📃 Summary

a (long awaited) attempt to fix https://github.com/shortcuts/no-neck-pain.nvim/issues/340

rely on the native `winlayout` fn to compute the layers/split layout state in order to determine what to do with the windows

as of now it kind of breaks the tests but it's muuuuuuuuuuuuuch more reliable than my custom logic