### PR TITLE
fix: default filetype not set

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -104,7 +104,10 @@ function N.init(scope, go_to_curr)
 
     -- if we do not have side buffers, we must ensure we only trigger a focus if we re-create them
     local had_side_buffers = true
-    if not S.is_side_win_enabled_and_valid(S, "left") or not S.is_side_win_enabled_and_valid(S, "right") then
+    if
+        not S.is_side_win_enabled_and_valid(S, "left")
+        or not S.is_side_win_enabled_and_valid(S, "right")
+    then
         had_side_buffers = false
     end
 

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -27,8 +27,10 @@ end
 function W.init_side_options(side, id)
     local bufid = vim.api.nvim_win_get_buf(id)
 
+    vim.print(S.get_scratchPad(S))
+
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
-        if not S.get_scratchPad(S) and opt ~= "filetype" then
+        if not (S.get_scratchPad(S) and opt == "filetype") then
             A.set_buffer_option(bufid, opt, val)
         end
     end

--- a/lua/no-neck-pain/wins.lua
+++ b/lua/no-neck-pain/wins.lua
@@ -27,8 +27,6 @@ end
 function W.init_side_options(side, id)
     local bufid = vim.api.nvim_win_get_buf(id)
 
-    vim.print(S.get_scratchPad(S))
-
     for opt, val in pairs(_G.NoNeckPain.config.buffers[side].bo) do
         if not (S.get_scratchPad(S) and opt == "filetype") then
             A.set_buffer_option(bufid, opt, val)

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -17,6 +17,23 @@ local T = MiniTest.new_set({
 
 T["setup"] = MiniTest.new_set()
 
+T["setup"]["sets default filetypes"] = function()
+    child.lua([[require('no-neck-pain').setup({width=30})]])
+    child.nnp()
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
+
+    Helpers.expect.equality(
+        child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1001), 'filetype')"),
+        "no-neck-pain"
+    )
+
+    Helpers.expect.equality(
+        child.lua_get("vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(1002), 'filetype')"),
+        "no-neck-pain"
+    )
+end
+
 T["setup"]["overrides default values"] = function()
     child.lua([[require('no-neck-pain').setup({
         buffers = {


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/385

the default filetype should be set, and skipped only if the scratchpad is enabled