### PR TITLE
feat(splits): leverage winlayout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,11 @@ deps:
 	# bc for mini.nvim before this date
 	./scripts/reset_deps_at_date.sh ./deps/mini.nvim
 
-deps-latest:
-	./scripts/clone_deps.sh 1 || true
+deps-lint:
+	luarocks install argparse --force
+	luarocks install luafilesystem --force
+	luarocks install lanes --force
+	luarocks install luacheck --force
 
 test-ci: deps test
 
@@ -39,6 +42,7 @@ documentation-ci: deps documentation
 
 lint:
 	stylua . -g '*.lua' -g '!deps/' -g '!nightly/'
+	luacheck plugin/ lua/
 
 luals-ci:
 	rm -rf .ci/lua-ls/log

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,6 @@ $(addprefix test-, $(TESTFILES)): test-%:
 		-c "lua MiniTest.run_file('tests/test_$*.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 deps:
 	./scripts/clone_deps.sh 1 || true
-	# bc for mini.nvim before this date
-	./scripts/reset_deps_at_date.sh ./deps/mini.nvim
 
 deps-lint:
 	luarocks install argparse --force

--- a/lua/no-neck-pain/colors.lua
+++ b/lua/no-neck-pain/colors.lua
@@ -116,6 +116,10 @@ end
 ---@param side "left"|"right": the side of the window being resized, used for logging only.
 ---@private
 function C.init(win, side)
+    if win == nil then
+        return
+    end
+
     if
         _G.NoNeckPain.config.buffers[side].colors.background == nil
         and _G.NoNeckPain.config.buffers[side].colors.text == nil

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -331,7 +331,7 @@ local defaults = vim.deepcopy(NoNeckPain.options)
 ---@private
 local function parseDeprecatedScratchPad(side, options, fileType)
     -- set the defaults if the user rely on them
-    if A.length(options) == 0 or options.pathToFile == nil then
+    if vim.tbl_count(options) == 0 or options.pathToFile == nil then
         options = A.tde(options, defaults.buffers.scratchPad)
     end
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -81,6 +81,8 @@ function N.toggleSide(scope, side)
         return N.disable(scope)
     end
 
+    S.scanLayout(S, scope)
+
     N.init(scope)
 end
 
@@ -223,15 +225,15 @@ function N.enable(scope)
                 end
 
                 if
-                    (S.isSideRegistered(S, "left") and not S.isSideWinValid(S, "left"))
-                    or (S.isSideRegistered(S, "right") and not S.isSideWinValid(S, "right"))
+                    (S.isSideWinValid(S, "left") and not S.isSideWinValid(S, "left"))
+                    or (S.isSideWinValid(S, "right") and not S.isSideWinValid(S, "right"))
                 then
                     D.log(p.event, "one of the NNP side has been closed")
 
                     return N.disable(p.event)
                 end
 
-                return N.init(p.event)
+                -- return N.init(p.event)
             end)
         end,
         group = augroupName,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -209,16 +209,16 @@ function N.enable(scope)
                         return
                     end
 
-                    local vsplits, nbVSplits = S.getVSplits(S, true)
-                    if nbVSplits == 0 then
+                    local vsplit = S.getFirstValidVSplit(S)
+                    if vsplit == nil then
                         D.log(p.event, "no active windows found")
 
                         return N.disable(p.event)
                     end
 
-                    S.setSideID(S, vsplits[1], "curr")
+                    S.setSideID(S, vsplit, "curr")
 
-                    D.log(p.event, "re-routing to %d", S.getSideID(S, "curr"))
+                    D.log(p.event, "re-routing to %d", vsplit)
 
                     return N.init(p.event, true)
                 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -180,7 +180,7 @@ function N.enable(scope)
         desc = "Keeps track of the currently active tab and the tab state",
     })
 
