### PR TITLE
chore: rework test helpers

### DIFF
--- a/scripts/init_with_aerial.lua
+++ b/scripts/init_with_aerial.lua
@@ -7,7 +7,7 @@ vim.cmd("set rtp+=deps/aerial")
 
 require("mini.test").setup()
 require("no-neck-pain").setup({
-    debug=true,
+    debug = true,
     width = 20,
     minSideBufferWidth = 0,
     integrations = { aerial = { reopen = true } },

--- a/scripts/init_with_tsplayground.lua
+++ b/scripts/init_with_tsplayground.lua
@@ -10,4 +10,4 @@ require("nvim-treesitter.configs").setup({
     },
 })
 require("mini.test").setup()
-require("no-neck-pain").setup({ debug=true, width = 1 })
+require("no-neck-pain").setup({ debug = true, width = 1 })

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -4,25 +4,6 @@ local Helpers = {}
 -- Add extra expectations
 Helpers.expect = vim.deepcopy(MiniTest.expect)
 
-function Helpers.toggle(child)
-    child.cmd("NoNeckPain")
-    child.wait()
-end
-
-function Helpers.currentWin(child)
-    return child.lua_get("vim.api.nvim_get_current_win()")
-end
-
-function Helpers.winsInTab(child, tab)
-    tab = tab or "_G.NoNeckPain.state.activeTab"
-
-    return child.lua_get("vim.api.nvim_tabpage_list_wins(" .. tab .. ")")
-end
-
-function Helpers.listBuffers(child)
-    return child.lua_get("vim.api.nvim_list_bufs()")
-end
-
 local function errorMessage(str, pattern)
     return string.format("Pattern: %s\nObserved string: %s", vim.inspect(pattern), str)
 end
@@ -108,12 +89,31 @@ Helpers.new_child_neovim = function()
         child.loop.sleep(10)
     end
 
+    child.nnp = function()
+        child.cmd("NoNeckPain")
+        child.wait()
+    end
+
+    child.get_wins_in_tab = function(tab)
+        tab = tab or "_G.NoNeckPain.state.activeTab"
+
+        return child.lua_get("vim.api.nvim_tabpage_list_wins(" .. tab .. ")")
+    end
+
+    child.list_buffers = function()
+        return child.lua_get("vim.api.nvim_list_bufs()")
+    end
+
     child.setup = function()
         child.restart({ "-u", "scripts/minimal_init.lua" })
 
         -- Change initial buffer to be readonly. This not only increases execution
         -- speed, but more closely resembles manually opened Neovim.
         child.bo.readonly = false
+    end
+
+    child.get_current_win = function()
+        return child.lua_get("vim.api.nvim_get_current_win()")
     end
 
     child.set_lines = function(arr, start, finish)

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -214,7 +214,7 @@ T["setup"]["starts the plugin on VimEnter"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "enabled", true)
 end
 
@@ -222,7 +222,7 @@ T["enable"] = MiniTest.new_set()
 
 T["enable"]["(single tab) sets state"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     -- state
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
@@ -251,7 +251,7 @@ end
 
 T["enable"]["(multiple tab) sets state"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     -- tab 1
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
@@ -278,7 +278,7 @@ T["enable"]["(multiple tab) sets state"] = function()
 
     -- tab 2
     child.cmd("tabnew")
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 2)
@@ -304,7 +304,7 @@ end
 T["disable"] = MiniTest.new_set()
 
 T["disable"]["(single tab) resets state"] = function()
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
 
@@ -313,7 +313,7 @@ T["disable"]["(single tab) resets state"] = function()
 
     Helpers.expect.state_type(child, "tabs", "table")
 
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
 
@@ -324,7 +324,7 @@ T["disable"]["(single tab) resets state"] = function()
 end
 
 T["disable"]["(multiple tab) resets state"] = function()
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
 
@@ -334,7 +334,7 @@ T["disable"]["(multiple tab) resets state"] = function()
     Helpers.expect.state_type(child, "tabs", "table")
 
     child.cmd("tabnew")
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
 
@@ -344,7 +344,7 @@ T["disable"]["(multiple tab) resets state"] = function()
     Helpers.expect.state_type(child, "tabs", "table")
 
     -- disable tab 2
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "activeTab", 2)
@@ -353,7 +353,7 @@ T["disable"]["(multiple tab) resets state"] = function()
 
     -- disable tab 1
     child.cmd("tabprevious")
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "enabled", false)
     Helpers.expect.state(child, "activeTab", 1)
