### PR TITLE
fix(split): vsplits integration resize inconsistencies

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -45,7 +45,7 @@ function NoNeckPain.resize(width)
         _G.NoNeckPain.config = vim.tbl_deep_extend("keep", { width = width }, _G.NoNeckPain.config)
     end
 
-    main.init("public_api_resize", false)
+    main.init("public_api_resize")
 end
 
 --- Toggles the config `${side}.enabled` and re-inits the plugin.

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -133,19 +133,7 @@ function main.init(scope, go_to_curr)
     -- if we still have side buffers open at this point, and we have vsplit opened,
     -- there might be width issues so we the resize_win opened vsplits.
     if state.check_sides(state, "or", true) and state.get_columns(state) > 1 then
-        log.debug("resize_win", "have %d columns", state.get_columns(state))
-
-        for _, win in pairs(state.get_unregistered_wins(state, scope)) do
-            ui.resize_win(win, _G.NoNeckPain.config.width, string.format("win:%d", win))
-        end
-
-        if not had_side_buffers then
-            ui.resize_win(
-                state.get_side_id(state, "curr"),
-                _G.NoNeckPain.config.width,
-                string.format("win:%d", state.get_side_id(state, "curr"))
-            )
-        end
+        state.walk_layout(state, scope, vim.fn.winlayout(state.active_tab), false, true)
     end
 
     state.save(state)

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -88,9 +88,8 @@ end
 
 --- Creates side buffers and set the tab state, focuses the `curr` window if required.
 ---@param scope string: internal identifier for logging purposes.
----@param go_to_curr boolean?: whether we should re-focus the `curr` window.
 ---@private
-function main.init(scope, go_to_curr)
+function main.init(scope)
     if not state.is_active_tab_registered(state) then
         error("called the internal `init` method on a `nil` tab.")
     end
@@ -102,37 +101,43 @@ function main.init(scope, go_to_curr)
         state.get_side_id(state, "curr")
     )
 
-    -- if we do not have side buffers, we must ensure we only trigger a focus if we re-create them
-    local had_side_buffers = true
-    if
-        not state.is_side_enabled_or_valid(state, "left")
-        or not state.is_side_enabled_or_valid(state, "right")
-    then
-        had_side_buffers = false
-    end
-
-    ui.create_side_buffers()
-
     if state.consume_redraw(state) then
         ui.move_sides(string.format("%s:consume_redraw", scope))
     end
 
+    ui.create_side_buffers()
+
+    local current_win = vim.api.nvim_get_current_win()
+
     if
-        go_to_curr
-        or (not had_side_buffers and state.check_sides(state, "or", true))
-        or (
+        (
             state.is_side_the_active_win(state, "left")
             or state.is_side_the_active_win(state, "right")
-        )
+        ) and state.get_previously_focused_win(state) ~= current_win
     then
-        log.debug(scope, "re-routing focus to curr")
+        log.debug(
+            scope,
+            "rerouting focus of %d to %s",
+            current_win,
+            state.get_previously_focused_win(state)
+        )
 
         vim.api.nvim_set_current_win(state.get_side_id(state, "curr"))
+
+        if
+            state.active_tab
+            == vim.api.nvim_win_get_tabpage(state.get_previously_focused_win(state))
+        then
+            vim.api.nvim_set_current_win(state.get_previously_focused_win(state))
+        end
     end
 
-    -- if we still have side buffers open at this point, and we have vsplit opened,
+    -- if we still have side buffers and something else opened than the `curr`
     -- there might be width issues so we the resize_win opened vsplits.
-    if state.check_sides(state, "or", true) and state.get_columns(state) > 1 then
+    if
+        state.check_sides(state, "or", true)
+        and state.get_columns(state) > state.get_nb_sides(state) + 1
+    then
         state.walk_layout(state, scope, vim.fn.winlayout(state.active_tab), false, true)
     end
 
@@ -158,7 +163,7 @@ function main.enable(scope)
 
     state.set_side_id(state, vim.api.nvim_get_current_win(), "curr")
     state.scan_layout(state, scope)
-    main.init(scope, true)
+    main.init(scope)
     state.scan_layout(state, scope)
 
     vim.api.nvim_create_autocmd({ "VimResized" }, {
@@ -278,7 +283,7 @@ function main.enable(scope)
 
                     log.debug(s, "re-routing to %d", wins[1])
 
-                    return main.init(s, true)
+                    return main.init(s)
                 end
 
                 if
@@ -315,66 +320,64 @@ function main.enable(scope)
         desc = "keeps track of the state after closing windows and deleting buffers",
     })
 
