### PR TITLE
fix(autocmds): do not force close unsaved buffers

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -429,6 +429,7 @@ function N.disable(scope)
 
     local sides = { left = S.getSideID(S, "left"), right = S.getSideID(S, "right") }
     local currID = S.getSideID(S, "curr")
+    local activeTab = S.activeTab
 
     if S.refreshTabs(S) == 0 then
         pcall(vim.api.nvim_del_augroup_by_name, "NoNeckPainVimEnterAutocmd")
@@ -442,7 +443,7 @@ function N.disable(scope)
 
     for side, id in pairs(sides) do
         if vim.api.nvim_win_is_valid(id) then
-            if #vim.api.nvim_tabpage_list_wins(S.activeTab) == 1 then
+            if #vim.api.nvim_tabpage_list_wins(activeTab) == 1 then
                 return vim.cmd("quit")
             end
 
@@ -452,17 +453,15 @@ function N.disable(scope)
     end
 
     -- shutdowns gracefully by focusing the stored `curr` buffer
-    if
-        currID ~= nil
-        and vim.api.nvim_win_is_valid(currID)
-        and not vim.api.nvim_get_current_win() == currID
-    then
+    if currID ~= nil and vim.api.nvim_win_is_valid(currID) then
         vim.fn.win_gotoid(currID)
 
         if _G.NoNeckPain.config.killAllBuffersOnDisable then
             vim.cmd("only")
         end
     end
+
+    S.save(S)
 end
 
 return N

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -439,8 +439,6 @@ function N.disable(scope)
         S.init(S)
     end
 
-    S.save(S)
-
     for side, id in pairs(sides) do
         if vim.api.nvim_win_is_valid(id) then
             if #vim.api.nvim_tabpage_list_wins(activeTab) == 1 then

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -253,7 +253,7 @@ function N.enable(scope)
                         and not S.isSideWinValid(S, "curr")
                     )
                 then
-                    D.log(s, "one of the NNP side has been closed, disabling...")
+                    D.log(s, "one of the NNP side has been closed")
 
                     return N.disable(p.event)
                 end
@@ -267,12 +267,14 @@ function N.enable(scope)
                 -- if we still have a side valid but curr has been deleted (mostly because of a :bd),
                 -- we will fallback to the first valid side
                 if p.event == "QuitPre" then
-                    D.log(s, "one of the NNP side has been closed, disabling...")
+                    D.log(s, "curr has been closed")
 
                     return N.disable(p.event)
                 end
 
                 D.log(s, "`curr` has been deleted, resetting state")
+
+                vim.cmd("new")
 
                 N.disable(string.format("%s:reset", s))
                 N.enable(string.format("%s:reset", s))
@@ -425,55 +427,8 @@ function N.disable(scope)
 
     pcall(vim.api.nvim_del_augroup_by_name, A.getAugroupName(S.activeTab))
 
+    local sides = { left = S.getSideID(S, "left"), right = S.getSideID(S, "right") }
     local currID = S.getSideID(S, "curr")
-
-    -- shutdowns gracefully by focusing the stored `curr` buffer
-    if
-        currID ~= nil
-        and vim.api.nvim_win_is_valid(currID)
-        and not S.isSideTheActiveWin(S, "curr")
-    then
-        vim.fn.win_gotoid(currID)
-
-        if _G.NoNeckPain.config.killAllBuffersOnDisable then
-            vim.cmd("only")
-        end
-    end
-
-    -- determine if we should quit vim or just close the window
-    for _, side in pairs(Co.SIDES) do
-        if S.isSideRegistered(S, side) then
-            local activeWins = vim.api.nvim_tabpage_list_wins(S.activeTab)
-            local haveOtherWins = false
-            local sideID = S.getSideID(S, side)
-
-            if S.isSideWinValid(S, side) then
-                S.removeNamespace(S, vim.api.nvim_win_get_buf(sideID), side)
-            end
-
-            -- if we have other wins active and usable, we won't quit vim
-            for _, activeWin in pairs(activeWins) do
-                if sideID ~= activeWin and not A.isRelativeWindow(activeWin) then
-                    haveOtherWins = true
-                end
-            end
-
-            -- we don't have any window left if we close this one
-            if not haveOtherWins then
-                -- either triggered by a :wq or quit event, we can just quit
-                if scope == "QuitPre" then
-                    return vim.cmd("quit!")
-                end
-
-                -- mostly triggered by :bd or similar
-                -- we will create a new window and close the other
-                vim.cmd("new")
-            end
-
-            -- when we have more than 1 window left, we can just close it
-            W.close(scope, sideID, side)
-        end
-    end
 
     if S.refreshTabs(S) == 0 then
         pcall(vim.api.nvim_del_augroup_by_name, "NoNeckPainVimEnterAutocmd")