-    vim.api.nvim_create_autocmd({ "WinEnter" }, {
+    vim.api.nvim_create_autocmd({ "WinEnter", "WinClosed" }, {
         callback = function(p)
             local s = string.format("%s:%d", p.event, vim.api.nvim_get_current_win())
             vim.schedule(function()

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -89,9 +89,8 @@ end
 --- Creates side buffers and set the tab state, focuses the `curr` window if required.
 --- @param scope string: internal identifier for logging purposes.
 --- @param goToCurr boolean?: whether we should re-focus the `curr` window.
---- @param skipIntegrations boolean?: whether we should skip the integrations logic.
 ---@private
-function N.init(scope, goToCurr, skipIntegrations)
+function N.init(scope, goToCurr)
     if not S.isActiveTabRegistered(S) then
         error("called the internal `init` method on a `nil` tab.")
     end
@@ -104,7 +103,12 @@ function N.init(scope, goToCurr, skipIntegrations)
         hadSideBuffers = false
     end
 
-    W.createSideBuffers(skipIntegrations)
+    if S.consumeRedraw(S) then
+        W.move(string.format("%s:consumeRedraw", scope), "left")
+        W.move(string.format("%s:consumeRedraw", scope), "right")
+    end
+
+    W.createSideBuffers()
 
     if
         goToCurr
@@ -209,16 +213,16 @@ function N.enable(scope)
                         return
                     end
 
-                    local vsplit = S.getFirstValidVSplit(S)
-                    if vsplit == nil then
+                    local wins = S.getUnregisteredWins(S)
+                    if #wins == 0 then
                         D.log(p.event, "no active windows found")
 
                         return N.disable(p.event)
                     end
 
-                    S.setSideID(S, vsplit, "curr")
+                    S.setSideID(S, wins[1], "curr")
 
-                    D.log(p.event, "re-routing to %d", vsplit)
+                    D.log(p.event, "re-routing to %d", wins[1])
 
                     return N.init(p.event, true)
                 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -96,8 +96,6 @@ function N.init(scope, goToCurr, skipIntegrations)
 
     D.log(scope, "init called on tab %d for current window %d", S.activeTab, S.getSideID(S, "curr"))
 
-    S.scanLayout(S, scope)
-
     -- if we do not have side buffers, we must ensure we only trigger a focus if we re-create them
     local hadSideBuffers = true
     if S.checkSides(S, "and", false) then
@@ -130,16 +128,15 @@ function N.enable(scope)
 
     D.log(scope, "calling enable for tab %d", A.getCurrentTab())
 
+    S.setEnabled(S)
     S.setTab(S, A.getCurrentTab())
 
     local augroupName = A.getAugroupName(S.activeTab)
     vim.api.nvim_create_augroup(augroupName, { clear = true })
 
     S.setSideID(S, vim.api.nvim_get_current_win(), "curr")
-
+    S.scanLayout(S, scope)
     N.init(scope, true)
-
-    S.setEnabled(S)
 
     vim.api.nvim_create_autocmd({ "VimResized" }, {
         callback = function(p)

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -132,7 +132,7 @@ function N.enable(scope)
     vim.api.nvim_create_augroup(augroupName, { clear = true })
 
     S.setSideID(S, vim.api.nvim_get_current_win(), "curr")
-    S.computeSplits(S, S.getSideID(S, "curr"))
+    S.refreshVSplits(S, scope)
 
     N.init(scope, true)
 
@@ -217,12 +217,7 @@ function N.enable(scope)
                     return D.log(p.event, "no new or too many unregistered windows")
                 end
 
-                local focusedWin = wins[1]
-
-                local isVSplit = S.computeSplits(S, focusedWin)
-                S.setSplit(S, { id = focusedWin, vertical = isVSplit })
-
-                if isVSplit then
+                if S.refreshVSplits(S, scope) then
                     N.init(p.event)
                 end
             end)

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -181,7 +181,7 @@ function N.enable(scope)
         desc = "Keeps track of the currently active tab and the tab state",
     })
 
-    vim.api.nvim_create_autocmd({ "QuitPre", "BufDelete", "WinEnter", "WinClosed" }, {
+    vim.api.nvim_create_autocmd({ "QuitPre", "BufDelete", "WinEnter" }, {
         callback = function(p)
             vim.schedule(function()
                 if not S.isActiveTabRegistered(S) or E.skip(S.getTab(S)) then

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -244,39 +244,21 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "WinEnter", "WinClosed" }, {
         callback = function(p)
             vim.schedule(function()
-                local s = string.format("%s:integration", p.event)
-                if
-                    not S.isActiveTabRegistered(S)
-                    or not S.isActiveTabRegistered(S)
-                    or E.skip(S.getTab(S))
-                then
-                    return D.log(s, "skip")
+                if not S.isActiveTabRegistered(S) or E.skip(S.getTab(S)) then
+                    return D.log(p.event, "skip")
                 end
 
                 S.refreshVSplits(S, scope)
 
                 if S.wantsSides(S) and S.checkSides(S, "and", false) then
-                    return D.log(s, "no side buffer")
+                    return D.log(p.event, "no side buffer")
                 end
 
                 if p.event == "WinClosed" and not S.hasIntegrations(S) then
-                    return D.log(s, "no registered integration")
+                    return D.log(p.event, "no registered integration")
                 end
 
-                local unregistered = S.getUnregisteredWins(S)
-                if p.event == "WinEnter" and #unregistered == 0 then
-                    return D.log(s, "no new windows")
-                end
-
-                if
-                    p.event == "WinEnter"
-                    and #unregistered == 1
-                    and not S.isSupportedIntegration(S, s, unregistered[1])
-                then
-                    return D.log(s, "encountered a new window, not an integration")
-                end
-
-                N.init(s, false, true)
+                N.init(p.event, false, true)
             end)
         end,
         group = augroupName,

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -224,8 +224,21 @@ function N.enable(scope)
                 end
 
                 if
-                    (S.isSideEnabled(S, "left") and not S.isSideWinValid(S, "left"))
-                    or (S.isSideEnabled(S, "right") and not S.isSideWinValid(S, "right"))
+                    p.event == "QuitPre"
+                    and not S.isSideWinValid(S, "left")
+                    and not S.isSideWinValid(S, "right")
+                then
+                    D.log(p.event, "closed a vsplit when no side buffers were present")
+
+                    return N.init(p.event)
+                end
+
+                if
+                    p.event ~= "WinEnter"
+                    and (
+                        (S.isSideEnabled(S, "left") and not S.isSideWinValid(S, "left"))
+                        or (S.isSideEnabled(S, "right") and not S.isSideWinValid(S, "right"))
+                    )
                 then
                     D.log(p.event, "one of the NNP side has been closed")
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -238,9 +238,7 @@ function N.enable(scope)
                     return
                 end
 
-                if S.getVSplits(S) > 0 then
-                    return D.log(s, "splits still active")
-                end
+                S.refreshVSplits(S, s)
 
                 if
                     (

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -96,7 +96,7 @@ function N.init(scope, goToCurr, skipIntegrations)
 
     D.log(scope, "init called on tab %d for current window %d", S.activeTab, S.getSideID(S, "curr"))
 
-    S.refreshVSplits(S, scope)
+    S.scanLayout(S, scope)
 
     -- if we do not have side buffers, we must ensure we only trigger a focus if we re-create them
     local hadSideBuffers = true
@@ -197,7 +197,7 @@ function N.enable(scope)
                     return
                 end
 
-                S.refreshVSplits(S, p.event)
+                S.scanLayout(S, p.event)
 
                 if not vim.api.nvim_win_is_valid(S.getSideID(S, "curr")) then
                     if p.event == "BufDelete" and _G.NoNeckPain.config.fallbackOnBufferDelete then
@@ -248,7 +248,7 @@ function N.enable(scope)
                     return D.log(p.event, "skip")
                 end
 
-                S.refreshVSplits(S, p.event)
+                S.scanLayout(S, p.event)
 
                 if S.wantsSides(S) and S.checkSides(S, "and", false) then
                     return D.log(p.event, "no side buffer")

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -96,6 +96,8 @@ function N.init(scope, goToCurr, skipIntegrations)
 
     D.log(scope, "init called on tab %d for current window %d", S.activeTab, S.getSideID(S, "curr"))
 
+    S.refreshVSplits(S, scope)
+
     -- if we do not have side buffers, we must ensure we only trigger a focus if we re-create them
     local hadSideBuffers = true
     if S.checkSides(S, "and", false) then
@@ -132,7 +134,6 @@ function N.enable(scope)
     vim.api.nvim_create_augroup(augroupName, { clear = true })
 
     S.setSideID(S, vim.api.nvim_get_current_win(), "curr")
-    S.refreshVSplits(S, scope)
 
     N.init(scope, true)
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -330,7 +330,7 @@ function N.disable(scope)
     local sides = { left = S.getSideID(S, "left"), right = S.getSideID(S, "right") }
     local currID = S.getSideID(S, "curr")
 
-    if S.refreshTabs(S) == 0 then
+    if S.refreshTabs(S, activeTab) == 0 then
         pcall(vim.api.nvim_del_augroup_by_name, "NoNeckPainVimEnterAutocmd")
 
         D.log(scope, "no more active tabs left, reinitializing state")

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -188,6 +188,13 @@ function N.enable(scope)
                     return
                 end
 
+                if
+                    p.event == "WinEnter"
+                    and (S.isSideTheActiveWin(S, "left") or S.isSideTheActiveWin(S, "right"))
+                then
+                    return D.log(p.event, "skip enter on side")
+                end
+
                 local refresh = S.scanLayout(S, p.event)
 
                 if not vim.api.nvim_win_is_valid(S.getSideID(S, "curr")) then
@@ -241,8 +248,7 @@ function N.enable(scope)
                     p.event = string.format("%s:skipEnteringNoNeckPainBuffer", p.event)
                     if
                         not S.isActiveTabRegistered(S)
-                        or not S.isActiveTabRegistered(S)
-                        or E.skip()
+                        or E.skip(S.getTab(S))
                         or S.getScratchPad(S)
                     then
                         return D.log(p.event, "skip")

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -248,7 +248,7 @@ function N.enable(scope)
                     return D.log(p.event, "skip")
                 end
 
-                S.refreshVSplits(S, scope)
+                S.refreshVSplits(S, p.event)
 
                 if S.wantsSides(S) and S.checkSides(S, "and", false) then
                     return D.log(p.event, "no side buffer")

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -166,19 +166,14 @@ function N.enable(scope)
         desc = "Resizes side windows after terminal has been resized, closes them if not enough space left.",
     })
 
-    vim.api.nvim_create_autocmd({ "TabLeave", "TabEnter" }, {
+    vim.api.nvim_create_autocmd({ "TabEnter" }, {
         callback = function(p)
             A.debounce(p.event, function()
-                if p.event == "TabLeave" then
-                    S.refreshTabs(S)
-                    D.log(p.event, "tab %d left", S.activeTab)
+                D.log(p.event, "tab %d entered", S.activeTab)
 
-                    return
-                end
+                S.refreshTabs(S, p.event)
 
                 S.setActiveTab(S, A.getCurrentTab())
-
-                D.log(p.event, "tab %d entered", S.activeTab)
             end)
         end,
         group = augroupName,
@@ -358,7 +353,7 @@ function N.disable(scope)
     local sides = { left = S.getSideID(S, "left"), right = S.getSideID(S, "right") }
     local currID = S.getSideID(S, "curr")
 
-    if S.refreshTabs(S, activeTab) == 0 then
+    if S.refreshTabs(S, scope, activeTab) == 0 then
         pcall(vim.api.nvim_del_augroup_by_name, "NoNeckPainVimEnterAutocmd")
 
         D.log(scope, "no more active tabs left, reinitializing state")

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -163,9 +163,7 @@ function N.enable(scope)
     vim.api.nvim_create_autocmd({ "TabLeave" }, {
         callback = function(p)
             vim.schedule(function()
-                if
-                    S.isActiveTabRegistered(S) and not vim.api.nvim_tabpage_is_valid(S.activeTab)
-                then
+                if not vim.api.nvim_tabpage_is_valid(S.activeTab) then
                     S.refreshTabs(S, S.activeTab)
                     D.log(p.event, "tab %d is now inactive", S.activeTab)
                 else

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -182,8 +182,6 @@ end
 ---@return table: the wins that are not in `tab`.
 ---@private
 function State:getUnregisteredWins(withCurr)
-
-
     return vim.tbl_filter(function(win)
         if A.isRelativeWindow(win) then
             return false
@@ -279,7 +277,9 @@ end
 ---@return boolean
 ---@private
 function State:isActiveTabRegistered()
-    return self.hasTabs(self) and self.tabs[self.activeTab] ~= nil and vim.api.nvim_tabpage_is_valid(self.activeTab)
+    return self.hasTabs(self)
+        and self.tabs[self.activeTab] ~= nil
+        and vim.api.nvim_tabpage_is_valid(self.activeTab)
 end
 
 ---Whether the side window is registered and enabled in the config or not.

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -493,13 +493,9 @@ end
 ---@param hasColParent boolean: whether or not the previous walked tree was a column.
 ---@private
 function State:walkLayout(scope, tree, hasColParent)
-    -- if col -- represents a vertical association of window, e.g. { { "leaf", int }, { "col", { ... } }, { "row", { ...} } }
-    --  - count every top level leaf only members
-    --  - any other entities are skipped because they will be walked in later
-    -- if row -- represents an horizontal association of window, e.g  { { "leaf", int }, { "col", { ... } }, { "row", { ...} } }
-    --  - count every top level leaf only members
-    --  - any other entities are skipped because they will be walked in later
-    -- if leaf -- represents a window, e.g. { "leaf", int }
+    -- col -- represents a vertical association of window, e.g. { { "leaf", int }, { "col", { ... } }, { "row", { ...} } }
+    -- row -- represents an horizontal association of window, e.g  { { "leaf", int }, { "col", { ... } }, { "row", { ...} } }
+    -- leaf -- represents a window, e.g. { "leaf", int }
 
     if tree == nil then
         return

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -466,9 +466,8 @@ function State:setLayoutWindows(scope, wins)
 
                 self.tabs[self.activeTab].redraw = true
                 self.tabs[self.activeTab].wins.integrations[name] = integration
-            else
-                self.tabs[self.activeTab].wins.columns = self.tabs[self.activeTab].wins.columns + 1
             end
+            self.tabs[self.activeTab].wins.columns = self.tabs[self.activeTab].wins.columns + 1
         elseif win[1] == "col" then
             self.tabs[self.activeTab].wins.columns = self.tabs[self.activeTab].wins.columns + 1
         end
@@ -528,6 +527,7 @@ function State:scanLayout(scope)
     -- basically when opening vim with nnp autocmds, nothing else than a curr window
     if layout[1] == "leaf" then
         self.setLayoutWindows(self, scope, { layout })
+    -- when a helper or vsplit takes most of the width
     elseif layout[1] == "col" and vim.tbl_count(layout) == 2 then
         self.walkLayout(self, scope, layout[2], false)
     else

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -74,7 +74,7 @@ end
 
 ---Iterates over the tabs in the state to remove invalid tabs.
 ---
----@param skipID number: the ID to skip from potentially valid tabs.
+---@param skipID number?: the ID to skip from potentially valid tabs.
 ---@return number: the total `tabs` in the state.
 ---@private
 function State:refreshTabs(skipID)

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -550,7 +550,7 @@ function State:scanLayout(scope)
         self.getColumns(self)
     )
 
-    return true
+    return columns ~= self.getColumns(self)
 end
 
 return State

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -515,25 +515,22 @@ function State:insertVSplits(vsplits)
     end
 end
 
----Recursively walks in the `winlayout` until it has computed every column present in the UI.
+---Recursively walks in the `winlayout` until it has computed every column present.
 ---
----When we find a `row`, we set `vsplit` to true, the next element will always be a `table` so once on it -we can increase the `vsplits` counter.
----
----In order to also compute nested vsplits, we need to keep track how deep we are in the layout, we remove
----that depth from the number of elements in the current `row` in order to avoid counting all parents many times.
+---Finding a parentless leaf means we are at the basic nvim just opened level
+---Finding any other string than a leaf result on a parent (row or col)
+---Finding a group of type table means we have a set of childrens windows
+---  When we are on a children of a row, we insert all of them in our vsplit states and reset the parent
 ---
 ---@private
 function State:walkLayout(parent, curr)
     for _, group in ipairs(curr) do
         if type(group) == "table" then
-            -- a row indicates a `vsplit` window container
             if parent == "row" then
-                -- we remove the depth from the len in order to avoid counting parents multiple times.
                 self.insertVSplits(self, group)
                 parent = nil
             end
             self.walkLayout(self, parent, group)
-        -- depth 0 on a leaf is only possible after enabling nnp as there's nothing in the layout other than the main window
         elseif group == "leaf" and parent == nil then
             self.insertVSplits(self, { curr })
         elseif type(group) == "string" then
@@ -542,7 +539,7 @@ function State:walkLayout(parent, curr)
     end
 end
 
----Refresh vsplits state based on the `winlayout`.
+---Refreshes the vsplit states by analyzing the winlayout.
 ---
 ---@param scope string: the caller of the method.
 ---@return boolean: whether the number of vsplits changed or not.

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -56,10 +56,9 @@ end
 ---Gets the tab vsplits counter.
 ---
 ---@return table: the vsplits window IDs.
----@return number: the number of vsplits.
 ---@private
 function State:getVSplits()
-    return self.tabs[self.activeTab].wins.vsplits, A.length(self.tabs[self.activeTab].wins.vsplits)
+    return self.tabs[self.activeTab].wins.vsplits
 end
 
 ---Whether the side is enabled in the config or not.
@@ -525,19 +524,18 @@ end
 ---@return boolean: whether the number of vsplits changed or not.
 ---@private
 function State:scanLayout(scope)
-    local _, nbVSplits = self.getVSplits(self)
+    local vsplits = self.getVSplits(self)
 
     self.initVSplits(self)
     self.initIntegrations(self)
     self.walkLayout(self, scope, nil, vim.fn.winlayout(self.activeTab))
     self.save(self)
 
-    local vsplits, nbNBVsplits = self.getVSplits(self)
+    local newVSplits = self.getVSplits(self)
 
-    D.log(scope, "computed vsplits: %s", vim.inspect(vsplits))
+    D.log(scope, "computed vsplits: %s - %s", vim.inspect(vsplits), vim.inspect(newVSplits))
 
-    -- TODO: real table diff
-    return nbVSplits ~= nbNBVsplits
+    return not vim.deep_equal(vsplits, newVSplits)
 end
 
 return State

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -74,10 +74,15 @@ end
 
 ---Iterates over the tabs in the state to remove invalid tabs.
 ---
+---@param skipID number: the ID to skip from potentially valid tabs.
 ---@return number: the total `tabs` in the state.
 ---@private
-function State:refreshTabs()
+function State:refreshTabs(skipID)
     local refreshedTabs = vim.tbl_filter(function(tab)
+        if skipID ~= nil and tab.id == skipID then
+            return false
+        end
+
         return vim.api.nvim_tabpage_is_valid(tab.id)
     end, self.tabs)
 

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -543,7 +543,13 @@ function State:scanLayout(scope)
     end
     self.save(self)
 
-    D.log(scope, "computed columns: %d - %d", columns, self.getColumns(self))
+    D.log(
+        scope,
+        "[tab %d] computed columns: %d - %d",
+        self.activeTab,
+        columns,
+        self.getColumns(self)
+    )
 
     return true
 end

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -538,8 +538,10 @@ function State:scanLayout(scope)
     -- basically when opening vim with nnp autocmds, nothing else than a curr window
     if layout[1] == "leaf" then
         self.setLayoutWindows(self, scope, { layout })
+    elseif layout[1] == "col" and vim.tbl_count(layout) == 2 then
+        self.walkLayout(self, scope, layout[2], false)
     else
-        self.walkLayout(self, scope, vim.fn.winlayout(self.activeTab), false)
+        self.walkLayout(self, scope, layout, false)
     end
     self.save(self)
 

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -182,6 +182,8 @@ end
 ---@return table: the wins that are not in `tab`.
 ---@private
 function State:getUnregisteredWins(withCurr)
+
+
     return vim.tbl_filter(function(win)
         if A.isRelativeWindow(win) then
             return false
@@ -272,20 +274,12 @@ function State:scanIntegrations(scope)
     return unregisteredIntegrations
 end
 
----Whether the `activeTab` is valid or not.
----
----@return boolean
----@private
-function State:isActiveTabValid()
-    return self.isActiveTabRegistered(self) and vim.api.nvim_tabpage_is_valid(self.activeTab)
-end
-
----Whether the `activeTab` is registered in the state or not.
+---Whether the `activeTab` is registered in the state and valid.
 ---
 ---@return boolean
 ---@private
 function State:isActiveTabRegistered()
-    return self.hasTabs(self) and self.tabs[self.activeTab] ~= nil
+    return self.hasTabs(self) and self.tabs[self.activeTab] ~= nil and vim.api.nvim_tabpage_is_valid(self.activeTab)
 end
 
 ---Whether the side window is registered and enabled in the config or not.

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -464,8 +464,8 @@ function State:setLayoutWindows(scope, wins)
                 integration.width = vim.api.nvim_win_get_width(id) * 2
                 integration.id = id
 
-                self.tabs[self.activeTab].wins.integrations[name] = integration
                 self.tabs[self.activeTab].redraw = true
+                self.tabs[self.activeTab].wins.integrations[name] = integration
             else
                 self.tabs[self.activeTab].wins.columns = self.tabs[self.activeTab].wins.columns + 1
             end
@@ -473,13 +473,6 @@ function State:setLayoutWindows(scope, wins)
             self.tabs[self.activeTab].wins.columns = self.tabs[self.activeTab].wins.columns + 1
         end
     end
-
-    D.log(
-        scope,
-        "increased to %d after %s",
-        self.tabs[self.activeTab].wins.columns,
-        vim.inspect(wins)
-    )
 end
 
 ---Recursively walks in the `winlayout` until it has computed every column present.
@@ -501,7 +494,7 @@ function State:walkLayout(scope, tree, hasColParent)
         return
     end
 
-    D.log(scope, "new layer entered%s: %s", hasColParent and " from col" or "", vim.inspect(tree))
+    -- D.log(scope, "new layer entered%s: %s", hasColParent and " from col" or "", vim.inspect(tree))
     for idx, leaf in ipairs(tree) do
         if leaf == "row" then
             local leafs = tree[idx + 1]

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -34,25 +34,32 @@ function State:save()
     _G.NoNeckPain.state = self
 end
 
+---Gets the first valid window in the current tab.
+---
+---@return number?: the number of vsplits.
+---@private
+function State:getFirstValidVSplit()
+    for win, _ in pairs(self.tabs[self.activeTab].wins.vsplits) do
+        if
+            win ~= self.getSideID(self, "left")
+            and win ~= self.getSideID(self, "right")
+            and win ~= self.getSideID(self, "curr")
+            and vim.api.nvim_win_is_valid(win)
+        then
+            return win
+        end
+    end
+
+    return nil
+end
+
 ---Gets the tab vsplits counter.
 ---
----@param filterMain boolean?: whether we should remove main windows or not.
 ---@return table: the vsplits window IDs.
 ---@return number: the number of vsplits.
 ---@private
-function State:getVSplits(filterMain)
-    if not filterMain then
-        return self.tabs[self.activeTab].wins.vsplits,
-            A.length(self.tabs[self.activeTab].wins.vsplits)
-    end
-
-    local filtered = vim.tbl_filter(function(vsplit)
-        return vsplit == self.getSideID(self, "left")
-            or vsplit == self.getSideID(self, "right")
-            or vsplit == self.getSideID(self, "curr")
-    end, self.tabs[self.activeTab].wins.vsplits)
-
-    return filtered, A.length(filtered)
+function State:getVSplits()
+    return self.tabs[self.activeTab].wins.vsplits, A.length(self.tabs[self.activeTab].wins.vsplits)
 end
 
 ---Whether the side is enabled in the config or not.

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -220,19 +220,6 @@ function State:isSupportedIntegration(scope, win)
         return true, integrationName, integrationInfo
     end
 
-    if fileType == "" and tab ~= nil then
-        local wins = self.getUnregisteredWins(self)
-
-        D.log(scope, "computing recursively")
-        if #wins ~= 1 or wins[1] == win then
-            D.log(scope, "too many windows to determine")
-
-            return false, nil, nil
-        end
-
-        return self.isSupportedIntegration(self, scope, wins[1])
-    end
-
     local registeredIntegrations = tab ~= nil and tab.wins.integrations or Co.INTEGRATIONS
 
     for name, integration in pairs(registeredIntegrations) do

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -23,22 +23,6 @@ function A.getAugroupName(id)
     return string.format("NoNeckPain-%d", id)
 end
 
----returns the width and height of a given window
----
----@param win number?: the win number, defaults to 0 if nil
----@return number: the width of the window
----@return number: the height of the window
----@private
-function A.getWidthAndHeight(win)
-    win = win or 0
-
-    if win ~= 0 and not vim.api.nvim_win_is_valid(win) then
-        win = 0
-    end
-
-    return vim.api.nvim_win_get_width(win), vim.api.nvim_win_get_height(win)
-end
-
 ---Determines if the given `win` or the current window is relative.
 ---
 ---@param win number?: the id of the window.
@@ -127,6 +111,7 @@ function A.debounce(context, callback, timeout)
 
         debouncer.executing = true
         vim.schedule(function()
+            D.log(context, ">> debouncer triggered")
             callback(context)
             debouncer.executing = false
 

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -10,19 +10,6 @@ function A.getCurrentTab()
     return vim.api.nvim_get_current_tabpage() or 1
 end
 
----Returns the number of keys in the given table
----
----@param tbl table: the table to count the keys.
----@return number: the number of keys in the table.
----@private
-function A.length(tbl)
-    local count = 0
-    for _ in pairs(tbl) do
-        count = count + 1
-    end
-    return count
-end
-
 function A.tde(t1, t2)
     return vim.deepcopy(vim.tbl_deep_extend("keep", t1 or {}, t2 or {}))
 end

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -6,13 +6,11 @@ local E = {}
 
 ---skips the event if:
 --- - the plugin is not enabled
---- - we have splits open (when `skipSplit` is `true`)
---- - we are focusing a floating window
---- - we are focusing one of the side buffer
+--- - the current window is a relative window
+--- - the event is triggered in a different tab
 ---
----@param tab table?: the table where the tab information are stored.
 ---@private
-function E.skip(tab)
+function E.skip()
     if _G.NoNeckPain.state == nil or not _G.NoNeckPain.state.enabled then
         return true
     end
@@ -21,7 +19,7 @@ function E.skip(tab)
         return true
     end
 
-    return tab ~= nil and A.getCurrentTab() ~= tab.id
+    return A.getCurrentTab() ~= S.activeTab
 end
 
 --- determines if we should skip the enabling of the plugin:

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -21,17 +21,7 @@ function E.skip(tab)
         return true
     end
 
-    if tab ~= nil then
-        if A.getCurrentTab() ~= tab.id then
-            return true
-        end
-
-        if S.isSideTheActiveWin(S, "left") or S.isSideTheActiveWin(S, "right") then
-            return true
-        end
-    end
-
-    return false
+    return tab ~= nil and A.getCurrentTab() ~= tab.id
 end
 
 --- determines if we should skip the enabling of the plugin:

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -10,7 +10,7 @@ local W = {}
 ---
 ---@param id number: the id of the window.
 ---@param width number: the width to apply to the window.
----@param side "left"|"right"|"split": the side of the window being resized, used for logging only.
+---@param side "left"|"right"|"curr": the side of the window being resized, used for logging only.
 ---@private
 local function resize(id, width, side)
     D.log(side, "resizing %d with padding %d", id, width)
@@ -21,7 +21,7 @@ local function resize(id, width, side)
 end
 
 ---Initializes the given `side` with the options from the user given configuration.
----@param side "left"|"right"|"split": the side of the window to initialize.
+---@param side "left"|"right"|"curr": the side of the window to initialize.
 ---@param id number: the id of the window.
 ---@private
 function W.initSideOptions(side, id)
@@ -177,30 +177,6 @@ function W.createSideBuffers(skipIntegrations)
         end
     end
 
-    -- if we still have side buffers open at this point, and we have vsplit opened,
-    -- there might be width issues so we the resize opened vsplits.
-    if S.checkSides(S, "or", true) and S.hasSplits(S) then
-        local side = S.getSideID(S, "left") or S.getSideID(S, "right")
-        local sWidth, _ = A.getWidthAndHeight(side)
-        local nbSide = 1
-
-        if S.getSideID(S, "left") and S.getSideID(S, "right") then
-            nbSide = 2
-        end
-
-        local tab = S.getTab(S)
-
-        -- get the available usable width (screen size without side paddings)
-        sWidth = vim.api.nvim_list_uis()[1].width - sWidth * nbSide
-        sWidth = math.floor(sWidth / tab.layers.vsplit)
-
-        for _, split in pairs(tab.wins.splits) do
-            if split.vertical then
-                resize(split.id, sWidth, "split")
-            end
-        end
-    end
-
     -- closing integrations and reopening them means new window IDs
     if closedIntegrations then
         S.refreshIntegrations(S, "createSideBuffers")
@@ -213,10 +189,11 @@ end
 ---@return number: the width of the side window.
 ---@private
 function W.getPadding(side)
+    local scope = string.format("W.getPadding:%s", side)
     local uis = vim.api.nvim_list_uis()
 
     if uis[1] == nil then
-        error("W.getPadding - attempted to get the padding of a non-existing UI.")
+        error("attempted to get the padding of a non-existing UI.")
 
         return 0
     end
@@ -226,55 +203,59 @@ function W.getPadding(side)
     -- if the available screen size is lower than the config width,
     -- we don't have to create side buffers.
     if _G.NoNeckPain.config.width >= width then
-        D.log("W.getPadding", "[%s] - ui %s - no space left to create side buffers", side, width)
+        D.log(scope, "[%s] - ui %s - no space left to create side buffers", side, width)
 
         return 0
     end
 
-    local tab = S.getTab(S)
+    local columns = S.getVSplits(S)
+
+    for _, s in ipairs(Co.SIDES) do
+        if S.isSideEnabled(S, s) then
+            columns = columns - 1
+        end
+    end
+
+    if columns < 1 then
+        columns = 1
+    end
 
     -- we need to see if there's enough space left to have side buffers
-    local occupied = _G.NoNeckPain.config.width * tab.layers.vsplit
+    local occupied = _G.NoNeckPain.config.width * columns
+
+    D.log(scope, "have %d vsplits", columns)
 
     -- if there's no space left according to the config width,
     -- then we don't have to create side buffers.
     if occupied >= width then
-        D.log(side, "%d vsplits - no space left to create side buffers", tab.layers.vsplit)
+        D.log(scope, "%d occupied - no space left to create side", occupied)
 
         return 0
     end
 
-    D.log(
-        side,
-        "%d currently with %d vsplits - computing integrations width",
-        occupied,
-        tab.layers.vsplit
-    )
+    D.log(scope, "%d/%d with vsplits, computing integrations", occupied, width)
 
     -- now we need to determine how much we should substract from the remaining padding
     -- if there's side integrations open.
-    local paddingToSubstract = 0
-
-    for name, tree in pairs(tab.wins.integrations) do
+    for name, tree in pairs(S.getIntegrations(S)) do
         if
             tree.id ~= nil
-            and (not S.wantsSides(S) or side == _G.NoNeckPain.config.integrations[name].position)
-        then
-            D.log(
-                "W.getPadding",
-                "[%s] - have an external open: %s with width %d",
-                side,
-                name,
-                tree.width
+            and (
+                not S.isSideWinValid(S, side)
+                or side == _G.NoNeckPain.config.integrations[name].position
             )
+        then
+            D.log(scope, "%s opened with width %d", name, tree.width)
 
-            paddingToSubstract = paddingToSubstract + tree.width
+            occupied = occupied + tree.width
         end
     end
 
-    return math.floor(
-        (width - paddingToSubstract - (_G.NoNeckPain.config.width * tab.layers.vsplit)) / 2
-    )
+    local final = math.floor((width - occupied) / 2)
+
+    D.log(scope, "%d/%d with integrations - final %d", occupied, width, final)
+
+    return final
 end
 
 ---Determine if the tab wins are still active and valid.

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -44,28 +44,13 @@ end
 ---@param side "left"|"right": the side of the window being closed, used for logging only.
 ---@private
 function W.move(scope, side)
-    local id = S.getSideID(S, side)
-    if id == nil then
-        return
+    if side == "left" then
+        vim.api.nvim_input("<C-W>H")
+    else
+        vim.api.nvim_input("<C-W>l")
     end
 
-    if vim.api.nvim_win_is_valid(id) then
-        local wins = vim.api.nvim_tabpage_list_wins(S.activeTab)
-
-        if side == "left" then
-            if wins[1] == id then
-                return
-            end
-            vim.fn.win_splitmove(id, wins[1], { vertical = true })
-        else
-            if wins[#wins] == id then
-                return
-            end
-            vim.fn.win_splitmove(id, wins[#wins], { vertical = true })
-        end
-
-        D.log(scope, "moving %s window", side)
-    end
+    D.log(scope, "moving %s window", side)
 end
 
 ---Closes a window if it's valid.
@@ -215,9 +200,9 @@ function W.createSideBuffers()
             nbSide
         )
 
-        for _, win in pairs(S.getUnregisteredWins(S)) do
-            resize(win, sWidth, string.format("unregistered:%d", win))
-        end
+        -- for _, win in pairs(S.getUnregisteredWins(S)) do
+        --     resize(win, sWidth, string.format("unregistered:%d", win))
+        -- end
     end
 end
 

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -107,9 +107,6 @@ end
 ---@param skipIntegrations boolean?: skip integrations action when true.
 ---@private
 function W.createSideBuffers(skipIntegrations)
-    -- before creating side buffers, we determine if we should consider externals
-    S.scanLayout(S, "createSideBuffers")
-
     local wins = {
         left = { cmd = "topleft vnew", padding = 0 },
         right = { cmd = "botright vnew", padding = 0 },
@@ -164,6 +161,19 @@ function W.createSideBuffers(skipIntegrations)
         S.reopenIntegration(S)
     end
 
+    for _, side in pairs(Co.SIDES) do
+        if S.isSideRegistered(S, side) then
+            local padding = wins[side].padding or W.getPadding(side)
+
+            if padding > _G.NoNeckPain.config.minSideBufferWidth then
+                resize(S.getSideID(S, side), padding, side)
+            else
+                W.close("W.createSideBuffers", S.getSideID(S, side), side)
+                S.setSideID(S, nil, side)
+            end
+        end
+    end
+
     local vsplits, nbVSplits = S.getVSplits(S)
     local leftID = S.getSideID(S, "left")
     local rightID = S.getSideID(S, "right")
@@ -187,18 +197,6 @@ function W.createSideBuffers(skipIntegrations)
         resize(S.getSideID(S, "curr"), _G.NoNeckPain.config.width, "curr")
     end
 
-    for _, side in pairs(Co.SIDES) do
-        if S.isSideRegistered(S, side) then
-            local padding = wins[side].padding or W.getPadding(side)
-
-            if padding > _G.NoNeckPain.config.minSideBufferWidth then
-                resize(S.getSideID(S, side), padding, side)
-            else
-                W.close("W.createSideBuffers", S.getSideID(S, side), side)
-                S.setSideID(S, nil, side)
-            end
-        end
-    end
 
     -- closing integrations and reopening them means new window IDs
     if closedIntegrations then

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -28,11 +28,9 @@ function W.initSideOptions(side, id)
     local bufid = vim.api.nvim_win_get_buf(id)
 
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
-        if S.getScratchPad(S) and opt == "filetype" then
-            goto continue
+        if not S.getScratchPad(S) and opt == "filetype" then
+            A.setBufferOption(bufid, opt, val)
         end
-        A.setBufferOption(bufid, opt, val)
-        ::continue::
     end
 
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].wo) do

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -28,7 +28,7 @@ function W.initSideOptions(side, id)
     local bufid = vim.api.nvim_win_get_buf(id)
 
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
-        if not S.getScratchPad(S) and opt == "filetype" then
+        if not S.getScratchPad(S) and opt ~= "filetype" then
             A.setBufferOption(bufid, opt, val)
         end
     end
@@ -187,7 +187,7 @@ function W.createSideBuffers(skipIntegrations)
         sWidth = math.floor(sWidth / (nbVSplits - nbSide))
 
         for vsplit, _ in pairs(vsplits) do
-            if vsplit ~= leftID and vsplit ~= rightID and vsplit ~= S.getSideID(S, "curr") then
+            if vsplit ~= leftID and vsplit ~= rightID then
                 resize(vsplit, sWidth, string.format("vsplit:%s", vsplit))
             end
         end

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -197,7 +197,6 @@ function W.createSideBuffers(skipIntegrations)
         resize(S.getSideID(S, "curr"), _G.NoNeckPain.config.width, "curr")
     end
 
-
     -- closing integrations and reopening them means new window IDs
     if closedIntegrations then
         S.scanLayout(S, "createSideBuffers")

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -258,39 +258,4 @@ function W.getPadding(side)
     return final
 end
 
----Determine if the tab wins are still active and valid.
----
----@param checkSplits boolean: whether splits state should be considered or not.
----@return boolean: whether all windows are active and valid or not.
----@private
-function W.stateWinsActive(checkSplits)
-    if not S.isActiveTabValid(S) then
-        return false
-    end
-
-    local tab = S.getTabSafe(S)
-
-    if tab == nil then
-        return false
-    end
-
-    if tab.wins.main ~= nil then
-        for _, side in pairs(tab.wins.main) do
-            if not vim.api.nvim_win_is_valid(side) then
-                return false
-            end
-        end
-    end
-
-    if checkSplits and tab.wins.splits ~= nil then
-        for _, split in pairs(tab.wins.splits) do
-            if not vim.api.nvim_win_is_valid(split.id) then
-                return false
-            end
-        end
-    end
-
-    return true
-end
-
 return W

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -166,20 +166,19 @@ function W.createSideBuffers(skipIntegrations)
         end
     end
 
-    local vsplits = S.getVSplits(S)
-    local nbVSplits = vim.tbl_count(vsplits)
+    local columns = S.getColumns(S)
     local leftID = S.getSideID(S, "left")
     local rightID = S.getSideID(S, "right")
 
     -- if we still have side buffers open at this point, and we have vsplit opened,
     -- there might be width issues so we the resize opened vsplits.
-    if (leftID or rightID) and nbVSplits > 1 then
+    if (leftID or rightID) and columns > 1 then
         local sWidth = wins.left.padding or wins.right.padding
         local nbSide = leftID and rightID and 2 or 1
 
         -- get the available usable width (screen size without side paddings)
         sWidth = vim.o.columns - sWidth * nbSide
-        local remainingVSplits = nbVSplits - nbSide
+        local remainingVSplits = columns - nbSide
 
         if remainingVSplits < 1 then
             remainingVSplits = 1
@@ -189,18 +188,18 @@ function W.createSideBuffers(skipIntegrations)
 
         D.log(
             "splitResize",
-            "%d/%d screen width remaining, %d vsplits including %d sides",
+            "%d/%d screen width remaining, %d columns including %d sides",
             sWidth,
             vim.o.columns,
-            nbVSplits,
+            columns,
             nbSide
         )
 
-        for vsplit, _ in pairs(vsplits) do
-            if vsplit ~= leftID and vsplit ~= rightID then
-                resize(vsplit, sWidth, string.format("vsplit:%s", vsplit))
-            end
-        end
+        -- for vsplit, _ in pairs(vsplits) do
+        -- if vsplit ~= leftID and vsplit ~= rightID then
+        --     -- resize(vsplit, sWidth, string.format("vsplit:%s", vsplit))
+        -- end
+        -- end
     end
 
     -- closing integrations and reopening them means new window IDs
@@ -224,7 +223,7 @@ function W.getPadding(side)
         return 0
     end
 
-    local columns = vim.tbl_count(S.getVSplits(S))
+    local columns = S.getColumns(S)
 
     for _, s in ipairs(Co.SIDES) do
         if S.isSideWinValid(S, s) and columns > 1 then
@@ -235,7 +234,7 @@ function W.getPadding(side)
     -- we need to see if there's enough space left to have side buffers
     local occupied = _G.NoNeckPain.config.width * columns
 
-    D.log(scope, "have %d vsplits", columns)
+    D.log(scope, "have %d columns", columns)
 
     -- if there's no space left according to the config width,
     -- then we don't have to create side buffers.
@@ -245,7 +244,7 @@ function W.getPadding(side)
         return 0
     end
 
-    D.log(scope, "%d/%d with vsplits, computing integrations", occupied, vim.o.columns)
+    D.log(scope, "%d/%d with columns, computing integrations", occupied, vim.o.columns)
 
     -- now we need to determine how much we should substract from the remaining padding
     -- if there's side integrations open.

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -183,7 +183,7 @@ function W.createSideBuffers(skipIntegrations)
         local nbSide = leftID and rightID and 2 or 1
 
         -- get the available usable width (screen size without side paddings)
-        sWidth = vim.api.nvim_list_uis()[1].width - sWidth * nbSide
+        sWidth = vim.o.columns - sWidth * nbSide
         sWidth = math.floor(sWidth / (nbVSplits - nbSide))
 
         for vsplit, _ in pairs(vsplits) do

--- a/scripts/init_with_aerial.lua
+++ b/scripts/init_with_aerial.lua
@@ -7,6 +7,7 @@ vim.cmd("set rtp+=deps/aerial")
 
 require("mini.test").setup()
 require("no-neck-pain").setup({
+    debug=true,
     width = 20,
     minSideBufferWidth = 0,
     integrations = { aerial = { reopen = true } },

--- a/scripts/init_with_neotree.lua
+++ b/scripts/init_with_neotree.lua
@@ -19,8 +19,7 @@ require("neo-tree").setup({
 })
 require("mini.test").setup()
 require("no-neck-pain").setup({
-    debug = true,
-    width = 30,
+    width = 5,
     minSideBufferWidth = 0,
     integrations = { NeoTree = { reopen = true } },
 })

--- a/scripts/init_with_neotree.lua
+++ b/scripts/init_with_neotree.lua
@@ -14,12 +14,13 @@ require("neo-tree").setup({
         },
     },
     window = {
-        width = 1,
+        width = 30,
     },
 })
 require("mini.test").setup()
 require("no-neck-pain").setup({
-    width = 1,
+    debug = true,
+    width = 30,
     minSideBufferWidth = 0,
     integrations = { NeoTree = { reopen = true } },
 })

--- a/scripts/init_with_nvimdapui.lua
+++ b/scripts/init_with_nvimdapui.lua
@@ -8,6 +8,7 @@ vim.cmd("set rtp+=deps/nvimdapui")
 require("dapui").setup()
 require("mini.test").setup()
 require("no-neck-pain").setup({
+    debug = true,
     width = 1,
     minSideBufferWidth = 0,
     integrations = { NvimDAPUI = { reopen = true } },

--- a/scripts/init_with_tsplayground.lua
+++ b/scripts/init_with_tsplayground.lua
@@ -10,4 +10,4 @@ require("nvim-treesitter.configs").setup({
     },
 })
 require("mini.test").setup()
-require("no-neck-pain").setup({ width = 1 })
+require("no-neck-pain").setup({ debug=true, width = 1 })

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -2,5 +2,6 @@ vim.cmd([[let &rtp.=','.getcwd()]])
 
 vim.cmd("set rtp+=deps/mini.nvim")
 
+-- require('no-neck-pain').setup({width=50})
 require("mini.test").setup()
 require("mini.doc").setup()

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -2,6 +2,5 @@ vim.cmd([[let &rtp.=','.getcwd()]])
 
 vim.cmd("set rtp+=deps/mini.nvim")
 
--- require('no-neck-pain').setup({width=50})
 require("mini.test").setup()
 require("mini.doc").setup()

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -6,11 +6,7 @@ Helpers.expect = vim.deepcopy(MiniTest.expect)
 
 function Helpers.toggle(child)
     child.cmd("NoNeckPain")
-    Helpers.wait(child)
-end
-
-function Helpers.wait(child)
-    child.loop.sleep(10)
+    child.wait()
 end
 
 function Helpers.currentWin(child)
@@ -106,6 +102,10 @@ Helpers.new_child_neovim = function()
         local msg =
             string.format("Can not use `child.%s` because child process is blocked.", method)
         error(msg)
+    end
+
+    child.wait = function()
+        child.loop.sleep(10)
     end
 
     child.setup = function()

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -242,7 +242,7 @@ T["enable"]["(single tab) sets state"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.vsplits[1000]", true)
+    Helpers.expect.state(child, "tabs[1].wins.columns", 1)
 
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
@@ -270,7 +270,7 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.state(child, "tabs[1].wins.vsplits[1000]", true)
+    Helpers.expect.state(child, "tabs[1].wins.columns", 1)
 
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
@@ -294,9 +294,7 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1004,
         right = 1005,
     })
-    Helpers.expect.state(child, "tabs[2].wins.vsplits[1003]", true)
-    Helpers.expect.state(child, "tabs[2].wins.vsplits[1004]", true)
-    Helpers.expect.state(child, "tabs[2].wins.vsplits[1005]", true)
+    Helpers.expect.state(child, "tabs[2].wins.columns", 3)
 
     Helpers.expect.state_type(child, "tabs[2].wins.integrations", "table")
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -216,8 +216,6 @@ T["setup"]["starts the plugin on VimEnter"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "enabled", true)
-
-    child.stop()
 end
 
 T["enable"] = MiniTest.new_set()
@@ -364,7 +362,6 @@ T["disable"]["(multiple tab) resets state"] = function()
 end
 
 T["disable"]["(no file) does not close the window if unsaved buffer"] = function()
-    child.set_size(500, 500)
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
     Helpers.toggle(child)
 
@@ -388,7 +385,6 @@ T["disable"]["(no file) does not close the window if unsaved buffer"] = function
 end
 
 T["disable"]["(on file) does not close the window if unsaved buffer"] = function()
-    child.set_size(500, 500)
     child.restart({ "-u", "scripts/minimal_init.lua", "lua/no-neck-pain/main.lua" })
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
     Helpers.toggle(child)
@@ -419,7 +415,6 @@ T["disable"]["relative window doesn't prevent quitting nvim"] = function()
         return
     end
 
-    child.set_size(500, 500)
     child.restart({ "-u", "scripts/init_with_incline.lua" })
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
     Helpers.toggle(child)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -244,7 +244,7 @@ T["enable"]["(single tab) sets state"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
 
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
@@ -272,7 +272,7 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
 
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
@@ -296,7 +296,7 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1004,
         right = 1005,
     })
-    Helpers.expect.state(child, "tabs[2].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[2].wins.vsplits", 3)
 
     Helpers.expect.state_type(child, "tabs[2].wins.integrations", "table")
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -320,7 +320,7 @@ T["disable"]["(single tab) resets state"] = function()
     Helpers.expect.state(child, "enabled", false)
     Helpers.expect.state(child, "activeTab", 1)
 
-    Helpers.expect.state(child, "tabs", vim.NIL)
+    Helpers.expect.state(child, "tabs", {})
 end
 
 T["disable"]["(multiple tab) resets state"] = function()
@@ -358,7 +358,7 @@ T["disable"]["(multiple tab) resets state"] = function()
     Helpers.expect.state(child, "enabled", false)
     Helpers.expect.state(child, "activeTab", 1)
 
-    Helpers.expect.state(child, "tabs", vim.NIL)
+    Helpers.expect.state(child, "tabs", {})
 end
 
 T["disable"]["(no file) does not close the window if unsaved buffer"] = function()

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -18,7 +18,7 @@ local T = MiniTest.new_set({
 T["install"] = MiniTest.new_set()
 
 T["install"]["sets global loaded variable"] = function()
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.global(child, "_G.NoNeckPain", vim.NIL)
     Helpers.expect.global_type(child, "_G.NoNeckPainLoaded", "boolean")
 end
@@ -212,7 +212,7 @@ end
 
 T["setup"]["starts the plugin on VimEnter"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "enabled", true)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -294,7 +294,7 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1004,
         right = 1005,
     })
-    Helpers.expect.state(child, "tabs[2].wins.columns", 3)
+    Helpers.expect.state(child, "tabs[2].wins.columns", 1)
 
     Helpers.expect.state_type(child, "tabs[2].wins.integrations", "table")
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -242,7 +242,7 @@ T["enable"]["(single tab) sets state"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.columns", 1)
+    Helpers.expect.state(child, "tabs[1].wins.columns", 3)
 
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
@@ -270,7 +270,7 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.state(child, "tabs[1].wins.columns", 1)
+    Helpers.expect.state(child, "tabs[1].wins.columns", 3)
 
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
@@ -294,7 +294,7 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1004,
         right = 1005,
     })
-    Helpers.expect.state(child, "tabs[2].wins.columns", 1)
+    Helpers.expect.state(child, "tabs[2].wins.columns", 3)
 
     Helpers.expect.state_type(child, "tabs[2].wins.integrations", "table")
 

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -242,7 +242,7 @@ T["enable"]["(single tab) sets state"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits[1000]", true)
 
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
@@ -270,7 +270,7 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits[1000]", true)
 
     Helpers.expect.state_type(child, "tabs[1].wins.integrations", "table")
 
@@ -294,7 +294,9 @@ T["enable"]["(multiple tab) sets state"] = function()
         left = 1004,
         right = 1005,
     })
-    Helpers.expect.state(child, "tabs[2].wins.vsplits", 3)
+    Helpers.expect.state(child, "tabs[2].wins.vsplits[1003]", true)
+    Helpers.expect.state(child, "tabs[2].wins.vsplits[1004]", true)
+    Helpers.expect.state(child, "tabs[2].wins.vsplits[1005]", true)
 
     Helpers.expect.state_type(child, "tabs[2].wins.integrations", "table")
 

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -29,7 +29,7 @@ end
 T["auto command"]["disabling clears VimEnter autocmd"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
     Helpers.toggle(child)
-    Helpers.wait(child)
+    child.wait()
 
     -- errors because it doesn't exist
     Helpers.expect.error(function()
@@ -96,11 +96,11 @@ T["skipEnteringNoNeckPainBuffer"]["goes to new valid buffer when entering side"]
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1001)
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1002)
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.cmd("split")
@@ -109,19 +109,19 @@ T["skipEnteringNoNeckPainBuffer"]["goes to new valid buffer when entering side"]
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
 
     child.fn.win_gotoid(1000)
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1003)
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
 
     child.fn.win_gotoid(1001)
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
 
     child.fn.win_gotoid(1002)
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
 end
 
@@ -139,7 +139,7 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1001)
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1001)
 end
 
@@ -157,7 +157,7 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1001)
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1001)
 end
 
@@ -175,7 +175,7 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1001)
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1001)
 end
 

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -38,7 +38,6 @@ T["auto command"]["disabling clears VimEnter autocmd"] = function()
 end
 
 T["auto command"]["does not shift when opening/closing float window"] = function()
-    child.set_size(5, 200)
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
     Helpers.toggle(child)
 
@@ -86,7 +85,6 @@ end
 T["skipEnteringNoNeckPainBuffer"] = MiniTest.new_set()
 
 T["skipEnteringNoNeckPainBuffer"]["goes to new valid buffer when entering side"] = function()
-    child.set_size(5, 200)
     child.lua(
         [[ require('no-neck-pain').setup({width=50, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]]
     )
@@ -128,7 +126,6 @@ T["skipEnteringNoNeckPainBuffer"]["goes to new valid buffer when entering side"]
 end
 
 T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is enabled (global)"] = function()
-    child.set_size(5, 200)
     child.lua(
         [[ require('no-neck-pain').setup({width=50, buffers = { scratchPad = { enabled = true } }, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]]
     )
@@ -147,7 +144,6 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
 end
 
 T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is enabled (left)"] = function()
-    child.set_size(5, 200)
     child.lua(
         [[ require('no-neck-pain').setup({width=50, buffers = { left = { scratchPad = { enabled = true } } }, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]]
     )
@@ -166,7 +162,6 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
 end
 
 T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is enabled (right)"] = function()
-    child.set_size(5, 200)
     child.lua(
         [[ require('no-neck-pain').setup({width=50, buffers = { right = { scratchPad = { enabled = true } } }, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]]
     )

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -79,7 +79,7 @@ T["auto command"]["does not shift when opening/closing float window"] = function
     })
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 13)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
 end
 
 T["skipEnteringNoNeckPainBuffer"] = MiniTest.new_set()

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -79,7 +79,7 @@ T["auto command"]["does not shift when opening/closing float window"] = function
     })
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 13)
 end
 
 T["skipEnteringNoNeckPainBuffer"] = MiniTest.new_set()

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -37,7 +37,7 @@ T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = fu
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 20)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 end
 
 T["commands"]["NoNeckPainResize throws with the plugin disabled"] = function()

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -33,7 +33,7 @@ T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = fu
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 80)
 
     child.cmd("NoNeckPainResize 20")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 20)
 

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -38,7 +38,7 @@ T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = fu
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 20)
 
     -- need to know why the child isn't precise enough
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
 end
 
 T["commands"]["NoNeckPainResize throws with the plugin disabled"] = function()

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -38,7 +38,7 @@ T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = fu
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 20)
 
     -- need to know why the child isn't precise enough
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 end
 
 T["commands"]["NoNeckPainResize throws with the plugin disabled"] = function()

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -37,8 +37,7 @@ T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = fu
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 20)
 
-    -- need to know why the child isn't precise enough
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 end
 
 T["commands"]["NoNeckPainResize throws with the plugin disabled"] = function()

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -37,7 +37,7 @@ T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = fu
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 20)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
 end
 
 T["commands"]["NoNeckPainResize throws with the plugin disabled"] = function()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -207,7 +207,7 @@ T["outline"]["keeps sides open"] = function()
     child.cmd("Outline")
     vim.loop.sleep(50)
 
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 4)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.outline", {
         close = "Outline",
@@ -251,7 +251,7 @@ T["NvimTree"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 4)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimTree", {
         close = "NvimTreeClose",
@@ -290,7 +290,7 @@ T["neo-tree"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 4)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.NeoTree", {
         close = "Neotree close",
@@ -358,7 +358,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
 
     child.lua([[
         require('no-neck-pain').setup({
-            width = 50,
+            width = 20,
             buffers = {
                 right = {
                     enabled = false,
@@ -376,21 +376,21 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
         left = 1001,
         right = nil,
     })
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
 
     child.cmd("TSPlaygroundToggle")
     vim.loop.sleep(50)
 
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 3)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 142)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1001)"), 15)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 144)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 20)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
         id = 1003,
         open = "TSPlaygroundToggle",
-        width = 284,
+        width = 288,
     })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -413,7 +413,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
         left = 1001,
         right = nil,
     })
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1001)"), 15)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
 end
 
 T["aerial"] = MiniTest.new_set()