-    if _G.NoNeckPain.config.autocmds.skipEnteringNoNeckPainBuffer then
-        vim.api.nvim_create_autocmd({ "WinLeave" }, {
-            callback = function(p)
-                vim.schedule(function()
-                    p.event = string.format("%s:skip_entering", p.event)
-                    if
-                        not state.is_active_tab_registered(state)
-                        or event.skip()
-                        or state.get_scratchPad(state)
-                    then
-                        return log.debug(p.event, "skip")
+    vim.api.nvim_create_autocmd({ "WinLeave" }, {
+        callback = function(p)
+            vim.schedule(function()
+                p.event = string.format("%s:skip_entering", p.event)
+                if not state.is_active_tab_registered(state) or event.skip() then
+                    return log.debug(p.event, "skip")
+                end
+
+                if not _G.NoNeckPain.config.autocmds.skipEnteringNoNeckPainBuffer then
+                    state.set_previously_focused_win(state, vim.api.nvim_get_current_win())
+                    return
+                end
+
+                if state.get_scratchPad(state) then
+                    return log.debug(p.event, "skip because scratchpad is enabled")
+                end
+
+                local current_side = vim.api.nvim_get_current_win()
+                local other_side = state.get_side_id(state, "right")
+                local left_id = state.get_side_id(state, "left")
+                local right_id = state.get_side_id(state, "right")
+
+                if current_side == left_id then
+                    other_side = right_id
+                elseif current_side == right_id then
+                    other_side = left_id
+                else
+                    state.set_previously_focused_win(state, vim.api.nvim_get_current_win())
+                    return
+                end
+
+                -- we need to know if the user navigates from ltr or rtl
+                -- so we keep track of the encounter of prev,curr to determine
+                -- the next valid window to focus
+
+                local wins = vim.api.nvim_list_wins()
+                local idx
+
+                for i = 1, #wins do
+                    if api.is_side_id(current_side, wins[i]) then
+                        idx = api.find_next_side_idx(i - 1, -1, wins, current_side, other_side)
+                        break
+                    elseif api.is_side_id(state.get_previously_focused_win(state), wins[i]) then
+                        idx = api.find_next_side_idx(i + 1, 1, wins, current_side, other_side)
+                        break
                     end
+                end
 
-                    local current_side = vim.api.nvim_get_current_win()
-                    local other_side = state.get_side_id(state, "right")
-                    local left_id = state.get_side_id(state, "left")
-                    local right_id = state.get_side_id(state, "right")
+                if idx then
+                    vim.api.nvim_set_current_win(wins[idx])
 
-                    if current_side == left_id then
-                        other_side = right_id
-                    elseif current_side == right_id then
-                        other_side = left_id
-                    else
-                        state.set_previously_focused_win(state, vim.api.nvim_get_current_win())
-                        return
-                    end
-
-                    -- we need to know if the user navigates from ltr or rtl
-                    -- so we keep track of the encounter of prev,curr to determine
-                    -- the next valid window to focus
-
-                    local wins = vim.api.nvim_list_wins()
-                    local idx
-
-                    for i = 1, #wins do
-                        if api.is_side_id(current_side, wins[i]) then
-                            idx = api.find_next_side_idx(i - 1, -1, wins, current_side, other_side)
-                            break
-                        elseif api.is_side_id(state.get_previously_focused_win(state), wins[i]) then
-                            idx = api.find_next_side_idx(i + 1, 1, wins, current_side, other_side)
-                            break
-                        end
-                    end
-
-                    if idx then
-                        vim.api.nvim_set_current_win(wins[idx])
-
-                        return log.debug(
-                            p.event,
-                            "rerouted focus of %d to %d",
-                            current_side,
-                            wins[idx]
-                        )
-                    end
-                end)
-            end,
-            group = augroup_name,
-            desc = "Entering a no-neck-pain side buffer skips to the next available buffer",
-        })
-    end
+                    return log.debug(p.event, "rerouted focus of %d to %d", current_side, wins[idx])
+                end
+            end)
+        end,
+        group = augroup_name,
+        desc = "Keeps track of the last focused win, and re-route if necessary",
+    })
 
     state.save(state)
 end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -125,8 +125,9 @@ function main.init(scope)
         vim.api.nvim_set_current_win(state.get_side_id(state, "curr"))
 
         if