@@ -363,7 +363,7 @@ end
 
 T["disable"]["(no file) does not close the window if unsaved buffer"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -371,12 +371,12 @@ T["disable"]["(no file) does not close the window if unsaved buffer"] = function
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3 })
+    Helpers.expect.equality(child.list_buffers(), { 1, 2, 3 })
 
     child.api.nvim_buf_set_lines(1, 0, 1, false, { "foo" })
     Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(1, 'modified')"), true)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.equality(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
 
     child.cmd("quit")
@@ -387,7 +387,7 @@ end
 T["disable"]["(on file) does not close the window if unsaved buffer"] = function()
     child.restart({ "-u", "scripts/minimal_init.lua", "lua/no-neck-pain/main.lua" })
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -395,12 +395,12 @@ T["disable"]["(on file) does not close the window if unsaved buffer"] = function
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3 })
+    Helpers.expect.equality(child.list_buffers(), { 1, 2, 3 })
 
     child.api.nvim_buf_set_lines(1, 0, 1, false, { "foo" })
     Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(1, 'modified')"), true)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.equality(child.lua_get("vim.api.nvim_get_current_win()"), 1000)
 
     child.cmd("quit")
@@ -417,7 +417,7 @@ T["disable"]["relative window doesn't prevent quitting nvim"] = function()
 
     child.restart({ "-u", "scripts/init_with_incline.lua" })
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -425,14 +425,14 @@ T["disable"]["relative window doesn't prevent quitting nvim"] = function()
         left = 1003,
         right = 1004,
     })
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1000, 1004, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1003, 1000, 1004, 1002 })
     vim.fn.win_gotoid(1000)
 
     child.cmd("quit")
 
     Helpers.expect.error(function()
         -- error because instance is closed
-        Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1000, 1004, 1002 })
+        Helpers.expect.equality(child.get_wins_in_tab(), { 1003, 1000, 1004, 1002 })
     end)
 end
 

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -18,9 +18,9 @@ T["auto command"] = MiniTest.new_set()
 
 T["auto command"]["does not create side buffers window's width < options.width"] = function()
     child.lua([[ require('no-neck-pain').setup({width=1000}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1000 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
     })
@@ -28,7 +28,7 @@ end
 
 T["auto command"]["disabling clears VimEnter autocmd"] = function()
     child.restart({ "-u", "scripts/init_auto_open.lua" })
-    Helpers.toggle(child)
+    child.nnp()
     child.wait()
 
     -- errors because it doesn't exist
@@ -39,9 +39,9 @@ end
 
 T["auto command"]["does not shift when opening/closing float window"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -57,7 +57,7 @@ T["auto command"]["does not shift when opening/closing float window"] = function
         { width = 100, height = 100, relative = "cursor", row = 0, col = 0 }
     )
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002, 1003 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002, 1003 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -71,7 +71,7 @@ T["auto command"]["does not shift when opening/closing float window"] = function
     child.fn.win_gotoid(1003)
     child.cmd("q")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -88,11 +88,11 @@ T["skipEnteringNoNeckPainBuffer"]["goes to new valid buffer when entering side"]
     child.lua(
         [[ require('no-neck-pain').setup({width=50, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.config(child, "autocmds.skipEnteringNoNeckPainBuffer", true)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1001)
@@ -105,7 +105,7 @@ T["skipEnteringNoNeckPainBuffer"]["goes to new valid buffer when entering side"]
 
     child.cmd("split")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
 
     child.fn.win_gotoid(1000)
@@ -129,13 +129,13 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     child.lua(
         [[ require('no-neck-pain').setup({width=50, buffers = { scratchPad = { enabled = true } }, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.config(child, "buffers.left.scratchPad.enabled", true)
     Helpers.expect.config(child, "buffers.right.scratchPad.enabled", true)
     Helpers.expect.config(child, "autocmds.skipEnteringNoNeckPainBuffer", true)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1001)
@@ -147,13 +147,13 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     child.lua(
         [[ require('no-neck-pain').setup({width=50, buffers = { left = { scratchPad = { enabled = true } } }, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.config(child, "buffers.left.scratchPad.enabled", true)
     Helpers.expect.config(child, "buffers.right.scratchPad.enabled", false)
     Helpers.expect.config(child, "autocmds.skipEnteringNoNeckPainBuffer", true)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1001)
@@ -165,13 +165,13 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     child.lua(
         [[ require('no-neck-pain').setup({width=50, buffers = { right = { scratchPad = { enabled = true } } }, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.config(child, "buffers.left.scratchPad.enabled", false)
     Helpers.expect.config(child, "buffers.right.scratchPad.enabled", true)
     Helpers.expect.config(child, "autocmds.skipEnteringNoNeckPainBuffer", true)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 
     child.fn.win_gotoid(1001)

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -195,7 +195,7 @@ T["curr"] = MiniTest.new_set()
 
 T["curr"]["have the default width"] = function()
     child.lua([[ require('no-neck-pain').setup() ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     -- need to know why the child isn't precise enough
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 80)
@@ -203,7 +203,7 @@ end
 
 T["curr"]["have the width from the config"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     -- need to know why the child isn't precise enough
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
@@ -211,16 +211,16 @@ end
 
 T["curr"]["closing `curr` window without any other window quits Neovim"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main.curr", 1000)
 
     child.cmd("q")
 
     -- neovim is closed, so it errors
     Helpers.expect.error(function()
-        Helpers.winsInTab(child)
+        child.get_wins_in_tab()
     end)
 end
 
@@ -230,14 +230,14 @@ T["left/right"]["setNames doesn't throw when re-creating side buffers"] = functi
     child.lua([[require('no-neck-pain').setup({width=50, buffers={setNames=true}})]])
 
     -- enable
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
 
     -- toggle
-    Helpers.toggle(child)
-    Helpers.toggle(child)
+    child.nnp()
+    child.nnp()
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
@@ -245,7 +245,7 @@ end
 
 T["left/right"]["have the same width"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
@@ -253,7 +253,7 @@ end
 
 T["left/right"]["only creates a `left` buffer when `right.enabled` is `false`"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50,buffers={right={enabled=false}}}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -265,7 +265,7 @@ end
 
 T["left/right"]["only creates a `right` buffer when `left.enabled` is `false`"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50,buffers={left={enabled=false}}}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -277,9 +277,9 @@ end
 
 T["left/right"]["closing the `left` buffer disables NNP"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -289,14 +289,14 @@ T["left/right"]["closing the `left` buffer disables NNP"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.left)")
     child.cmd("q")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1000 })
 end
 
 T["left/right"]["closing the `right` buffer disables NNP"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -306,7 +306,7 @@ T["left/right"]["closing the `right` buffer disables NNP"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.right)")
     child.cmd("q")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1000 })
 end
 
 return T

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -120,7 +120,7 @@ T["setup"]["`common` options spreads it to `left` and `right` buffers"] = functi
             },
         }})
     ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "enabled", true)
 
@@ -168,7 +168,7 @@ T["setup"]["(transparent) assert side buffers have the same colors as the main b
         highlight NonText ctermbg=none
     ]])
     child.lua([[ require('no-neck-pain').setup() ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.curr)")
     local currbg = child.lua_get("vim.api.nvim_get_hl_by_name('Normal', true).background")
@@ -187,7 +187,7 @@ end
 T["setup"]["(normal) assert side buffers have the same colors as the main buffer"] = function()
     child.cmd([[colorscheme blue]])
     child.lua([[ require('no-neck-pain').setup() ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.curr)")
     local currbg = child.lua_get("vim.api.nvim_get_hl_by_name('Normal', true).background")
@@ -270,7 +270,7 @@ T["color"]["refreshes the stored color when changing colorscheme"] = function()
     child.lua(
         [[ require('no-neck-pain').setup({ autocmds = { reloadOnColorSchemeChange=true } }) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.config(child, "buffers.colors", { blend = 0 })
 

--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -17,15 +17,15 @@ local T = MiniTest.new_set({
 T["commands"] = MiniTest.new_set()
 
 T["commands"]["NoNeckPain toggles the plugin state"] = function()
-    Helpers.toggle(child)
+    child.nnp()
     Helpers.expect.state(child, "enabled", true)
 
-    Helpers.toggle(child)
+    child.nnp()
     Helpers.expect.state(child, "enabled", false)
 end
 
 T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = function()
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -47,7 +47,7 @@ T["commands"]["NoNeckPainResize throws with the plugin disabled"] = function()
 end
 
 T["commands"]["NoNeckPainResize does nothing with the same width"] = function()
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -63,7 +63,7 @@ T["commands"]["NoNeckPainResize does nothing with the same width"] = function()
 end
 
 T["commands"]["NoNeckPainWidthUp increases the width by 5"] = function()
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -88,7 +88,7 @@ T["commands"]["NoNeckPainWidthUp increases the width by N when mappings.widthUp 
         }
     })]])
 
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -107,7 +107,7 @@ T["commands"]["NoNeckPainWidthUp increases the width by N when mappings.widthUp 
 end
 
 T["commands"]["NoNeckPainWidthUp decreases the width by 5"] = function()
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
@@ -132,7 +132,7 @@ T["commands"]["NoNeckPainWidthUp decreases the width by N when mappings.widthDow
         }
     })]])
 
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -125,10 +125,10 @@ T["nvimdapui"]["keeps sides open"] = function()
 
     child.restart({ "-u", "scripts/init_with_nvimdapui.lua" })
 
-    Helpers.toggle(child)
+    child.nnp()
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -139,7 +139,7 @@ T["nvimdapui"]["keeps sides open"] = function()
     child.wait()
 
     Helpers.expect.equality(
-        Helpers.winsInTab(child),
+        child.get_wins_in_tab(),
         { 1001, 1010, 1009, 1008, 1007, 1000, 1006, 1003, 1002 }
     )
 
@@ -163,9 +163,9 @@ T["neotest"]["keeps sides open"] = function()
 
     child.restart({ "-u", "scripts/init_with_neotest.lua", "lua/no-neck-pain/main.lua" })
 
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -190,9 +190,9 @@ T["outline"] = MiniTest.new_set()
 T["outline"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_outline.lua", "lua/no-neck-pain/main.lua" })
 
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -224,9 +224,9 @@ T["NvimTree"]["keeps sides open"] = function()
 
     child.restart({ "-u", "scripts/init_with_nvimtree.lua", "foo" })
 
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -237,7 +237,7 @@ T["NvimTree"]["keeps sides open"] = function()
 
     child.cmd([[NvimTreeOpen]])
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1001, 1000, 1002 })
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -261,9 +261,9 @@ T["neo-tree"] = MiniTest.new_set()
 T["neo-tree"]["keeps sides open"] = function()
     child.restart({ "-u", "scripts/init_with_neotree.lua", "foo" })
 
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -275,7 +275,7 @@ T["neo-tree"]["keeps sides open"] = function()
     child.cmd([[Neotree reveal]])
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1004, 1000, 1002 })
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -305,9 +305,9 @@ T["TSPlayground"]["keeps sides open"] = function()
 
     child.restart({ "-u", "scripts/init_with_tsplayground.lua" })
 
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -369,10 +369,10 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
             },
         })
     ]])
-    Helpers.toggle(child)
+    child.nnp()
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000 })
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1].wins.main", {
@@ -432,9 +432,9 @@ T["aerial"]["keeps sides open"] = function()
 
     child.restart({ "-u", "scripts/init_with_aerial.lua" })
 
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1].wins.main", {

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -184,10 +184,10 @@ end
 
 T["setup"]["increase the width with mapping"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50,mappings={enabled=true,widthUp="nn"}}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.api.nvim_input("nn")
     child.api.nvim_input("nn")
@@ -201,10 +201,10 @@ T["setup"]["increase the width with custom mapping and value"] = function()
     child.lua(
         [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,widthUp={mapping="nn", value=10}}}) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.api.nvim_input("nn")
     child.api.nvim_input("nn")
@@ -242,10 +242,10 @@ T["setup"]["decrease the width with mapping"] = function()
     child.lua(
         [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown="nn"}}) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.api.nvim_input("nn")
     child.api.nvim_input("nn")