@@ -441,7 +441,7 @@ T["aerial"]["keeps sides open"] = function()
 
     child.cmd("AerialToggle")
 
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 4)
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 25)
     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial.id", 1004)

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -126,6 +126,7 @@ T["nvimdapui"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_nvimdapui.lua" })
 
     Helpers.toggle(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -135,10 +136,11 @@ T["nvimdapui"]["keeps sides open"] = function()
     })
 
     child.lua([[require('dapui').open()]])
+    child.wait()
 
     Helpers.expect.equality(
         Helpers.winsInTab(child),
-        { 1010, 1009, 1008, 1007, 1001, 1000, 1002, 1006, 1003 }
+        { 1001, 1010, 1009, 1008, 1007, 1000, 1006, 1003, 1002 }
     )
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -147,15 +149,7 @@ T["nvimdapui"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.columns", 4)
-
-    Helpers.expect.state(child, "tabs[1].wins.integrations.NvimDAPUI", {
-        close = "lua require('dapui').close()",
-        fileTypePattern = "dap",
-        id = 1003,
-        open = "lua require('dapui').open()",
-        width = 58,
-    })
+    Helpers.expect.state(child, "tabs[1].wins.columns", 5)
 end
 
 T["neotest"] = MiniTest.new_set()
@@ -174,14 +168,14 @@ T["neotest"]["keeps sides open"] = function()
 
     child.lua([[require('neotest').summary.open()]])
 
-    Helpers.expect.state(child, "tabs[1].wins.columns", 3)
+    Helpers.expect.state(child, "tabs[1].wins.columns", 4)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.neotest", {
         close = "lua require('neotest').summary.close()",
         fileTypePattern = "neotest",
         id = 1003,
         open = "lua require('neotest').summary.open()",
-        width = 100,
+        width = 74,
     })
 end
 