-            state.active_tab
-            == vim.api.nvim_win_get_tabpage(state.get_previously_focused_win(state))
+            vim.api.nvim_win_is_valid(state.get_previously_focused_win(state))
+            and state.active_tab
+                == vim.api.nvim_win_get_tabpage(state.get_previously_focused_win(state))
         then
             vim.api.nvim_set_current_win(state.get_previously_focused_win(state))
         end

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -454,12 +454,7 @@ function state:walk_layout(scope, tree, has_col_parent, resize_only)
                         and self.get_side_id(self, "right") ~= id
                         and not self.is_supported_integration(self, scope, id)
                     then
-                        self.resize_win(
-                            self,
-                            id,
-                            _G.NoNeckPain.config.width,
-                            "unregistered"
-                        )
+                        self.resize_win(self, id, _G.NoNeckPain.config.width, "unregistered")
                         break
                     end
                 end

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -340,6 +340,18 @@ function state:check_sides(condition, expected)
         and self.is_side_enabled_and_valid(self, "right") == expected
 end
 
+--- Returns the number of enabled and valid sides.
+---
+---@return number
+---@private
+function state:get_nb_sides()
+    if self.is_side_enabled(self, "left") and self.is_side_enabled(self, "right") then
+        return 2
+    end
+
+    return 1
+end
+
 --- Gets wins that are not relative or main wins.
 ---
 ---@param scope string: caller of the method.
@@ -455,7 +467,6 @@ function state:walk_layout(scope, tree, has_col_parent, resize_only)
                         and not self.is_supported_integration(self, scope, id)
                     then
                         self.resize_win(self, id, _G.NoNeckPain.config.width, "unregistered")
-                        break
                     end
                 end
             end

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -348,7 +348,6 @@ end
 function state:get_unregistered_wins(scope)
     return vim.tbl_filter(function(win)
         return not api.is_relative_window(win)
-            and win ~= self.get_side_id(self, "curr")
             and win ~= self.get_side_id(self, "left")
             and win ~= self.get_side_id(self, "right")
             and not self.is_supported_integration(self, scope, win)
@@ -357,6 +356,20 @@ end
 
 ----- layout =======================================================
 ---@private
+
+--- Resizes a window if it's valid.
+---
+---@param id number: the id of the window.
+---@param width number: the width to apply to the window.
+---@param side "left"|"right"|"curr"|"unregistered": the side of the window being resized, used for logging only.
+---@private
+function state:resize_win(id, width, side)
+    log.debug(side, "resizing %d with padding %d", id, width)
+
+    if vim.api.nvim_win_is_valid(id) then
+        vim.api.nvim_win_set_width(id, width)
+    end
+end
 
 --- Gets the columns count in the current layout.
 ---
@@ -411,8 +424,9 @@ end
 ---@param scope string: the caller of the method.
 ---@param tree table: the tree to walk in.
 ---@param has_col_parent boolean: whether or not the previous walked tree was a column.
+---@param resize_only boolean?: walks the layout in order to find columns, but only resize 1 window of each column
 ---@private
-function state:walk_layout(scope, tree, has_col_parent)
+function state:walk_layout(scope, tree, has_col_parent, resize_only)
     -- col -- represents a vertical association of window, e.g. { { "leaf", int }, { "col", { ... } }, { "row", { ...} } }
     -- row -- represents an horizontal association of window, e.g  { { "leaf", int }, { "col", { ... } }, { "row", { ...} } }
     -- leaf -- represents a window, e.g. { "leaf", int }
@@ -425,16 +439,36 @@ function state:walk_layout(scope, tree, has_col_parent)
     for idx, leaf in ipairs(tree) do
         if leaf == "row" then
             local leafs = tree[idx + 1]
-            -- if on a row we were on a col, then it means one iteam of the row must be of the same width as a col one
-            if has_col_parent and vim.tbl_count(leafs) > 1 then
-                table.remove(leafs, 1)
+            if not resize_only then
+                -- if on a row we were on a col, then it means one iteam of the row must be of the same width as a col one
+                if has_col_parent and vim.tbl_count(leafs) > 1 then
+                    table.remove(leafs, 1)
+                end
+                self.set_layout_windows(self, scope, leafs)
+            else
+                for _, sub_leaf in ipairs(leafs) do
+                    local id = sub_leaf[2]
+                    if
+                        sub_leaf[1] == "leaf"
+                        and self.get_side_id(self, "left") ~= id
+                        and self.get_side_id(self, "right") ~= id
+                        and not self.is_supported_integration(self, scope, id)
+                    then
+                        self.resize_win(
+                            self,
+                            id,
+                            _G.NoNeckPain.config.width,
+                            "unregistered"
+                        )
+                        break
+                    end
+                end
             end
-            self.set_layout_windows(self, scope, leafs)
-            self.walk_layout(self, scope, tree[idx + 1], false)
+            self.walk_layout(self, scope, tree[idx + 1], false, resize_only)
         elseif leaf == "col" then
-            self.walk_layout(self, scope, tree[idx + 1], true)
+            self.walk_layout(self, scope, tree[idx + 1], true, resize_only)
         elseif type(leaf) == "table" and type(leaf[1]) == "string" then
-            self.walk_layout(self, scope, leaf, has_col_parent)
+            self.walk_layout(self, scope, leaf, has_col_parent, resize_only)
         end
     end
 end

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -464,7 +464,6 @@ function state:walk_layout(scope, tree, has_col_parent, resize_only)
                         sub_leaf[1] == "leaf"
                         and self.get_side_id(self, "left") ~= id
                         and self.get_side_id(self, "right") ~= id
-                        and not self.is_supported_integration(self, scope, id)
                     then
                         self.resize_win(self, id, _G.NoNeckPain.config.width, "unregistered")
                     end

--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -34,8 +34,6 @@ function ui.move_sides(scope)
         right = vim.api.nvim_replace_termcodes("normal <C-W>L", true, false, true),
     }
 