@@ -259,10 +259,10 @@ T["setup"]["decrease the width with custom mapping and value"] = function()
     child.lua(
         [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,widthDown={mapping="nn",value=7}}}) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 50)
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.api.nvim_input("nn")
     child.api.nvim_input("nn")
@@ -276,7 +276,7 @@ T["setup"]["toggles scratchPad"] = function()
     child.lua(
         [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,scratchPad="ns"}}) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.left.scratchPad.enabled", false)
     Helpers.expect.global(child, "_G.NoNeckPain.config.buffers.right.scratchPad.enabled", false)
@@ -294,7 +294,7 @@ T["setup"]["toggle sides and disable if none"] = function()
     child.lua(
         [[ require('no-neck-pain').setup({width=50,mappings={enabled=true,toggleLeftSide="nl",toggleRightSide="nr"}}) ]]
     )
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,

--- a/tests/test_options.lua
+++ b/tests/test_options.lua
@@ -18,7 +18,7 @@ T["minSideBufferWidth"] = MiniTest.new_set()
 
 T["minSideBufferWidth"]["closes side buffer respecting the given value"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
 
@@ -29,7 +29,7 @@ T["minSideBufferWidth"]["closes side buffer respecting the given value"] = funct
         require('no-neck-pain').disable()
         require('no-neck-pain').setup({width=50, minSideBufferWidth=20})
     ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000 })
 end
