### PR TITLE
fix: inconsistent resizes on vsplits

### DIFF
--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -46,7 +46,7 @@ function E.skipEnable()
         return true
     end
 
-    return S.isSupportedIntegration(S, "E.skipEnable", nil)
+    return S.is_supported_integration(S, "E.skipEnable", nil)
 end
 
 return E

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -12,7 +12,7 @@ local W = {}
 ---@param width number: the width to apply to the window.
 ---@param side "left"|"right"|"curr"|"unregistered": the side of the window being resized, used for logging only.
 ---@private
-local function resize(id, width, side)
+function W.resize(id, width, side)
     D.log(side, "resizing %d with padding %d", id, width)
 
     if vim.api.nvim_win_is_valid(id) then
@@ -152,7 +152,7 @@ end
 --- - If it already exists, we resize it.
 ---
 ---@private
-function W.createSideBuffers()
+function W.create_side_buffers()
     local wins = {
         left = { cmd = "topleft vnew", padding = 0 },
         right = { cmd = "botright vnew", padding = 0 },
@@ -197,45 +197,11 @@ function W.createSideBuffers()
             local padding = wins[side].padding or W.getPadding(side)
 
             if padding > _G.NoNeckPain.config.minSideBufferWidth then
-                resize(S.getSideID(S, side), padding, side)
+                W.resize(S.getSideID(S, side), padding, side)
             else
                 W.close("W.createSideBuffers", S.getSideID(S, side), side)
                 S.setSideID(S, nil, side)
             end
-        end
-    end
-
-    local columns = S.getColumns(S)
-    local leftID = S.getSideID(S, "left")
-    local rightID = S.getSideID(S, "right")
-
-    -- if we still have side buffers open at this point, and we have vsplit opened,
-    -- there might be width issues so we the resize opened vsplits.
-    if (leftID or rightID) and columns > 1 then
-        local sWidth = wins.left.padding or wins.right.padding
-        local nbSide = leftID and rightID and 2 or 1
-
-        -- get the available usable width (screen size without side paddings)
-        sWidth = vim.o.columns - sWidth * nbSide
-        local remainingVSplits = columns - nbSide
-
-        if remainingVSplits < 1 then
-            remainingVSplits = 1
-        end
-
-        sWidth = math.floor(sWidth / remainingVSplits)
-
-        D.log(
-            "splitResize",
-            "%d/%d screen width remaining, %d columns including %d sides",
-            sWidth,
-            vim.o.columns,
-            columns,
-            nbSide
-        )
-
-        for _, win in pairs(S.getUnregisteredWins(S)) do
-            -- resize(win, sWidth, string.format("unregistered:%d", win))
         end
     end
 end

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -132,7 +132,7 @@ T["vsplit"]["correctly size splits when opening helper with side buffers open"] 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
@@ -348,7 +348,7 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     Helpers.expect.equality(child.get_current_win(), 1004)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 38)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 17)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
 end
 
 return T


### PR DESCRIPTION
## 📃 Summary

should close https://github.com/shortcuts/no-neck-pain.nvim/issues/298

opening/closing a vsplit alters the ui, and since we resize side buffers, it might shrink buffers that are on the side of those sides.

we now resize splits as well, but not integrations