-    local restore_focus = false
-
     for side, keys in pairs(sides) do
         local sscope = string.format("%s:%s", scope, side)
 
@@ -63,13 +61,7 @@ function ui.move_sides(scope)
                     vim.inspect(wins)
                 )
             end
-
-            restore_focus = true
         end
-    end
-
-    if restore_focus and state.get_side_id(state, "curr") ~= nil then
-        vim.api.nvim_set_current_win(state.get_side_id(state, "curr"))
     end
 end
 
@@ -237,7 +229,7 @@ function ui.get_side_width(side)
 
     log.debug(
         scope,
-        "%d/%d after integrations - %d columns remaining after removing integrations",
+        "%d/%d after integrations - %d columns remaining",
         occupied,
         vim.o.columns,
         columns

--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -43,8 +43,6 @@ function ui.move_sides(scope)
             local curr = vim.api.nvim_get_current_win()
 
             if curr ~= id then
-                log.debug(sscope, "wrong win focused %d re-routing to %d", curr, id)
-
                 vim.api.nvim_set_current_win(id)
             end
 

--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -6,20 +6,6 @@ local state = require("no-neck-pain.state")
 
 local ui = {}
 
---- Resizes a window if it's valid.
----
----@param id number: the id of the window.
----@param width number: the width to apply to the window.
----@param side "left"|"right"|"curr"|"unregistered": the side of the window being resized, used for logging only.
----@private
-function ui.resize_win(id, width, side)
-    log.debug(side, "resizing %d with padding %d", id, width)
-
-    if vim.api.nvim_win_is_valid(id) then
-        vim.api.nvim_win_set_width(id, width)
-    end
-end
-
 --- Initializes the given `side` with the options from the user given configuration.
 ---@param side "left"|"right"|"curr": the side of the window to initialize.
 ---@param id number: the id of the window.
@@ -197,7 +183,7 @@ function ui.create_side_buffers()
             local padding = wins[side].padding or ui.get_side_width(side)
 
             if padding > _G.NoNeckPain.config.minSideBufferWidth then
-                ui.resize_win(state.get_side_id(state, side), padding, side)
+                state.resize_win(state, state.get_side_id(state, side), padding, side)
             else
                 ui.close_win("ui.create_side_buffers", state.get_side_id(state, side), side)
                 state.set_side_id(state, nil, side)
@@ -224,46 +210,53 @@ function ui.get_side_width(side)
     local columns = state.get_columns(state)
 
     for _, s in ipairs(constants.SIDES) do
+        -- remove sides but always keep 1 column for the curr, which will be computed with "splits"
         if state.is_side_enabled_and_valid(state, s) and columns > 1 then
             columns = columns - 1
         end
     end
 
-    -- we need to see if there's enough space left to have side buffers
-    local occupied = _G.NoNeckPain.config.width * columns
+    local occupied = 0
 
-    log.debug(scope, "have %d columns", columns)
+    -- remove width of registered integrations to the correct side
+    for name, opts in pairs(state.get_integrations(state)) do
+        if opts.id ~= nil then
+            if
+                not state.is_side_enabled_and_valid(state, side)
+                or side == _G.NoNeckPain.config.integrations[name].position
+            then
+                local integration_width = vim.api.nvim_win_get_width(opts.id)
+                log.debug(scope, "%s opened with width %d", name, integration_width)
 
-    -- if there's no space left according to the config width,
+                occupied = occupied + integration_width
+            end
+
+            columns = columns - 1
+        end
+    end
+
+    log.debug(
+        scope,
+        "%d/%d after integrations - %d columns remaining after removing integrations",
+        occupied,
+        vim.o.columns,
+        columns
+    )
+
+    while columns > 0 do
+        occupied = occupied + _G.NoNeckPain.config.width
+        columns = columns - 1
+    end
     -- then we don't have to create side buffers.
     if occupied >= vim.o.columns then
-        log.debug(scope, "%d occupied - no space left to create side", occupied)
+        log.debug(scope, "%d/%d - no space left to create side", occupied, vim.o.columns)
 
         return 0
     end
 
-    log.debug(scope, "%d/%d with columns, computing integrations", occupied, vim.o.columns)
-
-    -- now we need to determine how much we should substract from the remaining padding
-    -- if there's side integrations open.
-    for name, opts in pairs(state.get_integrations(state)) do
-        if
-            opts.id ~= nil
-            and (
-                not state.is_side_enabled_and_valid(state, side)
-                or side == _G.NoNeckPain.config.integrations[name].position
-            )
-        then
-            local integration_width = vim.api.nvim_win_get_width(opts.id)
-            log.debug(scope, "%s opened with width %d", name, integration_width)
-
-            occupied = occupied + integration_width
-        end
-    end
-
     local final = math.floor((vim.o.columns - occupied) / 2)
 
-    log.debug(scope, "%d/%d with integrations - final %d", occupied, vim.o.columns, final)
+    log.debug(scope, "%d/%d after splits - final %d", occupied, vim.o.columns, final)
 
     return final
 end

--- a/scripts/init_with_tsplayground.lua
+++ b/scripts/init_with_tsplayground.lua
@@ -10,4 +10,4 @@ require("nvim-treesitter.configs").setup({
     },
 })
 require("mini.test").setup()