@@ -200,6 +194,7 @@ T["outline"]["keeps sides open"] = function()
     })
 
     child.cmd("Outline")
+    child.wait()
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
 
@@ -272,8 +267,9 @@ T["neo-tree"]["keeps sides open"] = function()
     })
 
     child.cmd([[Neotree reveal]])
+    child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1000, 1002 })
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -288,7 +284,7 @@ T["neo-tree"]["keeps sides open"] = function()
         fileTypePattern = "neo-tree",
         id = 1004,
         open = "Neotree reveal",
-        width = 2,
+        width = 60,
     })
 end
 
@@ -309,21 +305,23 @@ T["TSPlayground"]["keeps sides open"] = function()
     })
 
     child.cmd("TSPlaygroundToggle")
+    child.wait()
 
-    Helpers.expect.state(child, "tabs[1].wins.columns", 3)
+    Helpers.expect.state(child, "tabs[1].wins.columns", 4)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 159)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 19)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
         id = 1004,
         open = "TSPlaygroundToggle",
-        width = 318,
+        width = 38,
     })
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
+        right = 1002,
     })
 
     child.cmd("TSPlaygroundToggle")
@@ -336,7 +334,7 @@ T["TSPlayground"]["keeps sides open"] = function()
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
-        right = 1005,
+        right = 1002,
     })
 end
 
@@ -354,6 +352,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
         })
     ]])
     Helpers.toggle(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
 
@@ -364,19 +363,21 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
         right = nil,
     })
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
+    Helpers.expect.state(child, "tabs[1].wins.columns", 2)
 
     child.cmd("TSPlaygroundToggle")
+    child.wait()
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 144)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 20)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 26)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 26)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
         id = 1003,
         open = "TSPlaygroundToggle",
-        width = 288,
+        width = 52,
     })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -385,6 +386,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
     })
 
     child.cmd("TSPlaygroundToggle")
+    child.wait()
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 2)
 
@@ -398,7 +400,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
         left = 1001,
         right = nil,
     })
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 40)
 end
 
 T["aerial"] = MiniTest.new_set()
@@ -424,10 +426,11 @@ T["aerial"]["keeps sides open"] = function()
     })
 
     child.cmd("AerialToggle")
+    child.wait()
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 25)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 14)
     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial.id", 1004)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -437,6 +440,7 @@ T["aerial"]["keeps sides open"] = function()
     })
 
     child.cmd("AerialToggle")
+    child.wait()
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial", {
         close = "AerialToggle",

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -155,6 +155,12 @@ end
 T["neotest"] = MiniTest.new_set()
 
 T["neotest"]["keeps sides open"] = function()
+    if child.fn.has("nvim-0.8") == 0 then
+        MiniTest.skip("neotest doesn't support version below 8")
+
+        return
+    end
+
     child.restart({ "-u", "scripts/init_with_neotest.lua", "lua/no-neck-pain/main.lua" })
 
     Helpers.toggle(child)
@@ -211,7 +217,7 @@ T["NvimTree"] = MiniTest.new_set()
 
 T["NvimTree"]["keeps sides open"] = function()
     if child.fn.has("nvim-0.9") == 0 then
-        MiniTest.skip("NvimTree doesn't support version below 8")
+        MiniTest.skip("NvimTree doesn't support version below 9")
 
         return
     end
@@ -292,7 +298,7 @@ T["TSPlayground"] = MiniTest.new_set()
 
 T["TSPlayground"]["keeps sides open"] = function()
     if child.fn.has("nvim-0.9") == 0 then
-        MiniTest.skip("tsplayground doesn't support version below 8")
+        MiniTest.skip("tsplayground doesn't support version below 9")
 
         return
     end
@@ -346,7 +352,7 @@ end
 
 T["TSPlayground"]["reduces `left` side if only active when integration is on `right`"] = function()
     if child.fn.has("nvim-0.9") == 0 then
-        MiniTest.skip("tsplayground doesn't support version below 8")
+        MiniTest.skip("tsplayground doesn't support version below 9")
 
         return
     end

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -291,6 +291,12 @@ end
 T["TSPlayground"] = MiniTest.new_set()
 
 T["TSPlayground"]["keeps sides open"] = function()
+    if child.fn.has("nvim-0.9") == 0 then
+        MiniTest.skip("tsplayground doesn't support version below 8")
+
+        return
+    end
+
     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
 
     Helpers.toggle(child)
@@ -339,6 +345,12 @@ T["TSPlayground"]["keeps sides open"] = function()
 end
 
 T["TSPlayground"]["reduces `left` side if only active when integration is on `right`"] = function()
