### PR TITLE
feat: add mini.starter dashboard to constants

### DIFF
--- a/lua/no-neck-pain/util/constants.lua
+++ b/lua/no-neck-pain/util/constants.lua
@@ -82,6 +82,6 @@ Co.INTEGRATIONS = {
 ---Dashboards filetypes that delays the plugin enable step until next buffer entered.
 ---
 ---@private
-Co.DASHBOARDS = { "dashboard", "alpha", "ministarter" }
+Co.DASHBOARDS = { "dashboard", "alpha", "starter" }
 
 return Co

--- a/lua/no-neck-pain/util/constants.lua
+++ b/lua/no-neck-pain/util/constants.lua
@@ -82,6 +82,6 @@ Co.INTEGRATIONS = {
 ---Dashboards filetypes that delays the plugin enable step until next buffer entered.
 ---
 ---@private
-Co.DASHBOARDS = { "dashboard", "alpha" }
+Co.DASHBOARDS = { "dashboard", "alpha", "ministarter" }
 
 return Co


### PR DESCRIPTION
## 📃 Summary

<!-- Provide some context about the pull request, it makes the review easier. -->
I use mini.starter as a dashboard and I enjoy your plugin very much. This fixes the integration between them.
Thanks for reviewing!

## 📸 Preview

Before change:
<img width="1788" alt="Screenshot 2024-08-15 at 10 36 18 PM" src="https://github.com/user-attachments/assets/e91f34bc-4c62-4782-9253-052a03d6268e">

After change:
<img width="1786" alt="Screenshot 2024-08-15 at 10 37 18 PM" src="https://github.com/user-attachments/assets/9ace1160-378d-4421-a48f-7605c35b6681">