@@ -38,21 +38,21 @@ T["killAllBuffersOnDisable"] = MiniTest.new_set()
 
 T["killAllBuffersOnDisable"]["closes every windows when disabling the plugin"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20,killAllBuffersOnDisable=true}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
 
-    Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3 })
+    Helpers.expect.equality(child.list_buffers(), { 1, 2, 3 })
     child.cmd("badd 1")
     child.cmd("vsplit")
     child.cmd("split")
-    Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3, 4 })
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.list_buffers(), { 1, 2, 3, 4 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1004, 1003, 1000, 1002 })
 
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.listBuffers(child), { 1, 2, 3, 4 })
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1000 })
+    Helpers.expect.equality(child.list_buffers(), { 1, 2, 3, 4 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1000 })
 end
 
 T["fallbackOnBufferDelete"] = MiniTest.new_set()
@@ -61,7 +61,7 @@ T["fallbackOnBufferDelete"]["invoking :bd keeps nnp enabled"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true}) ]])
 
     Helpers.expect.config(child, "fallbackOnBufferDelete", true)
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
 
@@ -74,7 +74,7 @@ end
 
 T["fallbackOnBufferDelete"]["still allows nvim to quit"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
 

--- a/tests/test_scratchpad.lua
+++ b/tests/test_scratchpad.lua
@@ -70,8 +70,8 @@ T["scratchPad"]["default to `norg` fileType"] = function()
             }
         },
     })]])
