### PR TITLE
chore: pin mini.nvim version before bc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,22 +23,13 @@ $(addprefix test-, $(TESTFILES)): test-%:
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua MiniTest.run_file('tests/test_$*.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 deps:
-	git clone --depth 1 https://github.com/nvim-lua/plenary.nvim deps/plenary
-	git clone --depth 1 https://github.com/nvim-neotest/nvim-nio deps/nvim-nio
-	git clone --depth 1 https://github.com/echasnovski/mini.nvim deps/mini.nvim --branch stable
-	git clone --depth 1 https://github.com/nvim-treesitter/nvim-treesitter deps/nvim-treesitter
-	git clone --depth 1 https://github.com/nvim-treesitter/playground deps/playground
-	git clone --depth 1 https://github.com/nvim-neotest/neotest deps/neotest
-	git clone --depth 1 https://github.com/nvim-tree/nvim-tree.lua deps/nvimtree
-	git clone --depth 1 https://github.com/nvim-neo-tree/neo-tree.nvim deps/neo-tree
-	git clone --depth 1 https://github.com/nvim-tree/nvim-web-devicons deps/nvim-web-devicons
-	git clone --depth 1 https://github.com/MunifTanjim/nui.nvim deps/nui
-	git clone --depth 1 https://github.com/antoinemadec/FixCursorHold.nvim deps/fixcursorhold
-	git clone --depth 1 https://github.com/mfussenegger/nvim-dap deps/nvimdap
-	git clone --depth 1 https://github.com/rcarriga/nvim-dap-ui deps/nvimdapui
-	git clone --depth 1 https://github.com/hedyhli/outline.nvim deps/outline
-	git clone --depth 1 https://github.com/b0o/incline.nvim deps/incline
-	git clone --depth 1 https://github.com/stevearc/aerial.nvim deps/aerial
+	./scripts/clone_deps.sh 1 || true
+	# bc for mini.nvim before this date
+	./scripts/reset_deps_at_date.sh ./deps/mini.nvim
+
+deps-at-date:
+	./scripts/clone_deps.sh || true
+	find deps -type d -mindepth 1 -maxdepth 1 | xargs -I{} bash -c './scripts/reset_deps_at_date.sh {}'
 
 test-ci: deps test
 

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,8 @@ deps:
 	# bc for mini.nvim before this date
 	./scripts/reset_deps_at_date.sh ./deps/mini.nvim
 
-deps-at-date:
-	./scripts/clone_deps.sh || true
-	find deps -type d -mindepth 1 -maxdepth 1 | xargs -I{} bash -c './scripts/reset_deps_at_date.sh {}'
+deps-latest:
+	./scripts/clone_deps.sh 1 || true
 
 test-ci: deps test
 

--- a/scripts/clone_deps.sh
+++ b/scripts/clone_deps.sh
@@ -1,0 +1,22 @@
+DEPTH=""
+
+if [[ -n $1 ]]; then
+    DEPTH="--depth $1"
+fi
+
+git clone $DEPTH https://github.com/MunifTanjim/nui.nvim deps/nui
+git clone $DEPTH https://github.com/antoinemadec/FixCursorHold.nvim deps/fixcursorhold
+git clone $DEPTH https://github.com/b0o/incline.nvim deps/incline
+git clone https://github.com/echasnovski/mini.nvim deps/mini.nvim --branch stable
+git clone $DEPTH https://github.com/hedyhli/outline.nvim deps/outline
+git clone $DEPTH https://github.com/mfussenegger/nvim-dap deps/nvimdap
+git clone $DEPTH https://github.com/nvim-lua/plenary.nvim deps/plenary
+git clone $DEPTH https://github.com/nvim-neo-tree/neo-tree.nvim deps/neo-tree
+git clone $DEPTH https://github.com/nvim-neotest/neotest deps/neotest
+git clone $DEPTH https://github.com/nvim-neotest/nvim-nio deps/nvim-nio
+git clone $DEPTH https://github.com/nvim-tree/nvim-tree.lua deps/nvimtree
+git clone $DEPTH https://github.com/nvim-tree/nvim-web-devicons deps/nvim-web-devicons
+git clone $DEPTH https://github.com/nvim-treesitter/nvim-treesitter deps/nvim-treesitter
+git clone $DEPTH https://github.com/nvim-treesitter/playground deps/playground
+git clone $DEPTH https://github.com/rcarriga/nvim-dap-ui deps/nvimdapui
+git clone $DEPTH https://github.com/stevearc/aerial.nvim deps/aerial

--- a/scripts/reset_deps_at_date.sh
+++ b/scripts/reset_deps_at_date.sh
@@ -1,0 +1,9 @@
+cd $1
+
+SINCE=$(git rev-parse --until=2024-04-03)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+HASH=$(git rev-list -1 $SINCE $BRANCH)
+
+echo $1
+
+git reset --hard $HASH

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -18,8 +18,9 @@ local T = MiniTest.new_set({
 T["install"] = MiniTest.new_set()
 
 T["install"]["sets global loaded variable"] = function()
-    Helpers.expect.global_type(child, "_G.NoNeckPainLoaded", "boolean")
+    Helpers.wait(child)
     Helpers.expect.global(child, "_G.NoNeckPain", vim.NIL)
+    Helpers.expect.global_type(child, "_G.NoNeckPainLoaded", "boolean")
 end
 
 T["setup"] = MiniTest.new_set()


### PR DESCRIPTION
## 📃 Summary

https://github.com/echasnovski/mini.nvim/commit/dbea32594cb644d6a78da50d156f66a56096942c?diff=split&w=1 introduces a breaking change but I'm not yet sure what's required to make it work like before