+    if child.fn.has("nvim-0.9") == 0 then
+        MiniTest.skip("tsplayground doesn't support version below 8")
+
+        return
+    end
+
     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
 
     child.lua([[
@@ -406,7 +418,7 @@ end
 T["aerial"] = MiniTest.new_set()
 
 T["aerial"]["keeps sides open"] = function()
-    if child.fn.has("nvim-0.8") == 0 then
+    if child.fn.has("nvim-0.9") == 0 then
         MiniTest.skip("aerial doesn't support version below 8")
 
         return

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -114,77 +114,77 @@ T["integrations"]["NeoTree throws with wrong values"] = function()
     end)
 end
 
--- T["nvimdapui"] = MiniTest.new_set()
---
--- T["nvimdapui"]["keeps sides open"] = function()
---     if child.fn.has("nvim-0.8") == 0 then
---         MiniTest.skip("NvimDAPUI doesn't support version below 8")
---
---         return
---     end
---
---     child.restart({ "-u", "scripts/init_with_nvimdapui.lua" })
---
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     child.lua([[require('dapui').open()]])
---
---     Helpers.expect.equality(
---         Helpers.winsInTab(child),
---         { 1010, 1009, 1008, 1007, 1001, 1000, 1002, 1006, 1003 }
---     )
---
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     Helpers.expect.state(child, "tabs[1].wins.columns", 5)
---
---     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimDAPUI", {
---         close = "lua require('dapui').close()",
---         fileTypePattern = "dap",
---         id = 1003,
---         open = "lua require('dapui').open()",
---         width = 58,
---     })
--- end
---
--- T["neotest"] = MiniTest.new_set()
---
--- T["neotest"]["keeps sides open"] = function()
---     child.restart({ "-u", "scripts/init_with_neotest.lua", "lua/no-neck-pain/main.lua" })
---
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     child.lua([[require('neotest').summary.open()]])
---
---     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
---
---     Helpers.expect.state(child, "tabs[1].wins.integrations.neotest", {
---         close = "lua require('neotest').summary.close()",
---         fileTypePattern = "neotest",
---         id = 1003,
---         open = "lua require('neotest').summary.open()",
---         width = 100,
---     })
--- end
---
+T["nvimdapui"] = MiniTest.new_set()
+
+T["nvimdapui"]["keeps sides open"] = function()
+    if child.fn.has("nvim-0.8") == 0 then
+        MiniTest.skip("NvimDAPUI doesn't support version below 8")
+
+        return
+    end
+
+    child.restart({ "-u", "scripts/init_with_nvimdapui.lua" })
+
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    child.lua([[require('dapui').open()]])
+
+    Helpers.expect.equality(
+        Helpers.winsInTab(child),
+        { 1010, 1009, 1008, 1007, 1001, 1000, 1002, 1006, 1003 }
+    )
+
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    Helpers.expect.state(child, "tabs[1].wins.columns", 1)
+
+    Helpers.expect.state(child, "tabs[1].wins.integrations.NvimDAPUI", {
+        close = "lua require('dapui').close()",
+        fileTypePattern = "dap",
+        id = 1003,
+        open = "lua require('dapui').open()",
+        width = 58,
+    })
+end
+
+T["neotest"] = MiniTest.new_set()
+
+T["neotest"]["keeps sides open"] = function()
+    child.restart({ "-u", "scripts/init_with_neotest.lua", "lua/no-neck-pain/main.lua" })
+
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    child.lua([[require('neotest').summary.open()]])
+
+    Helpers.expect.state(child, "tabs[1].wins.columns", 3)
+
+    Helpers.expect.state(child, "tabs[1].wins.integrations.neotest", {
+        close = "lua require('neotest').summary.close()",
+        fileTypePattern = "neotest",
+        id = 1003,
+        open = "lua require('neotest').summary.open()",
+        width = 100,
+    })
+end
+
 -- T["outline"] = MiniTest.new_set()
 --
 -- T["outline"]["keeps sides open"] = function()
@@ -211,7 +211,7 @@ end
 --         width = 40,
 --     })
 -- end
---
+
 -- T["NvimTree"] = MiniTest.new_set()
 --
 -- T["NvimTree"]["keeps sides open"] = function()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -147,7 +147,7 @@ T["nvimdapui"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.columns", 1)
+    Helpers.expect.state(child, "tabs[1].wins.columns", 4)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimDAPUI", {
         close = "lua require('dapui').close()",
@@ -185,269 +185,269 @@ T["neotest"]["keeps sides open"] = function()
     })
 end
 
--- T["outline"] = MiniTest.new_set()
---
--- T["outline"]["keeps sides open"] = function()
---     child.restart({ "-u", "scripts/init_with_outline.lua", "lua/no-neck-pain/main.lua" })
---
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     child.cmd("Outline")
---
---     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
---
---     Helpers.expect.state(child, "tabs[1].wins.integrations.outline", {
---         close = "Outline",
---         fileTypePattern = "outline",
---         id = 1004,
---         open = "Outline",
---         width = 40,
---     })
--- end
+T["outline"] = MiniTest.new_set()
 
--- T["NvimTree"] = MiniTest.new_set()
---
--- T["NvimTree"]["keeps sides open"] = function()
---     if child.fn.has("nvim-0.9") == 0 then
---         MiniTest.skip("NvimTree doesn't support version below 8")
---
---         return
---     end
---
---     child.restart({ "-u", "scripts/init_with_nvimtree.lua", "foo" })
---
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
---
---     Helpers.expect.state(child, "enabled", true)
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     child.cmd([[NvimTreeOpen]])
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
---
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
---
---     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimTree", {
---         close = "NvimTreeClose",
---         fileTypePattern = "nvimtree",
---         id = 1004,
---         open = "NvimTreeOpen",
---         width = 38,
---     })
--- end
---
--- T["neo-tree"] = MiniTest.new_set()
---
--- T["neo-tree"]["keeps sides open"] = function()
---     child.restart({ "-u", "scripts/init_with_neotree.lua", "foo" })
---
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
---
---     Helpers.expect.state(child, "enabled", true)
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     child.cmd([[Neotree reveal]])
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
---
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
---
---     Helpers.expect.state(child, "tabs[1].wins.integrations.NeoTree", {
---         close = "Neotree close",
---         fileTypePattern = "neo-tree",
---         id = 1004,
---         open = "Neotree reveal",
---         width = 2,
---     })
--- end
---
--- T["TSPlayground"] = MiniTest.new_set()
---
--- T["TSPlayground"]["keeps sides open"] = function()
---     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
---
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
---
---     Helpers.expect.state(child, "enabled", true)
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     child.cmd("TSPlaygroundToggle")
---
---     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
---
---     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 159)
---     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
---         close = "TSPlaygroundToggle",
---         fileTypePattern = "tsplayground",
---         id = 1004,
---         open = "TSPlaygroundToggle",
---         width = 318,
---     })
---
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---     })
---
---     child.cmd("TSPlaygroundToggle")
---
---     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
---         close = "TSPlaygroundToggle",
---         fileTypePattern = "tsplayground",
---         open = "TSPlaygroundToggle",
---     })
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1005,
---     })
--- end
---
--- T["TSPlayground"]["reduces `left` side if only active when integration is on `right`"] = function()
---     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
---
---     child.lua([[
---         require('no-neck-pain').setup({
---             width = 20,
---             buffers = {
---                 right = {
---                     enabled = false,
---                 },
---             },
---         })
---     ]])
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
---
---     Helpers.expect.state(child, "enabled", true)
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = nil,
---     })
---     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
---
---     child.cmd("TSPlaygroundToggle")
---
---     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
---
---     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 144)
---     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 20)
---     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
---         close = "TSPlaygroundToggle",
---         fileTypePattern = "tsplayground",
---         id = 1003,
---         open = "TSPlaygroundToggle",
---         width = 288,
---     })
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = nil,
---     })
---
---     child.cmd("TSPlaygroundToggle")
---
---     Helpers.expect.state(child, "tabs[1].wins.columns", 2)
---
---     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
---         close = "TSPlaygroundToggle",
---         fileTypePattern = "tsplayground",
---         open = "TSPlaygroundToggle",
---     })
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = nil,
---     })
---     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
--- end
---
--- T["aerial"] = MiniTest.new_set()
---
--- T["aerial"]["keeps sides open"] = function()
---     if child.fn.has("nvim-0.8") == 0 then
---         MiniTest.skip("aerial doesn't support version below 8")
---
---         return
---     end
---
---     child.restart({ "-u", "scripts/init_with_aerial.lua" })
---
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
---
---     Helpers.expect.state(child, "enabled", true)
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     child.cmd("AerialToggle")
---
---     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
---
---     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 25)
---     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial.id", 1004)
---
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
---
---     child.cmd("AerialToggle")
---
---     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial", {
---         close = "AerialToggle",
---         fileTypePattern = "aerial",
---         open = "AerialToggle",
---     })
---     Helpers.expect.state(child, "tabs[1].wins.main", {
---         curr = 1000,
---         left = 1001,
---         right = 1002,
---     })
--- end
+T["outline"]["keeps sides open"] = function()
+    child.restart({ "-u", "scripts/init_with_outline.lua", "lua/no-neck-pain/main.lua" })
+
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    child.cmd("Outline")
+
+    Helpers.expect.state(child, "tabs[1].wins.columns", 4)
+
+    Helpers.expect.state(child, "tabs[1].wins.integrations.outline", {
+        close = "Outline",
+        fileTypePattern = "outline",
+        id = 1004,
+        open = "Outline",
+        width = 40,
+    })
+end
+
+T["NvimTree"] = MiniTest.new_set()
+
+T["NvimTree"]["keeps sides open"] = function()
+    if child.fn.has("nvim-0.9") == 0 then
+        MiniTest.skip("NvimTree doesn't support version below 8")
+
+        return
+    end
+
+    child.restart({ "-u", "scripts/init_with_nvimtree.lua", "foo" })
+
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    Helpers.expect.state(child, "enabled", true)
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    child.cmd([[NvimTreeOpen]])
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
+
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    Helpers.expect.state(child, "tabs[1].wins.columns", 4)
+
+    Helpers.expect.state(child, "tabs[1].wins.integrations.NvimTree", {
+        close = "NvimTreeClose",
+        fileTypePattern = "nvimtree",
+        id = 1004,
+        open = "NvimTreeOpen",
+        width = 38,
+    })
+end
+
+T["neo-tree"] = MiniTest.new_set()
+
+T["neo-tree"]["keeps sides open"] = function()
+    child.restart({ "-u", "scripts/init_with_neotree.lua", "foo" })
+
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    Helpers.expect.state(child, "enabled", true)
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    child.cmd([[Neotree reveal]])
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
+
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    Helpers.expect.state(child, "tabs[1].wins.columns", 4)
+
+    Helpers.expect.state(child, "tabs[1].wins.integrations.NeoTree", {
+        close = "Neotree close",
+        fileTypePattern = "neo-tree",
+        id = 1004,
+        open = "Neotree reveal",
+        width = 2,
+    })
+end
+
+T["TSPlayground"] = MiniTest.new_set()
+
+T["TSPlayground"]["keeps sides open"] = function()
+    child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
+
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    Helpers.expect.state(child, "enabled", true)
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    child.cmd("TSPlaygroundToggle")
+
+    Helpers.expect.state(child, "tabs[1].wins.columns", 3)
+
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 159)
+    Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
+        close = "TSPlaygroundToggle",
+        fileTypePattern = "tsplayground",
+        id = 1004,
+        open = "TSPlaygroundToggle",
+        width = 318,
+    })
+
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+    })
+
+    child.cmd("TSPlaygroundToggle")
+
+    Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
+        close = "TSPlaygroundToggle",
+        fileTypePattern = "tsplayground",
+        open = "TSPlaygroundToggle",
+    })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1005,
+    })
+end
+
+T["TSPlayground"]["reduces `left` side if only active when integration is on `right`"] = function()
+    child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
+
+    child.lua([[
+        require('no-neck-pain').setup({
+            width = 20,
+            buffers = {
+                right = {
+                    enabled = false,
+                },
+            },
+        })
+    ]])
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
+
+    Helpers.expect.state(child, "enabled", true)
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = nil,
+    })
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
+
+    child.cmd("TSPlaygroundToggle")
+
+    Helpers.expect.state(child, "tabs[1].wins.columns", 3)
+
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 144)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 20)
+    Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
+        close = "TSPlaygroundToggle",
+        fileTypePattern = "tsplayground",
+        id = 1003,
+        open = "TSPlaygroundToggle",
+        width = 288,
+    })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = nil,
+    })
+
+    child.cmd("TSPlaygroundToggle")
+
+    Helpers.expect.state(child, "tabs[1].wins.columns", 2)
+
+    Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
+        close = "TSPlaygroundToggle",
+        fileTypePattern = "tsplayground",
+        open = "TSPlaygroundToggle",
+    })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = nil,
+    })
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
+end
+
+T["aerial"] = MiniTest.new_set()
+
+T["aerial"]["keeps sides open"] = function()
+    if child.fn.has("nvim-0.8") == 0 then
+        MiniTest.skip("aerial doesn't support version below 8")
+
+        return
+    end
+
+    child.restart({ "-u", "scripts/init_with_aerial.lua" })
+
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    Helpers.expect.state(child, "enabled", true)
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    child.cmd("AerialToggle")
+
+    Helpers.expect.state(child, "tabs[1].wins.columns", 4)
+
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 25)
+    Helpers.expect.state(child, "tabs[1].wins.integrations.aerial.id", 1004)
+
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+
+    child.cmd("AerialToggle")
+
+    Helpers.expect.state(child, "tabs[1].wins.integrations.aerial", {
+        close = "AerialToggle",
+        fileTypePattern = "aerial",
+        open = "AerialToggle",
+    })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
+end
 
 return T

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -383,17 +383,18 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
 
     Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 149)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 142)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1001)"), 15)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
         id = 1003,
         open = "TSPlaygroundToggle",
-        width = 298,
+        width = 284,
     })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
-        left = nil,
+        left = 1001,
         right = nil,
     })
 
@@ -409,9 +410,10 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
     })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
-        left = 1004,
+        left = 1001,
         right = nil,
     })
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1001)"), 15)
 end
 
 T["aerial"] = MiniTest.new_set()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -114,350 +114,340 @@ T["integrations"]["NeoTree throws with wrong values"] = function()
     end)
 end
 