-    Helpers.toggle(child)
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    child.nnp()
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/no-neck-pain-left.norg"
@@ -115,9 +115,9 @@ T["scratchPad"]["override of filetype is reflected to the buffer"] = function()
             }
         },
     })]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/no-neck-pain-left.md"
@@ -159,9 +159,9 @@ T["scratchPad"]["side buffer can have their own definition"] = function()
             }
         },
     })]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/lua/no-neck-pain-left.norg"
@@ -202,9 +202,9 @@ T["scratchPad"]["side buffer definition overrides global one"] = function()
             },
         },
     })]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     local cwd = child.lua_get("vim.fn.getcwd()")
     local left = cwd .. "/lua/no-neck-pain-left.norg"
@@ -242,9 +242,9 @@ T["scratchPad"]["forwards the given filetype to the scratchPad"] = function()
             },
         },
     })]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     Helpers.expect.config(child, "buffers.left.bo.filetype", "custom")
     Helpers.expect.config(child, "buffers.right.bo.filetype", "custom")
@@ -264,9 +264,9 @@ T["scratchPad"]["toggling the scratchPad sets the buffer/window options"] = func
         buffers = { scratchPad = { enabled = false }, },
         mappings = { scratchPad = "foo" },
     })]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.fn.win_gotoid(1001)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_buf_get_option(0, 'buflisted')"), false)

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -18,30 +18,30 @@ T["split"] = MiniTest.new_set()
 
 T["split"]["only one side buffer, closing help doesn't close NNP"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20, buffers={right={enabled=false}}}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000 })
 
     child.cmd("h")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1002, 1001, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1002, 1001, 1000 })
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001 })
 
     child.lua("vim.fn.win_gotoid(1002)")
     child.cmd("q")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