@@ -484,6 +439,30 @@ function N.disable(scope)
     end
 
     S.save(S)
+
+    for side, id in pairs(sides) do
+        if vim.api.nvim_win_is_valid(id) then
+            if #vim.api.nvim_tabpage_list_wins(S.activeTab) == 1 then
+                return vim.cmd("quit")
+            end
+
+            S.removeNamespace(S, vim.api.nvim_win_get_buf(id), side)
+            W.close(scope, id, side)
+        end
+    end
+
+    -- shutdowns gracefully by focusing the stored `curr` buffer
+    if
+        currID ~= nil
+        and vim.api.nvim_win_is_valid(currID)
+        and not vim.api.nvim_get_current_win() == currID
+    then
+        vim.fn.win_gotoid(currID)
+
+        if _G.NoNeckPain.config.killAllBuffersOnDisable then
+            vim.cmd("only")
+        end
+    end
 end
 
 return N

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -50,7 +50,7 @@ function W.close(scope, id, side)
     D.log(scope, "closing %s window", side)
 
     if vim.api.nvim_win_is_valid(id) then
-        vim.api.nvim_win_close(id, false)
+        vim.api.nvim_win_close(id, true)
     end
 end
 

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -50,7 +50,7 @@ function W.close(scope, id, side)
     D.log(scope, "closing %s window", side)
 
     if vim.api.nvim_win_is_valid(id) then
-        vim.api.nvim_win_close(id, true)
+        vim.api.nvim_win_close(id, false)
     end
 end
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -358,4 +358,26 @@ T["disable"]["(multiple tab) resets state"] = function()
     Helpers.expect.state(child, "tabs", vim.NIL)
 end
 
+T["disable"]["does not close the window if unsaved buffer"] = function()
+    child.set_size(500, 500)
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
+
+    Helpers.expect.state(child, "enabled", true)
+
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+    Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3 })
+
+    child.api.nvim_buf_set_lines(1, 0, 1, false, { "foo" })
+    child.cmd("quit")
+
+    Helpers.expect.equality(Helpers.listBuffers(child), { 2 })
+    Helpers.expect.state(child, "enabled", false)
+    Helpers.expect.equality(Helpers.listBuffers(child), { 1 })
+end
+
 return T

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -364,7 +364,6 @@ T["disable"]["does not close the window if unsaved buffer"] = function()
     Helpers.toggle(child)
 
     Helpers.expect.state(child, "enabled", true)
-
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -373,11 +372,14 @@ T["disable"]["does not close the window if unsaved buffer"] = function()
     Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3 })
 
     child.api.nvim_buf_set_lines(1, 0, 1, false, { "foo" })
+
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(1, 'modified')"), true)
+
     child.cmd("quit")
 
-    Helpers.expect.equality(Helpers.listBuffers(child), { 2 })
-    Helpers.expect.state(child, "enabled", false)
-    Helpers.expect.equality(Helpers.listBuffers(child), { 1 })
+    Helpers.expect.error(function()
+        child.cmd("quit")
+    end)
 end
 
 return T


### PR DESCRIPTION
## 📃 Summary

we were force closing remaining windows on teardown but it's possible that the buffer isn't yet saved, we therefore need to replicate this behavior

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/348