-T["nvimdapui"] = MiniTest.new_set()
-
-T["nvimdapui"]["keeps sides open"] = function()
-    if child.fn.has("nvim-0.8") == 0 then
-        MiniTest.skip("NvimDAPUI doesn't support version below 8")
-
-        return
-    end
-
-    child.restart({ "-u", "scripts/init_with_nvimdapui.lua" })
-
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    child.lua([[require('dapui').open()]])
-    vim.loop.sleep(50)
-
-    Helpers.expect.equality(
-        Helpers.winsInTab(child),
-        { 1010, 1009, 1008, 1007, 1001, 1000, 1002, 1006, 1003 }
-    )
-
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 5)
-
-    Helpers.expect.state(child, "tabs[1].wins.integrations.NvimDAPUI", {
-        close = "lua require('dapui').close()",
-        fileTypePattern = "dap",
-        id = 1003,
-        open = "lua require('dapui').open()",
-        width = 58,
-    })
-end
-
-T["neotest"] = MiniTest.new_set()
-
-T["neotest"]["keeps sides open"] = function()
-    child.restart({ "-u", "scripts/init_with_neotest.lua", "lua/no-neck-pain/main.lua" })
-
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    child.lua([[require('neotest').summary.open()]])
-    vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 3)
-
-    Helpers.expect.state(child, "tabs[1].wins.integrations.neotest", {
-        close = "lua require('neotest').summary.close()",
-        fileTypePattern = "neotest",
-        id = 1003,
-        open = "lua require('neotest').summary.open()",
-        width = 100,
-    })
-end
-
-T["outline"] = MiniTest.new_set()
-
-T["outline"]["keeps sides open"] = function()
-    child.restart({ "-u", "scripts/init_with_outline.lua", "lua/no-neck-pain/main.lua" })
-
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    child.cmd("Outline")
-    vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 4)
-
-    Helpers.expect.state(child, "tabs[1].wins.integrations.outline", {
-        close = "Outline",
-        fileTypePattern = "outline",
-        id = 1004,
-        open = "Outline",
-        width = 40,
-    })
-end
-
-T["NvimTree"] = MiniTest.new_set()
-
-T["NvimTree"]["keeps sides open"] = function()
-    if child.fn.has("nvim-0.9") == 0 then
-        MiniTest.skip("NvimTree doesn't support version below 8")
-
-        return
-    end
-
-    child.restart({ "-u", "scripts/init_with_nvimtree.lua", "foo" })
-
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-
-    Helpers.expect.state(child, "enabled", true)
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    child.cmd([[NvimTreeOpen]])
-    child.loop.sleep(50)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
-
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 4)
-
-    Helpers.expect.state(child, "tabs[1].wins.integrations.NvimTree", {
-        close = "NvimTreeClose",
-        fileTypePattern = "nvimtree",
-        id = 1004,
-        open = "NvimTreeOpen",
-        width = 38,
-    })
-end
-
-T["neo-tree"] = MiniTest.new_set()
-
-T["neo-tree"]["keeps sides open"] = function()
-    child.restart({ "-u", "scripts/init_with_neotree.lua", "foo" })
-
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-
-    Helpers.expect.state(child, "enabled", true)
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    child.cmd([[Neotree reveal]])
-    child.loop.sleep(50)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
-
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 4)
-
-    Helpers.expect.state(child, "tabs[1].wins.integrations.NeoTree", {
-        close = "Neotree close",
-        fileTypePattern = "neo-tree",
-        id = 1004,
-        open = "Neotree reveal",
-        width = 2,
-    })
-end
-
-T["TSPlayground"] = MiniTest.new_set()
-
-T["TSPlayground"]["keeps sides open"] = function()
-    child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
-
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-
-    Helpers.expect.state(child, "enabled", true)
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    child.cmd("TSPlaygroundToggle")
-    vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 3)
-
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 159)
-    Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
-        close = "TSPlaygroundToggle",
-        fileTypePattern = "tsplayground",
-        id = 1004,
-        open = "TSPlaygroundToggle",
-        width = 318,
-    })
-
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-    })
-
-    child.cmd("TSPlaygroundToggle")
-    vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
-        close = "TSPlaygroundToggle",
-        fileTypePattern = "tsplayground",
-        open = "TSPlaygroundToggle",
-    })
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1005,
-    })
-end
-
-T["TSPlayground"]["reduces `left` side if only active when integration is on `right`"] = function()
-    child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
-
-    child.lua([[
-        require('no-neck-pain').setup({
-            width = 20,
-            buffers = {
-                right = {
-                    enabled = false,
-                },
-            },
-        })
-    ]])
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
-
-    Helpers.expect.state(child, "enabled", true)
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = nil,
-    })
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
-
-    child.cmd("TSPlaygroundToggle")
-    vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 3)
-
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 144)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 20)
-    Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
-        close = "TSPlaygroundToggle",
-        fileTypePattern = "tsplayground",
-        id = 1003,
-        open = "TSPlaygroundToggle",
-        width = 288,
-    })
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = nil,
-    })
-
-    child.cmd("TSPlaygroundToggle")
-    vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 2)
-
-    Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
-        close = "TSPlaygroundToggle",
-        fileTypePattern = "tsplayground",
-        open = "TSPlaygroundToggle",
-    })
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = nil,
-    })
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
-end
-
-T["aerial"] = MiniTest.new_set()
-
-T["aerial"]["keeps sides open"] = function()
-    if child.fn.has("nvim-0.8") == 0 then
-        MiniTest.skip("aerial doesn't support version below 8")
-
-        return
-    end
-
-    child.restart({ "-u", "scripts/init_with_aerial.lua" })
-
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-
-    Helpers.expect.state(child, "enabled", true)
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    child.cmd("AerialToggle")
-
-    Helpers.expect.state(child, "tabs[1].wins.vsplits", 4)
-
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 25)
-    Helpers.expect.state(child, "tabs[1].wins.integrations.aerial.id", 1004)
-
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-
-    child.cmd("AerialToggle")
-    vim.loop.sleep(50)
-
-    Helpers.expect.state(child, "tabs[1].wins.integrations.aerial", {
-        close = "AerialToggle",
-        fileTypePattern = "aerial",
-        open = "AerialToggle",
-    })
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1001,
-        right = 1002,
-    })
-end
+-- T["nvimdapui"] = MiniTest.new_set()
+--
+-- T["nvimdapui"]["keeps sides open"] = function()
+--     if child.fn.has("nvim-0.8") == 0 then
+--         MiniTest.skip("NvimDAPUI doesn't support version below 8")
+--
+--         return
+--     end
+--
+--     child.restart({ "-u", "scripts/init_with_nvimdapui.lua" })
+--
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     child.lua([[require('dapui').open()]])
+--
+--     Helpers.expect.equality(
+--         Helpers.winsInTab(child),
+--         { 1010, 1009, 1008, 1007, 1001, 1000, 1002, 1006, 1003 }
+--     )
+--
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     Helpers.expect.state(child, "tabs[1].wins.columns", 5)
+--
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimDAPUI", {
+--         close = "lua require('dapui').close()",
+--         fileTypePattern = "dap",
+--         id = 1003,
+--         open = "lua require('dapui').open()",
+--         width = 58,
+--     })
+-- end
+--
+-- T["neotest"] = MiniTest.new_set()
+--
+-- T["neotest"]["keeps sides open"] = function()
+--     child.restart({ "-u", "scripts/init_with_neotest.lua", "lua/no-neck-pain/main.lua" })
+--
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     child.lua([[require('neotest').summary.open()]])
+--
+--     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
+--
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.neotest", {
+--         close = "lua require('neotest').summary.close()",
+--         fileTypePattern = "neotest",
+--         id = 1003,
+--         open = "lua require('neotest').summary.open()",
+--         width = 100,
+--     })
+-- end
+--
+-- T["outline"] = MiniTest.new_set()
+--
+-- T["outline"]["keeps sides open"] = function()
+--     child.restart({ "-u", "scripts/init_with_outline.lua", "lua/no-neck-pain/main.lua" })
+--
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     child.cmd("Outline")
+--
+--     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
+--
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.outline", {
+--         close = "Outline",
+--         fileTypePattern = "outline",
+--         id = 1004,
+--         open = "Outline",
+--         width = 40,
+--     })
+-- end
+--
+-- T["NvimTree"] = MiniTest.new_set()
+--
+-- T["NvimTree"]["keeps sides open"] = function()
+--     if child.fn.has("nvim-0.9") == 0 then
+--         MiniTest.skip("NvimTree doesn't support version below 8")
+--
+--         return
+--     end
+--
+--     child.restart({ "-u", "scripts/init_with_nvimtree.lua", "foo" })
+--
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+--
+--     Helpers.expect.state(child, "enabled", true)
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     child.cmd([[NvimTreeOpen]])
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
+--
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
+--
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimTree", {
+--         close = "NvimTreeClose",
+--         fileTypePattern = "nvimtree",
+--         id = 1004,
+--         open = "NvimTreeOpen",
+--         width = 38,
+--     })
+-- end
+--
+-- T["neo-tree"] = MiniTest.new_set()
+--
+-- T["neo-tree"]["keeps sides open"] = function()
+--     child.restart({ "-u", "scripts/init_with_neotree.lua", "foo" })
+--
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+--
+--     Helpers.expect.state(child, "enabled", true)
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     child.cmd([[Neotree reveal]])
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
+--
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
+--
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.NeoTree", {
+--         close = "Neotree close",
+--         fileTypePattern = "neo-tree",
+--         id = 1004,
+--         open = "Neotree reveal",
+--         width = 2,
+--     })
+-- end
+--
+-- T["TSPlayground"] = MiniTest.new_set()
+--
+-- T["TSPlayground"]["keeps sides open"] = function()
+--     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
+--
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+--
+--     Helpers.expect.state(child, "enabled", true)
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     child.cmd("TSPlaygroundToggle")
+--
+--     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
+--
+--     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 159)
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
+--         close = "TSPlaygroundToggle",
+--         fileTypePattern = "tsplayground",
+--         id = 1004,
+--         open = "TSPlaygroundToggle",
+--         width = 318,
+--     })
+--
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--     })
+--
+--     child.cmd("TSPlaygroundToggle")
+--
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
+--         close = "TSPlaygroundToggle",
+--         fileTypePattern = "tsplayground",
+--         open = "TSPlaygroundToggle",
+--     })
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1005,
+--     })
+-- end
+--
+-- T["TSPlayground"]["reduces `left` side if only active when integration is on `right`"] = function()
+--     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
+--
+--     child.lua([[
+--         require('no-neck-pain').setup({
+--             width = 20,
+--             buffers = {
+--                 right = {
+--                     enabled = false,
+--                 },
+--             },
+--         })
+--     ]])
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
+--
+--     Helpers.expect.state(child, "enabled", true)
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = nil,
+--     })
+--     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
+--
+--     child.cmd("TSPlaygroundToggle")
+--
+--     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
+--
+--     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 144)
+--     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 20)
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
+--         close = "TSPlaygroundToggle",
+--         fileTypePattern = "tsplayground",
+--         id = 1003,
+--         open = "TSPlaygroundToggle",
+--         width = 288,
+--     })
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = nil,
+--     })
+--
+--     child.cmd("TSPlaygroundToggle")
+--
+--     Helpers.expect.state(child, "tabs[1].wins.columns", 2)
+--
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
+--         close = "TSPlaygroundToggle",
+--         fileTypePattern = "tsplayground",
+--         open = "TSPlaygroundToggle",
+--     })
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = nil,
+--     })
+--     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
+-- end
+--
+-- T["aerial"] = MiniTest.new_set()
+--
+-- T["aerial"]["keeps sides open"] = function()
+--     if child.fn.has("nvim-0.8") == 0 then
+--         MiniTest.skip("aerial doesn't support version below 8")
+--
+--         return
+--     end
+--
+--     child.restart({ "-u", "scripts/init_with_aerial.lua" })
+--
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+--
+--     Helpers.expect.state(child, "enabled", true)
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     child.cmd("AerialToggle")
+--
+--     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
+--
+--     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 25)
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial.id", 1004)
+--
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+--
+--     child.cmd("AerialToggle")
+--
+--     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial", {
+--         close = "AerialToggle",
+--         fileTypePattern = "aerial",
+--         open = "AerialToggle",
+--     })
+--     Helpers.expect.state(child, "tabs[1].wins.main", {
+--         curr = 1000,
+--         left = 1001,
+--         right = 1002,
+--     })
+-- end
 
 return T

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -149,7 +149,7 @@ T["nvimdapui"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 5)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimDAPUI", {
         close = "lua require('dapui').close()",
@@ -178,7 +178,7 @@ T["neotest"]["keeps sides open"] = function()
     child.lua([[require('neotest').summary.open()]])
     vim.loop.sleep(50)
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 3)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.neotest", {
         close = "lua require('neotest').summary.close()",
@@ -207,7 +207,7 @@ T["outline"]["keeps sides open"] = function()
     child.cmd("Outline")
     vim.loop.sleep(50)
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.outline", {
         close = "Outline",
@@ -251,7 +251,7 @@ T["NvimTree"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.NvimTree", {
         close = "NvimTreeClose",
@@ -290,7 +290,7 @@ T["neo-tree"]["keeps sides open"] = function()
         right = 1002,
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.NeoTree", {
         close = "Neotree close",
@@ -321,7 +321,7 @@ T["TSPlayground"]["keeps sides open"] = function()
     child.cmd("TSPlaygroundToggle")
     vim.loop.sleep(50)
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 3)
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 159)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
@@ -381,7 +381,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
     child.cmd("TSPlaygroundToggle")
     vim.loop.sleep(50)
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 142)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1001)"), 15)
@@ -401,7 +401,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
     child.cmd("TSPlaygroundToggle")
     vim.loop.sleep(50)
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 2)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
@@ -441,7 +441,7 @@ T["aerial"]["keeps sides open"] = function()
 
     child.cmd("AerialToggle")
 
-    Helpers.expect.state(child, "tabs[1].wins.splits", vim.NIL)
+    Helpers.expect.state(child, "tabs[1].wins.vsplits", 1)
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 25)
     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial.id", 1004)

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -124,7 +124,6 @@ T["nvimdapui"]["keeps sides open"] = function()
     end
 
     child.restart({ "-u", "scripts/init_with_nvimdapui.lua" })
-    child.set_size(20, 100)
 
     Helpers.toggle(child)
 
@@ -164,7 +163,6 @@ T["neotest"] = MiniTest.new_set()
 
 T["neotest"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_neotest.lua", "lua/no-neck-pain/main.lua" })
-    child.set_size(20, 100)
 
     Helpers.toggle(child)
 
@@ -193,7 +191,6 @@ T["outline"] = MiniTest.new_set()
 
 T["outline"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_outline.lua", "lua/no-neck-pain/main.lua" })
-    child.set_size(20, 100)
 
     Helpers.toggle(child)
 
@@ -266,7 +263,6 @@ T["neo-tree"] = MiniTest.new_set()
 
 T["neo-tree"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_neotree.lua", "foo" })
-    child.set_size(5, 300)
 
     Helpers.toggle(child)
 
@@ -305,7 +301,6 @@ T["TSPlayground"] = MiniTest.new_set()
 
 T["TSPlayground"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
-    child.set_size(5, 300)
 
     Helpers.toggle(child)
 
@@ -354,7 +349,6 @@ end
 
 T["TSPlayground"]["reduces `left` side if only active when integration is on `right`"] = function()
     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
-    child.set_size(5, 300)
 
     child.lua([[
         require('no-neck-pain').setup({
@@ -426,7 +420,6 @@ T["aerial"]["keeps sides open"] = function()
     end
 
     child.restart({ "-u", "scripts/init_with_aerial.lua" })
-    child.set_size(5, 500)
 
     Helpers.toggle(child)
 

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -283,7 +283,7 @@ T["setup"]["toggles scratchPad"] = function()
     Helpers.expect.global(child, "_G.NoNeckPain.state.tabs[1].scratchPadEnabled", false)
 
     child.api.nvim_input("ns")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.left.scratchPad.enabled", false)
     Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.right.scratchPad.enabled", false)
@@ -303,7 +303,7 @@ T["setup"]["toggle sides and disable if none"] = function()
     })
 
     child.api.nvim_input("nl")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -312,7 +312,7 @@ T["setup"]["toggle sides and disable if none"] = function()
     })
 
     child.api.nvim_input("nl")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -321,7 +321,7 @@ T["setup"]["toggle sides and disable if none"] = function()
     })
 
     child.api.nvim_input("nr")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -330,7 +330,7 @@ T["setup"]["toggle sides and disable if none"] = function()
     })
 
     child.api.nvim_input("nl")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "enabled", false)
 end

--- a/tests/test_options.lua
+++ b/tests/test_options.lua
@@ -17,7 +17,6 @@ local T = MiniTest.new_set({
 T["minSideBufferWidth"] = MiniTest.new_set()
 
 T["minSideBufferWidth"]["closes side buffer respecting the given value"] = function()
-    child.set_size(500, 500)
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
     Helpers.toggle(child)
 
@@ -38,7 +37,6 @@ end
 T["killAllBuffersOnDisable"] = MiniTest.new_set()
 
 T["killAllBuffersOnDisable"]["closes every windows when disabling the plugin"] = function()
-    child.set_size(500, 500)
     child.lua([[ require('no-neck-pain').setup({width=20,killAllBuffersOnDisable=true}) ]])
     Helpers.toggle(child)
 
@@ -60,7 +58,6 @@ end
 T["fallbackOnBufferDelete"] = MiniTest.new_set()
 
 T["fallbackOnBufferDelete"]["invoking :bd keeps nnp enabled"] = function()
-    child.set_size(500, 500)
     child.lua([[ require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true}) ]])
 
     Helpers.expect.config(child, "fallbackOnBufferDelete", true)
@@ -76,7 +73,6 @@ T["fallbackOnBufferDelete"]["invoking :bd keeps nnp enabled"] = function()
 end
 
 T["fallbackOnBufferDelete"]["still allows nvim to quit"] = function()
-    child.set_size(500, 500)
     child.lua([[ require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true}) ]])
     Helpers.toggle(child)
 

--- a/tests/test_options.lua
+++ b/tests/test_options.lua
@@ -39,7 +39,7 @@ T["killAllBuffersOnDisable"] = MiniTest.new_set()
 
 T["killAllBuffersOnDisable"]["closes every windows when disabling the plugin"] = function()
     child.set_size(500, 500)
-    child.lua([[ require('no-neck-pain').setup({width=50,killAllBuffersOnDisable=true}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20,killAllBuffersOnDisable=true}) ]])
     Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