-    Helpers.expect.equality(Helpers.currentWin(child), 1000)
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000 })
+    Helpers.expect.equality(child.get_current_win(), 1000)
     Helpers.expect.state(child, "enabled", true)
 end
 
 T["split"]["closing `curr` makes `split` the new `curr`"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     child.cmd("split")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -51,17 +51,17 @@ T["split"]["closing `curr` makes `split` the new `curr`"] = function()
     child.lua("vim.fn.win_gotoid(_G.NoNeckPain.state.tabs[1].wins.main.curr)")
     child.cmd("q")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1002 })
-    Helpers.expect.equality(Helpers.currentWin(child), 1003)
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1002 })
+    Helpers.expect.equality(child.get_current_win(), 1003)
 end
 
 T["split"]["keeps side buffers"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     child.cmd("split")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -71,34 +71,34 @@ T["split"]["keeps side buffers"] = function()
     child.lua("vim.fn.win_gotoid(1003)")
     child.cmd("q")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 28)
 end
 
 T["split"]["keeps correct focus"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.currentWin(child), 1000)
-
-    child.cmd("split")
-    Helpers.expect.equality(Helpers.currentWin(child), 1003)
+    Helpers.expect.equality(child.get_current_win(), 1000)
 
     child.cmd("split")
-    Helpers.expect.equality(Helpers.currentWin(child), 1004)
+    Helpers.expect.equality(child.get_current_win(), 1003)
 
     child.cmd("split")
-    Helpers.expect.equality(Helpers.currentWin(child), 1005)
+    Helpers.expect.equality(child.get_current_win(), 1004)
+
+    child.cmd("split")
+    Helpers.expect.equality(child.get_current_win(), 1005)
 
     child.cmd("q")
-    Helpers.expect.equality(Helpers.currentWin(child), 1004)
+    Helpers.expect.equality(child.get_current_win(), 1004)
 
     child.cmd("q")
-    Helpers.expect.equality(Helpers.currentWin(child), 1003)
+    Helpers.expect.equality(child.get_current_win(), 1003)
 
     child.cmd("q")
-    Helpers.expect.equality(Helpers.currentWin(child), 1000)
+    Helpers.expect.equality(child.get_current_win(), 1000)
 end
 
 T["vsplit"] = MiniTest.new_set()
@@ -108,28 +108,28 @@ T["vsplit"]["does not create side buffers when there's not enough space"] = func
     child.cmd("vsplit")
     child.cmd("vsplit")
 
-    Helpers.expect.equality(Helpers.winsInTab(child, 1), { 1003, 1002, 1001, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(1), { 1003, 1002, 1001, 1000 })
 
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1002, 1001, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1003, 1002, 1001, 1000 })
 end
 
 T["vsplit"]["correctly size splits when opening helper with side buffers open"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     child.cmd("vsplit")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 19)
 
     child.cmd("h")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
@@ -138,34 +138,34 @@ end
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
     child.cmd("vsplit")
 
-    Helpers.expect.equality(Helpers.winsInTab(child, 1), { 1001, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(1), { 1001, 1000 })
 
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1002, 1001, 1000, 1003 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1002, 1001, 1000, 1003 })
 end
 
 T["vsplit"]["preserve vsplit width when having side buffers"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20,buffers={right={enabled=false}}}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000 })
 
     child.cmd("vsplit")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1002, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1002, 1000 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 26)
 end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     child.cmd("vsplit")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -180,15 +180,15 @@ T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
         left = 1001,
         right = 1002,
     })
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1002 })
-    Helpers.expect.equality(Helpers.currentWin(child), 1003)
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1002 })
+    Helpers.expect.equality(child.get_current_win(), 1003)
 end
 
 T["vsplit"]["hides side buffers"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50,minSideBufferWidth=0}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1001,
@@ -198,13 +198,13 @@ T["vsplit"]["hides side buffers"] = function()
     child.cmd("vsplit")
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1003, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1003, 1000 })
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000 })
 
     child.lua("vim.fn.win_gotoid(1003)")
     child.cmd("q")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1000, 1005 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1000, 1005 })
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
         left = 1004,
