### PR TITLE
fix(disable): prevent blocked quit with relative windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ deps:
 	git clone --depth 1 https://github.com/mfussenegger/nvim-dap deps/nvimdap
 	git clone --depth 1 https://github.com/rcarriga/nvim-dap-ui deps/nvimdapui
 	git clone --depth 1 https://github.com/hedyhli/outline.nvim deps/outline
+	git clone --depth 1 https://github.com/b0o/incline.nvim deps/incline
 
 test-ci: deps test
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -441,7 +441,12 @@ function N.disable(scope)
 
     for side, id in pairs(sides) do
         if vim.api.nvim_win_is_valid(id) then
-            if #vim.api.nvim_tabpage_list_wins(activeTab) == 1 then
+            local wins = vim.tbl_filter(function(win)
+                return win ~= id and not A.isRelativeWindow(win)
+                -- return win ~= id
+            end, vim.api.nvim_tabpage_list_wins(activeTab))
+
+            if #wins == 0 then
                 return vim.cmd("quit")
             end
 

--- a/scripts/init_with_incline.lua
+++ b/scripts/init_with_incline.lua
@@ -1,0 +1,41 @@
+vim.cmd([[let &rtp.=','.getcwd()]])
+
+vim.cmd("set rtp+=deps/mini.nvim")
+vim.cmd("set rtp+=deps/nvim-web-devicons")
+vim.cmd("set rtp+=deps/incline")
+
+require("mini.test").setup()
+require("no-neck-pain").setup({
+    width = 1,
+    minSideBufferWidth = 0,
+    integrations = { NeoTree = { reopen = true } },
+})
+local helpers = require("incline.helpers")
+local devicons = require("nvim-web-devicons")
+require("incline").setup({
+    window = {
+        padding = 0,
+        margin = { horizontal = 0 },
+    },
+    render = function(props)
+        local filename = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(props.buf), ":t")
+        if filename == "" then
+            filename = "[No Name]"
+        end
+        local ft_icon, ft_color = devicons.get_icon_color(filename)
+        local modified = vim.bo[props.buf].modified
+        return {
+            ft_icon and {
+                " ",
+                ft_icon,
+                " ",
+                guibg = ft_color,
+                guifg = helpers.contrast_color(ft_color),
+            } or "",
+            " ",
+            { filename, gui = modified and "bold,italic" or "bold" },
+            " ",
+            guibg = "#44406e",
+        }
+    end,
+})

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -377,8 +377,30 @@ T["disable"]["does not close the window if unsaved buffer"] = function()
 
     child.cmd("quit")
 
+    -- error because e37 requires confirmation
+    Helpers.expect.equality(child.is_blocked(), true)
+end
+
+T["disable"]["relative window doesn't prevent quitting nvim"] = function()
+    child.set_size(500, 500)
+    child.restart({ "-u", "scripts/init_with_incline.lua" })
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
+
+    Helpers.expect.state(child, "enabled", true)
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1003,
+        right = 1004,
+    })
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1000, 1004, 1002 })
+    vim.fn.win_gotoid(1000)
+
+    child.cmd("quit")
+
     Helpers.expect.error(function()
-        child.cmd("quit")
+        -- error because instance is closed
+        Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1000, 1004, 1002 })
     end)
 end
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -382,8 +382,8 @@ T["disable"]["does not close the window if unsaved buffer"] = function()
 end
 
 T["disable"]["relative window doesn't prevent quitting nvim"] = function()
-    if child.fn.has("nvim-0.7") == 0 then
-        MiniTest.skip("incline doesn't support version below 7")
+    if child.fn.has("nvim-0.8") == 0 then
+        MiniTest.skip("incline doesn't support version below 8")
 
         return
     end

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -382,6 +382,12 @@ T["disable"]["does not close the window if unsaved buffer"] = function()
 end
 
 T["disable"]["relative window doesn't prevent quitting nvim"] = function()
+    if child.fn.has("nvim-0.7") == 0 then
+        MiniTest.skip("incline doesn't support version below 7")
+
+        return
+    end
+
     child.set_size(500, 500)
     child.restart({ "-u", "scripts/init_with_incline.lua" })
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])


### PR DESCRIPTION
## 📃 Summary

relative windows are considered as windows, so the disable check was false in case one is opened

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/352