@@ -62,6 +62,8 @@ T["fallbackOnBufferDelete"] = MiniTest.new_set()
 T["fallbackOnBufferDelete"]["invoking :bd keeps nnp enabled"] = function()
     child.set_size(500, 500)
     child.lua([[ require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true}) ]])
+
+    Helpers.expect.config(child, "fallbackOnBufferDelete", true)
     Helpers.toggle(child)
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -124,8 +124,8 @@ T["vsplit"]["corretly size splits when opening helper with side buffers open"] =
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 19)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
 
     child.cmd("h")
 
@@ -156,7 +156,7 @@ T["vsplit"]["preserve vsplit width when having side buffers"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1002, 1000 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 32)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 38)
 end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -125,14 +125,14 @@ T["vsplit"]["correctly size splits when opening helper with side buffers open"] 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 19)
 
     child.cmd("h")
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
@@ -156,7 +156,7 @@ T["vsplit"]["preserve vsplit width when having side buffers"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1002, 1000 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 30)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 26)
 end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
@@ -185,15 +185,20 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
 end
 
 T["vsplit"]["hides side buffers"] = function()
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=58}) ]])
     Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.state(child, "tabs[1].wins.main", {
+        curr = 1000,
+        left = 1001,
+        right = 1002,
+    })
 
     child.cmd("vsplit")
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1000 })
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-    })
+    Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000 })
 
     child.lua("vim.fn.win_gotoid(1003)")
     child.cmd("q")

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -73,7 +73,7 @@ T["split"]["keeps side buffers"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 30)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 28)
 end
 
 T["split"]["keeps correct focus"] = function()
@@ -124,15 +124,15 @@ T["vsplit"]["corretly size splits when opening helper with side buffers open"] =
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 19)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 
     child.cmd("h")
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
@@ -294,52 +294,51 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
 
     child.cmd("q")
     child.cmd("q")
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1006, 1003, 1000, 1007 })
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1012, 1004, 1003, 1013 })
 
-    Helpers.expect.equality(Helpers.currentWin(child), 1000)
+    Helpers.expect.equality(Helpers.currentWin(child), 1004)
 end
 
--- T["vsplit/split"]["closing help page doens't break layout"] = function()
---     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
---
---     child.cmd("split")
---     child.cmd("h")
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
---
---     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
---
---     child.cmd("q")
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
---
---     Helpers.expect.equality(Helpers.currentWin(child), 1003)
---
---     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
--- end
---
--- T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
---     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
---     Helpers.toggle(child)
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
---     Helpers.expect.equality(Helpers.currentWin(child), 1000)
---
---     child.cmd("split")
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
---     Helpers.expect.equality(Helpers.currentWin(child), 1003)
---     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 468)
---
---     child.cmd("vsplit")
---
---     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
---     Helpers.expect.equality(Helpers.currentWin(child), 1004)
---
---     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 468)
---     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 417)
---     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1000)"), 468)
--- end
+T["vsplit/split"]["closing help page doens't break layout"] = function()
+    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+
+    child.cmd("split")
+    child.cmd("h")
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
+
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 50)
+
+    child.cmd("q")
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+
+    Helpers.expect.equality(Helpers.currentWin(child), 1003)
+
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 50)
+end
+
+T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
+    Helpers.toggle(child)
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(Helpers.currentWin(child), 1000)
+
+    child.cmd("split")
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(Helpers.currentWin(child), 1003)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+
+    child.cmd("vsplit")
+
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
+    Helpers.expect.equality(Helpers.currentWin(child), 1004)
+
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 2)
+end
 
 return T

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -124,15 +124,15 @@ T["vsplit"]["correctly size splits when opening helper with side buffers open"] 
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 19)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
 
     child.cmd("h")
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 8)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
@@ -156,7 +156,7 @@ T["vsplit"]["preserve vsplit width when having side buffers"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1002, 1000 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 32)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 30)
 end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
@@ -309,14 +309,14 @@ T["vsplit/split"]["closing help page doens't break layout"] = function()
     child.cmd("h")
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 50)
 
     child.cmd("q")
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(Helpers.currentWin(child), 1003)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 50)
 end
 
 T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
@@ -330,7 +330,7 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
     Helpers.expect.equality(Helpers.currentWin(child), 1003)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 
     child.cmd("vsplit")
 
@@ -338,7 +338,7 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     Helpers.expect.equality(Helpers.currentWin(child), 1004)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 38)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 2)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
 end
 
 return T

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -156,7 +156,7 @@ T["vsplit"]["preserve vsplit width when having side buffers"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1002, 1000 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 38)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 28)
 end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -17,18 +17,17 @@ local T = MiniTest.new_set({
 T["split"] = MiniTest.new_set()
 
 T["split"]["only one side buffer, closing help doesn't close NNP"] = function()
-    child.set_size(500, 500)
-    child.lua([[ require('no-neck-pain').setup({width=50, buffers={right={enabled=false}}}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20, buffers={right={enabled=false}}}) ]])
     Helpers.toggle(child)
 
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
+
     child.cmd("h")
-    child.loop.sleep(50)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1002, 1000 })
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1002, 1001, 1000 })
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001 })
-    Helpers.expect.state(child, "tabs[1].wins.splits[1002]", { id = 1002, vertical = false })
 
-    child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.splits[1002].id)")
+    child.lua("vim.fn.win_gotoid(1002)")
     child.cmd("q")
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
@@ -37,12 +36,10 @@ T["split"]["only one side buffer, closing help doesn't close NNP"] = function()
 end
 
 T["split"]["closing `curr` makes `split` the new `curr`"] = function()
-    child.set_size(200, 200)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
     child.cmd("split")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -50,7 +47,6 @@ T["split"]["closing `curr` makes `split` the new `curr`"] = function()
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.state(child, "tabs[1].wins.splits[1003]", { id = 1003, vertical = false })
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.curr)")
     child.cmd("q")
@@ -60,12 +56,10 @@ T["split"]["closing `curr` makes `split` the new `curr`"] = function()
 end
 
 T["split"]["keeps side buffers"] = function()
-    child.set_size(200, 200)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
     child.cmd("split")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -73,19 +67,17 @@ T["split"]["keeps side buffers"] = function()
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.state(child, "tabs[1].wins.splits[1003]", { id = 1003, vertical = false })
 
-    child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.splits[1003].id)")
+    child.lua("vim.fn.win_gotoid(1003)")
     child.cmd("q")
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 30)
 end
 
 T["split"]["keeps correct focus"] = function()
-    child.set_size(300, 300)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.currentWin(child), 1000)
@@ -125,61 +117,54 @@ T["vsplit"]["does not create side buffers when there's not enough space"] = func
 end
 
 T["vsplit"]["corretly size splits when opening helper with side buffers open"] = function()
-    child.set_size(150, 150)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.set_size(30, 300)
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
     child.cmd("vsplit")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.splits[1003].id", 50)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 67)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 129)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 128)
 
     child.cmd("h")
-    child.loop.sleep(50)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.splits[1004].id", 150)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 67)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 129)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 128)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
-    child.set_size(500, 500)
     child.cmd("vsplit")
 
     Helpers.expect.equality(Helpers.winsInTab(child, 1), { 1001, 1000 })
 
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1002, 1001, 1000, 1003 })
 end
 
 T["vsplit"]["preserve vsplit width when having side buffers"] = function()
-    child.set_size(500, 500)
-    child.lua([[ require('no-neck-pain').setup({width=50,buffers={right={enabled=false}}}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20,buffers={right={enabled=false}}}) ]])
     Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
 
     child.cmd("vsplit")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1002, 1000 })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.splits[1002].id", 65)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 32)
 end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
-    child.set_size(400, 400)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
     child.cmd("vsplit")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -187,7 +172,6 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.state(child, "tabs[1].wins.splits[1003]", { id = 1003, vertical = true })
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.curr)")
     child.cmd("q")
@@ -206,15 +190,13 @@ T["vsplit"]["hides side buffers"] = function()
     Helpers.toggle(child)
 
     child.cmd("vsplit")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1000 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
     })
-    Helpers.expect.state(child, "tabs[1].wins.splits[1003]", { id = 1003, vertical = true })
 
-    child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.splits[1003].id)")
+    child.lua("vim.fn.win_gotoid(1003)")
     child.cmd("q")
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1000, 1005 })
@@ -227,21 +209,17 @@ T["vsplit"]["hides side buffers"] = function()
 end
 
 T["vsplit"]["many vsplit leave side buffers open as long as there's space for it"] = function()
-    child.set_size(100, 100)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("vsplit")
-    child.loop.sleep(50)
     child.cmd("vsplit")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1000 })
 
     child.cmd("q")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1003, 1000, 1006 })
     Helpers.expect.state(child, "tabs[_G.NoNeckPain.state.activeTab].wins.main", {
@@ -252,8 +230,7 @@ T["vsplit"]["many vsplit leave side buffers open as long as there's space for it
 end
 
 T["vsplit"]["keeps correct focus"] = function()
-    child.set_size(200, 200)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=10}) ]])
     Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.currentWin(child), 1000)
@@ -270,8 +247,7 @@ end
 T["vsplit/split"] = MiniTest.new_set()
 
 T["vsplit/split"]["state is correctly sync'd even after many changes"] = function()
-    child.set_size(100, 100)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
 
     Helpers.expect.equality(Helpers.winsInTab(child, 1), { 1000 })
 
@@ -284,12 +260,10 @@ T["vsplit/split"]["state is correctly sync'd even after many changes"] = functio
     child.cmd("q")
 
     child.cmd("vsplit")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1000, 1002 })
 
     child.cmd("vsplit")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1004, 1000 })
 
@@ -305,21 +279,17 @@ T["vsplit/split"]["state is correctly sync'd even after many changes"] = functio
 end
 
 T["vsplit/split"]["closing side buffers because of splits restores focus"] = function()
-    child.set_size(100, 100)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("vsplit")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
     child.cmd("vsplit")
-    child.loop.sleep(50)
     child.cmd("vsplit")
-    child.loop.sleep(50)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1004, 1003, 1000 })
 
@@ -330,50 +300,47 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
     Helpers.expect.equality(Helpers.currentWin(child), 1000)
 end
 
-T["vsplit/split"]["closing help page doens't break layout"] = function()
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-
-    child.cmd("split")
-    child.cmd("h")
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
-
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
-
-    child.cmd("q")
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
-
-    Helpers.expect.equality(Helpers.currentWin(child), 1003)
-
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
-end
-
-T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
-    child.set_size(50, 500)
-    child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-    Helpers.expect.equality(Helpers.currentWin(child), 1000)
-
-    child.cmd("split")
-    vim.loop.sleep(50)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
-    Helpers.expect.equality(Helpers.currentWin(child), 1003)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 468)
-
-    child.cmd("vsplit")
-    vim.loop.sleep(50)
-
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
-    Helpers.expect.equality(Helpers.currentWin(child), 1004)
-
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 468)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 417)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1000)"), 468)
-end
+-- T["vsplit/split"]["closing help page doens't break layout"] = function()
+--     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+--
+--     child.cmd("split")
+--     child.cmd("h")
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
+--
+--     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
+--
+--     child.cmd("q")
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+--
+--     Helpers.expect.equality(Helpers.currentWin(child), 1003)
+--
+--     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
+-- end
+--
+-- T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
+--     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
+--     Helpers.toggle(child)
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+--     Helpers.expect.equality(Helpers.currentWin(child), 1000)
+--
+--     child.cmd("split")
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+--     Helpers.expect.equality(Helpers.currentWin(child), 1003)
+--     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 468)
+--
+--     child.cmd("vsplit")
+--
+--     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
+--     Helpers.expect.equality(Helpers.currentWin(child), 1004)
+--
+--     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 468)
+--     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 417)
+--     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1000)"), 468)
+-- end
 
 return T

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -196,7 +196,7 @@ T["vsplit"]["hides side buffers"] = function()
     })
 
     child.cmd("vsplit")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1000 })
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000 })
@@ -221,7 +221,7 @@ T["vsplit"]["many vsplit leave side buffers open as long as there's space for it
 
     child.cmd("vsplit")
     child.cmd("vsplit")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1000 })
 
@@ -270,7 +270,7 @@ T["vsplit/split"]["state is correctly sync'd even after many changes"] = functio
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1000, 1002 })
 
     child.cmd("vsplit")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1004, 1000 })
 
@@ -297,7 +297,7 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
 
     child.cmd("vsplit")
     child.cmd("vsplit")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1004, 1003, 1000 })
 
@@ -342,7 +342,7 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 
     child.cmd("vsplit")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
     Helpers.expect.equality(Helpers.currentWin(child), 1004)

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -73,7 +73,7 @@ T["split"]["keeps side buffers"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 28)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 30)
 end
 
 T["split"]["keeps correct focus"] = function()
@@ -116,7 +116,7 @@ T["vsplit"]["does not create side buffers when there's not enough space"] = func
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1002, 1001, 1000 })
 end
 
-T["vsplit"]["corretly size splits when opening helper with side buffers open"] = function()
+T["vsplit"]["correctly size splits when opening helper with side buffers open"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
@@ -124,15 +124,15 @@ T["vsplit"]["corretly size splits when opening helper with side buffers open"] =
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 19)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
 
     child.cmd("h")
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 8)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
@@ -156,7 +156,7 @@ T["vsplit"]["preserve vsplit width when having side buffers"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1002, 1000 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 28)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 32)
 end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
@@ -309,14 +309,14 @@ T["vsplit/split"]["closing help page doens't break layout"] = function()
     child.cmd("h")
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 50)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
 
     child.cmd("q")
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(Helpers.currentWin(child), 1003)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 50)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
 end
 
 T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
@@ -330,14 +330,14 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
     Helpers.expect.equality(Helpers.currentWin(child), 1003)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
 
     child.cmd("vsplit")
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
     Helpers.expect.equality(Helpers.currentWin(child), 1004)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 38)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 2)
 end
 

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -73,7 +73,7 @@ T["split"]["keeps side buffers"] = function()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 30)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 28)
 end
 
 T["split"]["keeps correct focus"] = function()
@@ -309,14 +309,14 @@ T["vsplit/split"]["closing help page doens't break layout"] = function()
     child.cmd("h")
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 50)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
 
     child.cmd("q")
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(Helpers.currentWin(child), 1003)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 50)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
 end
 
 T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -294,9 +294,9 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
 
     child.cmd("q")
     child.cmd("q")
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1012, 1004, 1003, 1013 })
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1006, 1003, 1000, 1007 })
 
-    Helpers.expect.equality(Helpers.currentWin(child), 1004)
+    Helpers.expect.equality(Helpers.currentWin(child), 1000)
 end
 
 T["vsplit/split"]["closing help page doens't break layout"] = function()

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -185,7 +185,7 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
 end
 
 T["vsplit"]["hides side buffers"] = function()
-    child.lua([[ require('no-neck-pain').setup({width=58}) ]])
+    child.lua([[ require('no-neck-pain').setup({width=50,minSideBufferWidth=0}) ]])
     Helpers.toggle(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
@@ -196,6 +196,7 @@ T["vsplit"]["hides side buffers"] = function()
     })
 
     child.cmd("vsplit")
+    Helpers.wait(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1000 })
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000 })
@@ -220,6 +221,7 @@ T["vsplit"]["many vsplit leave side buffers open as long as there's space for it
 
     child.cmd("vsplit")
     child.cmd("vsplit")
+    Helpers.wait(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1000 })
 
@@ -268,6 +270,7 @@ T["vsplit/split"]["state is correctly sync'd even after many changes"] = functio
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1000, 1002 })
 
     child.cmd("vsplit")
+    Helpers.wait(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1004, 1000 })
 
@@ -294,6 +297,7 @@ T["vsplit/split"]["closing side buffers because of splits restores focus"] = fun
 
     child.cmd("vsplit")
     child.cmd("vsplit")
+    Helpers.wait(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1004, 1003, 1000 })
 
@@ -338,12 +342,13 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 
     child.cmd("vsplit")
+    Helpers.wait(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
     Helpers.expect.equality(Helpers.currentWin(child), 1004)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 38)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 17)
 end
 
 return T

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -117,7 +117,6 @@ T["vsplit"]["does not create side buffers when there's not enough space"] = func
 end
 
 T["vsplit"]["corretly size splits when opening helper with side buffers open"] = function()
-    child.set_size(30, 300)
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
     Helpers.toggle(child)
 