@@ -215,19 +215,19 @@ end
 
 T["vsplit"]["many vsplit leave side buffers open as long as there's space for it"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.cmd("vsplit")
     child.cmd("vsplit")
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1003, 1000 })
 
     child.cmd("q")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1003, 1000, 1006 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1005, 1003, 1000, 1006 })
     Helpers.expect.state(child, "tabs[_G.NoNeckPain.state.activeTab].wins.main", {
         curr = 1000,
         left = 1005,
@@ -237,17 +237,17 @@ end
 
 T["vsplit"]["keeps correct focus"] = function()
     child.lua([[ require('no-neck-pain').setup({width=10}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.currentWin(child), 1000)
-
-    child.cmd("vsplit")
-    Helpers.expect.equality(Helpers.currentWin(child), 1003)
+    Helpers.expect.equality(child.get_current_win(), 1000)
 
     child.cmd("vsplit")
-    Helpers.expect.equality(Helpers.currentWin(child), 1004)
+    Helpers.expect.equality(child.get_current_win(), 1003)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
+    child.cmd("vsplit")
+    Helpers.expect.equality(child.get_current_win(), 1004)
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1004, 1003, 1000, 1002 })
 end
 
 T["vsplit/split"] = MiniTest.new_set()
@@ -255,29 +255,29 @@ T["vsplit/split"] = MiniTest.new_set()
 T["vsplit/split"]["state is correctly sync'd even after many changes"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
 
-    Helpers.expect.equality(Helpers.winsInTab(child, 1), { 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(1), { 1000 })
 
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.cmd("split")
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
     child.cmd("q")
 
     child.cmd("vsplit")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1004, 1000, 1002 })
 
     child.cmd("vsplit")
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1004, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1005, 1004, 1000 })
 
     child.cmd("q")
     child.cmd("q")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1006, 1004, 1007 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1006, 1004, 1007 })
     Helpers.expect.state(child, "tabs[_G.NoNeckPain.state.activeTab].wins.main", {
         curr = 1004,
         left = 1006,
@@ -287,65 +287,65 @@ end
 
 T["vsplit/split"]["closing side buffers because of splits restores focus"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.cmd("vsplit")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
 
     child.cmd("vsplit")
     child.cmd("vsplit")
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1005, 1004, 1003, 1000 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1005, 1004, 1003, 1000 })
 
     child.cmd("q")
     child.cmd("q")
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1006, 1003, 1000, 1007 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1006, 1003, 1000, 1007 })
 
-    Helpers.expect.equality(Helpers.currentWin(child), 1000)
+    Helpers.expect.equality(child.get_current_win(), 1000)
 end
 
 T["vsplit/split"]["closing help page doens't break layout"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.cmd("split")
     child.cmd("h")
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
 
     child.cmd("q")
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.equality(Helpers.currentWin(child), 1003)
+    Helpers.expect.equality(child.get_current_win(), 1003)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
 end
 
 T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     child.lua([[ require('no-neck-pain').setup({width=20}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
-    Helpers.expect.equality(Helpers.currentWin(child), 1000)
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_current_win(), 1000)
 
     child.cmd("split")
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1003, 1000, 1002 })
-    Helpers.expect.equality(Helpers.currentWin(child), 1003)
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_current_win(), 1003)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 
     child.cmd("vsplit")
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1004, 1003, 1000, 1002 })
-    Helpers.expect.equality(Helpers.currentWin(child), 1004)
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1004, 1003, 1000, 1002 })
+    Helpers.expect.equality(child.get_current_win(), 1004)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 38)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 17)

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -19,7 +19,7 @@ T["tabs"] = MiniTest.new_set()
 
 T["tabs"]["keeps the active tab in state"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     Helpers.expect.state(child, "activeTab", 1)
 
@@ -31,63 +31,63 @@ end
 
 T["tabs"]["new tab doesn't have side buffers"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "activeTab", 1)
 
     child.cmd("tabnew")
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1003 })
 end
 
 T["tabs"]["side buffers coexist on many tabs"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     -- tab 1
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "activeTab", 1)
 
     -- tab 2
     child.cmd("tabnew")
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1003, 1005 })
     Helpers.expect.state(child, "activeTab", 2)
 
     -- tab 3
     child.cmd("tabnew")
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1007, 1006, 1008 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1007, 1006, 1008 })
     Helpers.expect.state(child, "activeTab", 3)
 