-require("no-neck-pain").setup({ debug = true, width = 1 })
+require("no-neck-pain").setup({ debug = true, width = 20 })

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -529,7 +529,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 26)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 32)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 26)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
@@ -558,7 +558,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
         left = 1001,
         right = nil,
     })
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 40)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 59)
 end
 
 T["aerial"] = MiniTest.new_set()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -530,7 +530,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 28)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 26)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
@@ -558,7 +558,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
         left = 1001,
         right = nil,
     })
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 59)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
 end
 
 T["aerial"] = MiniTest.new_set()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -463,7 +463,7 @@ T["TSPlayground"]["keeps sides open"] = function()
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 19)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 20)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
@@ -529,7 +529,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 32)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 28)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 26)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
@@ -588,7 +588,7 @@ T["aerial"]["keeps sides open"] = function()
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 14)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 20)
     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial.id", 1004)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -160,7 +160,7 @@ T["vsplit"]["correctly size splits when opening helper with side buffers open"] 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 17)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
@@ -376,7 +376,7 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     Helpers.expect.equality(child.get_current_win(), 1004)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 38)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 17)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
 end
 
 return T

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -376,7 +376,7 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     Helpers.expect.equality(child.get_current_win(), 1004)
 
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 38)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 17)
 end
 
 return T


### PR DESCRIPTION
## 📃 Summary

rework the way we compute the size of side buffers by properly assessing the number of valid sides, which was causing weird layout when 2 were actives.

also resize the vsplits based on the layout, rather than guessing which windows are vsplits, this allows a super consistent ui layout

todo: closing an integration doesn't restore the position of the `curr` buffer, but the width is correct

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/389