@@ -125,15 +124,15 @@ T["vsplit"]["corretly size splits when opening helper with side buffers open"] =
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 129)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 128)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
 
     child.cmd("h")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
+    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 129)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 128)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -24,6 +24,7 @@ T["tabs"]["keeps the active tab in state"] = function()
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
+    Helpers.wait(child)
 
     Helpers.expect.state(child, "activeTab", 2)
 end
@@ -36,6 +37,7 @@ T["tabs"]["new tab doesn't have side buffers"] = function()
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
+    Helpers.wait(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
 end
@@ -77,11 +79,13 @@ T["tabs"]["previous tab kept side buffers if enabled"] = function()
 
     -- tab 2
     child.cmd("tabnew")
+    Helpers.wait(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
 
     -- tab 1
     child.cmd("tabprevious")
+    Helpers.wait(child)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "activeTab", 1)
@@ -134,10 +138,12 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
 
     -- tab 1
     child.cmd("tabprevious")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 1)
 
     -- tab 2
     child.cmd("tabnext")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 2)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
@@ -157,6 +163,7 @@ T["tabnew/tabclose"]["opening and closing tabs does not throw any error"] = func
     Helpers.expect.state(child, "activeTab", 2)
 
     child.cmd("tabclose")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
@@ -166,9 +173,11 @@ T["tabnew/tabclose"]["opening and closing tabs does not throw any error"] = func
     Helpers.expect.state(child, "activeTab", 4)
 
     child.cmd("tabclose")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 3)
 
     child.cmd("tabclose")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 1)
 end
 
@@ -181,6 +190,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -199,6 +209,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -212,6 +223,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
         },
         {
             id = 2,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -226,9 +238,11 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     })
 
     child.cmd("tabclose")
+    Helpers.wait(child)
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -253,6 +267,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -269,11 +284,13 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     child.cmd("tabnew")
     Helpers.wait(child)
     child.cmd("badd 2")
+    Helpers.wait(child)
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -287,6 +304,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
         {
             id = 2,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -295,7 +313,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1004,
                     right = 1005,
                 },
-                columns = 3,
+                columns = 1,
             },
         },
     })
@@ -304,6 +322,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -321,6 +340,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -334,6 +354,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
         {
             id = 2,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -342,16 +363,18 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1006,
                     right = 1007,
                 },
-                columns = 3,
+                columns = 1,
             },
         },
     })
 
     child.cmd("tabprevious")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 1)
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -365,6 +388,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
         {
             id = 2,
+            redraw = false,
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -373,12 +397,13 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1006,
                     right = 1007,
                 },
-                columns = 3,
+                columns = 1,
             },
         },
     })
 
     child.cmd("tabprevious")
+    Helpers.wait(child)
     Helpers.expect.state(child, "activeTab", 2)
 end
 
@@ -391,6 +416,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     child.cmd("badd 1")
 
     child.cmd("tabnew")
+    Helpers.wait(child)
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     child.cmd("badd 2")
 
@@ -403,6 +429,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
+        redraw = false,
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -416,6 +443,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     })
 
     child.cmd("tabprevious")
+    Helpers.wait(child)
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 1)
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.state(child, "enabled", true)
@@ -425,6 +453,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     Helpers.toggle(child)
     Helpers.expect.state(child, "tabs[1]", {
         id = 1,
+        redraw = false,
         scratchPadEnabled = false,
         wins = {
             integrations = {
@@ -474,11 +503,12 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1004,
                 right = 1005,
             },
-            columns = 3,
+            columns = 1,
         },
     })
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
+        redraw = false,
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -501,6 +531,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     child.cmd("badd 1")
 
     child.cmd("tabnew")
+    Helpers.wait(child)
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     child.cmd("badd 2")
 
@@ -513,6 +544,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
+        redraw = false,
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -521,10 +553,12 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
                 left = 1002,
                 right = 1003,
             },
+            columns = 1,
         },
     })
 
     child.cmd("tabprevious")
+    Helpers.wait(child)
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 1)
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.state(child, "enabled", true)
@@ -532,6 +566,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnext")
+    Helpers.wait(child)
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     Helpers.expect.state(child, "activeTab", 2)
@@ -539,6 +574,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     Helpers.expect.state(child, "tabs[1]", vim.NIL)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
+        redraw = false,
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -547,6 +583,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
                 left = 1002,
                 right = 1003,
             },
+            columns = 1,
         },
     })
 
@@ -562,6 +599,7 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("tabnew")
+    Helpers.wait(child)
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     Helpers.toggle(child)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
@@ -569,6 +607,7 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1]", {
         id = 1,
+        redraw = false,
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -577,11 +616,13 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
                 left = 1001,
                 right = 1002,
             },
+            columns = 1,
         },
     })
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
+        redraw = false,
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -590,14 +631,17 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
                 left = 1004,
                 right = 1005,
             },
+            columns = 1,
         },
     })
 
     child.cmd("q")
+    Helpers.wait(child)
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 1)
     Helpers.expect.state(child, "activeTab", 1)
     Helpers.expect.state(child, "tabs[1]", {
         id = 1,
+        redraw = false,
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -606,6 +650,7 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
                 left = 1001,
                 right = 1002,
             },
+            columns = 1,
         },
     })
     Helpers.expect.state(child, "tabs[2]", vim.NIL)

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -24,7 +24,7 @@ T["tabs"]["keeps the active tab in state"] = function()
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "activeTab", 2)
 end
@@ -37,7 +37,7 @@ T["tabs"]["new tab doesn't have side buffers"] = function()
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
 end
@@ -79,13 +79,13 @@ T["tabs"]["previous tab kept side buffers if enabled"] = function()
 
     -- tab 2
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
 
     -- tab 1
     child.cmd("tabprevious")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "activeTab", 1)
@@ -95,7 +95,7 @@ T["TabNewEntered"] = MiniTest.new_set()
 
 T["TabNewEntered"]["starts the plugin on new tab"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "enabled", true)
 
@@ -106,7 +106,7 @@ T["TabNewEntered"]["starts the plugin on new tab"] = function()
 
     -- tab 2
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "activeTab", 2)
 
@@ -115,7 +115,7 @@ end
 
 T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "enabled", true)
 
@@ -126,7 +126,7 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
 
     -- tab 2
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 2)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
@@ -138,12 +138,12 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
 
     -- tab 1
     child.cmd("tabprevious")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 1)
 
     -- tab 2
     child.cmd("tabnext")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 2)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
@@ -153,37 +153,37 @@ T["tabnew/tabclose"] = MiniTest.new_set()
 
 T["tabnew/tabclose"]["opening and closing tabs does not throw any error"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 2)
 
     child.cmd("tabclose")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 4)
 
     child.cmd("tabclose")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 3)
 
     child.cmd("tabclose")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 1)
 end
 
 T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
-    Helpers.wait(child)
+    child.wait()
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 1)
@@ -205,7 +205,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     })
 
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
@@ -238,7 +238,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     })
 
     child.cmd("tabclose")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
@@ -259,7 +259,7 @@ end
 
 T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
-    Helpers.wait(child)
+    child.wait()
 
     child.cmd("badd 1")
     Helpers.expect.state(child, "enabled", true)
@@ -282,9 +282,9 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     })
 
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
     child.cmd("badd 2")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs", {
@@ -369,7 +369,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     })
 
     child.cmd("tabprevious")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 1)
     Helpers.expect.state(child, "tabs", {
         {
@@ -403,7 +403,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     })
 
     child.cmd("tabprevious")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.state(child, "activeTab", 2)
 end
 
@@ -416,7 +416,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     child.cmd("badd 1")
 
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     child.cmd("badd 2")
 
@@ -443,7 +443,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     })
 
     child.cmd("tabprevious")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 1)
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.state(child, "enabled", true)
@@ -531,7 +531,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     child.cmd("badd 1")
 
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     child.cmd("badd 2")
 
@@ -558,7 +558,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     })
 
     child.cmd("tabprevious")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 1)
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.state(child, "enabled", true)
@@ -566,7 +566,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnext")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     Helpers.expect.state(child, "activeTab", 2)
@@ -599,7 +599,7 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
     Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
 
     child.cmd("tabnew")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     Helpers.toggle(child)
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
@@ -636,7 +636,7 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
     })
 
     child.cmd("q")
-    Helpers.wait(child)
+    child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 1)
     Helpers.expect.state(child, "activeTab", 1)
     Helpers.expect.state(child, "tabs[1]", {

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -199,7 +199,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
     })
@@ -218,7 +218,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
         {
@@ -232,7 +232,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1004,
                     right = 1005,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
     })
@@ -251,7 +251,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
     })
@@ -276,7 +276,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
     })
@@ -299,7 +299,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
         {
@@ -313,7 +313,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1004,
                     right = 1005,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
     })
@@ -331,7 +331,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
     })
@@ -349,7 +349,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
         {
@@ -363,7 +363,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1006,
                     right = 1007,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
     })
@@ -383,7 +383,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
         {
@@ -397,7 +397,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1006,
                     right = 1007,
                 },
-                columns = 1,
+                columns = 3,
             },
         },
     })
@@ -438,7 +438,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1002,
                 right = 1003,
             },
-            columns = 1,
+            columns = 3,
         },
     })
 
@@ -503,7 +503,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1004,
                 right = 1005,
             },
-            columns = 1,
+            columns = 3,
         },
     })
     Helpers.expect.state(child, "tabs[2]", {
@@ -517,7 +517,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1002,
                 right = 1003,
             },
-            columns = 1,
+            columns = 3,
         },
     })
 end
@@ -553,7 +553,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
                 left = 1002,
                 right = 1003,
             },
-            columns = 1,
+            columns = 3,
         },
     })
 
@@ -583,7 +583,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
                 left = 1002,
                 right = 1003,
             },
-            columns = 1,
+            columns = 3,
         },
     })
 
@@ -616,7 +616,7 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
                 left = 1001,
                 right = 1002,
             },
-            columns = 1,
+            columns = 3,
         },
     })
     Helpers.expect.state(child, "activeTab", 2)
@@ -631,7 +631,7 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
                 left = 1004,
                 right = 1005,
             },
-            columns = 1,
+            columns = 3,
         },
     })
 
@@ -650,7 +650,7 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
                 left = 1001,
                 right = 1002,
             },
-            columns = 1,
+            columns = 3,
         },
     })
     Helpers.expect.state(child, "tabs[2]", vim.NIL)

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -588,7 +588,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     })
 
     Helpers.toggle(child)
-    Helpers.expect.state(child, "tabs", vim.NIL)
+    Helpers.expect.state(child, "tabs", {})
 end
 
 T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] = function()

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -107,8 +107,6 @@ T["TabNewEntered"]["starts the plugin on new tab"] = function()
     Helpers.expect.state(child, "activeTab", 2)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
-
-    child.stop()
 end
 
 T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
@@ -143,8 +141,6 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
     Helpers.expect.state(child, "activeTab", 2)
 
     Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
-
-    child.stop()
 end
 
 T["tabnew/tabclose"] = MiniTest.new_set()

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -185,10 +185,6 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -197,6 +193,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1001,
                     right = 1002,
                 },
+                vsplits = 1,
             },
         },
     })
@@ -206,10 +203,6 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -218,14 +211,11 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1001,
                     right = 1002,
                 },
+                vsplits = 1,
             },
         },
         {
             id = 2,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -234,6 +224,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1004,
                     right = 1005,
                 },
+                vsplits = 1,
             },
         },
     })
@@ -242,10 +233,6 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -254,6 +241,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1001,
                     right = 1002,
                 },
+                vsplits = 1,
             },
         },
     })
@@ -269,10 +257,6 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -281,6 +265,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
+                vsplits = 1,
             },
         },
     })
@@ -293,10 +278,6 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -305,14 +286,11 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
+                vsplits = 1,
             },
         },
         {
             id = 2,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -321,6 +299,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1004,
                     right = 1005,
                 },
+                vsplits = 3,
             },
         },
     })
@@ -329,10 +308,6 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -341,6 +316,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
+                vsplits = 1,
             },
         },
     })
@@ -349,10 +325,6 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -361,14 +333,11 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
+                vsplits = 1,
             },
         },
         {
             id = 2,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -377,6 +346,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1006,
                     right = 1007,
                 },
+                vsplits = 3,
             },
         },
     })
@@ -386,10 +356,6 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -398,14 +364,11 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
+                vsplits = 1,
             },
         },
         {
             id = 2,
-            layers = {
-                split = 1,
-                vsplit = 1,
-            },
             scratchPadEnabled = false,
             wins = {
                 integrations = Co.INTEGRATIONS,
@@ -414,6 +377,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1006,
                     right = 1007,
                 },
+                vsplits = 3,
             },
         },
     })
@@ -443,10 +407,6 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -455,6 +415,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1002,
                 right = 1003,
             },
+            vsplits = 1,
         },
     })
 
@@ -468,10 +429,6 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     Helpers.toggle(child)
     Helpers.expect.state(child, "tabs[1]", {
         id = 1,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = {
@@ -521,14 +478,11 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1004,
                 right = 1005,
             },
+            vsplits = 3,
         },
     })
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -537,6 +491,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1002,
                 right = 1003,
             },
+            vsplits = 1,
         },
     })
 end
@@ -562,10 +517,6 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -592,10 +543,6 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     Helpers.expect.state(child, "tabs[1]", vim.NIL)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -626,10 +573,6 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1]", {
         id = 1,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -643,10 +586,6 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
     Helpers.expect.state(child, "activeTab", 2)
     Helpers.expect.state(child, "tabs[2]", {
         id = 2,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,
@@ -663,10 +602,6 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
     Helpers.expect.state(child, "activeTab", 1)
     Helpers.expect.state(child, "tabs[1]", {
         id = 1,
-        layers = {
-            split = 1,
-            vsplit = 1,
-        },
         scratchPadEnabled = false,
         wins = {
             integrations = Co.INTEGRATIONS,

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -189,7 +189,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                vsplits = 1,
+                columns = 1,
             },
         },
     })
@@ -207,7 +207,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                vsplits = 1,
+                columns = 1,
             },
         },
         {
@@ -220,7 +220,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1004,
                     right = 1005,
                 },
-                vsplits = 1,
+                columns = 1,
             },
         },
     })
@@ -237,7 +237,7 @@ T["tabnew/tabclose"]["doesn't keep closed tabs in state"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                vsplits = 1,
+                columns = 1,
             },
         },
     })
@@ -261,7 +261,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                vsplits = 1,
+                columns = 1,
             },
         },
     })
@@ -282,7 +282,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                vsplits = 1,
+                columns = 1,
             },
         },
         {
@@ -295,7 +295,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1004,
                     right = 1005,
                 },
-                vsplits = 3,
+                columns = 3,
             },
         },
     })
@@ -312,7 +312,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                vsplits = 1,
+                columns = 1,
             },
         },
     })
@@ -329,7 +329,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                vsplits = 1,
+                columns = 1,
             },
         },
         {
@@ -342,7 +342,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1006,
                     right = 1007,
                 },
-                vsplits = 3,
+                columns = 3,
             },
         },
     })
@@ -360,7 +360,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1001,
                     right = 1002,
                 },
-                vsplits = 1,
+                columns = 1,
             },
         },
         {
@@ -373,7 +373,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
                     left = 1006,
                     right = 1007,
                 },
-                vsplits = 3,
+                columns = 3,
             },
         },
     })
@@ -411,7 +411,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1002,
                 right = 1003,
             },
-            vsplits = 1,
+            columns = 1,
         },
     })
 
@@ -474,7 +474,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1004,
                 right = 1005,
             },
-            vsplits = 3,
+            columns = 3,
         },
     })
     Helpers.expect.state(child, "tabs[2]", {
@@ -487,7 +487,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
                 left = 1002,
                 right = 1003,
             },
-            vsplits = 1,
+            columns = 1,
         },
     })
 end


### PR DESCRIPTION
## 📃 Summary

the custom logic for vsplit handling has reached its limits, it's now impossible to handle every edge cases and might make the user experience clunky.

This winlayout refactoring aims at increasing consistency by considering nvim as the source of truth, as it should be. Leveraging also allows the plugin to avoid debouncing and concurrent refreshes in order to wait for the ui to be refreshed, we can now just evaluate the API instantly.

This also unlocks nnp buffers to be CONSISTENTLY on both sides, where they should always be.

supersede https://github.com/shortcuts/no-neck-pain.nvim/pull/374
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/368