-    Helpers.expect.equality(Helpers.winsInTab(child, 1), { 1001, 1000, 1002 })
-    Helpers.expect.equality(Helpers.winsInTab(child, 2), { 1004, 1003, 1005 })
-    Helpers.expect.equality(Helpers.winsInTab(child, 3), { 1007, 1006, 1008 })
+    Helpers.expect.equality(child.get_wins_in_tab(1), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(2), { 1004, 1003, 1005 })
+    Helpers.expect.equality(child.get_wins_in_tab(3), { 1007, 1006, 1008 })
 end
 
 T["tabs"]["previous tab kept side buffers if enabled"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
-    Helpers.toggle(child)
+    child.nnp()
 
     -- tab 1
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "activeTab", 1)
 
     -- tab 2
     child.cmd("tabnew")
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1003 })
 
     -- tab 1
     child.cmd("tabprevious")
     child.wait()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "activeTab", 1)
 end
 
@@ -100,7 +100,7 @@ T["TabNewEntered"]["starts the plugin on new tab"] = function()
     Helpers.expect.state(child, "enabled", true)
 
     -- tab 1
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     Helpers.expect.state(child, "activeTab", 1)
 
@@ -110,7 +110,7 @@ T["TabNewEntered"]["starts the plugin on new tab"] = function()
 
     Helpers.expect.state(child, "activeTab", 2)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1003, 1005 })
 end
 
 T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
@@ -120,7 +120,7 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
     Helpers.expect.state(child, "enabled", true)
 
     -- tab 1
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     Helpers.expect.state(child, "activeTab", 1)
 
@@ -129,11 +129,11 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
     child.wait()
     Helpers.expect.state(child, "activeTab", 2)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1003, 1005 })
 
-    Helpers.toggle(child)
+    child.nnp()
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1003 })
     Helpers.expect.state(child, "activeTab", 2)
 
     -- tab 1
@@ -146,7 +146,7 @@ T["TabNewEntered"]["does not re-enable if the user disables it"] = function()
     child.wait()
     Helpers.expect.state(child, "activeTab", 2)
 
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1003 })
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1003 })
 end
 
 T["tabnew/tabclose"] = MiniTest.new_set()
@@ -318,7 +318,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
     })
 
-    Helpers.toggle(child)
+    child.nnp()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
@@ -336,7 +336,7 @@ T["tabnew/tabclose"]["keeps state synchronized between tabs"] = function()
         },
     })
 
-    Helpers.toggle(child)
+    child.nnp()
     Helpers.expect.state(child, "tabs", {
         {
             id = 1,
@@ -421,7 +421,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     child.cmd("badd 2")
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "nil")
-    Helpers.toggle(child)
+    child.nnp()
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.state(child, "enabled", true)
@@ -450,7 +450,7 @@ T["tabnew/tabclose"]["does not pick tab 1 for the first active tab"] = function(
     Helpers.expect.state(child, "tabs[1]", vim.NIL)
     Helpers.expect.state(child, "activeTab", 1)
 
-    Helpers.toggle(child)
+    child.nnp()
     Helpers.expect.state(child, "tabs[1]", {
         id = 1,
         redraw = false,
@@ -536,7 +536,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
     child.cmd("badd 2")
 
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "nil")
-    Helpers.toggle(child)
+    child.nnp()
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
     Helpers.expect.global_type(child, "_G.NoNeckPain.state", "table")
     Helpers.expect.state(child, "enabled", true)
@@ -587,7 +587,7 @@ T["tabnew/tabclose"]["keep state synchronized on second tab"] = function()
         },
     })
 
-    Helpers.toggle(child)
+    child.nnp()
     Helpers.expect.state(child, "tabs", {})
 end
 
@@ -595,14 +595,14 @@ T["tabnew/tabclose"]["does not close nvim when quitting tab if some are left"] =
     child.lua([[require('no-neck-pain').setup({width=50})]])
 
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 1)
-    Helpers.toggle(child)
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1001, 1000, 1002 })
+    child.nnp()
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.cmd("tabnew")
     child.wait()
     Helpers.expect.equality(child.api.nvim_get_current_tabpage(), 2)
-    Helpers.toggle(child)
-    Helpers.expect.equality(Helpers.winsInTab(child), { 1004, 1003, 1005 })
+    child.nnp()
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1003, 1005 })
 
     Helpers.expect.state(child, "enabled", true)
     Helpers.expect.state(child, "tabs[1]", {


### PR DESCRIPTION
use a more idiomatic solution for test helpers rather than re-importing the helper module