### PR TITLE
fix(autocmds): prevent stucked focus on skip enter

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -339,7 +339,7 @@ function main.enable(scope)
                 end
 
                 local current_side = vim.api.nvim_get_current_win()
-                local other_side = state.get_side_id(state, "right")
+                local other_side
                 local left_id = state.get_side_id(state, "left")
                 local right_id = state.get_side_id(state, "right")
 
@@ -361,19 +361,33 @@ function main.enable(scope)
 
                 for i = 1, #wins do
                     if api.is_side_id(current_side, wins[i]) then
-                        idx = api.find_next_side_idx(i - 1, -1, wins, current_side, other_side)
+                        idx = api.find_next_side_idx(
+                            i - 1,
+                            -1,
+                            wins,
+                            current_side,
+                            other_side,
+                            state.get_previously_focused_win(state)
+                        )
                         break
                     elseif api.is_side_id(state.get_previously_focused_win(state), wins[i]) then
-                        idx = api.find_next_side_idx(i + 1, 1, wins, current_side, other_side)
+                        idx = api.find_next_side_idx(
+                            i + 1,
+                            1,
+                            wins,
+                            current_side,
+                            other_side,
+                            state.get_previously_focused_win(state)
+                        )
                         break
                     end
                 end
 
-                if idx then
-                    vim.api.nvim_set_current_win(wins[idx])
+                local new_focus = wins[idx] or state.get_previously_focused_win(state)
 
-                    return log.debug(p.event, "rerouted focus of %d to %d", current_side, wins[idx])
-                end
+                vim.api.nvim_set_current_win(new_focus)
+
+                return log.debug(p.event, "rerouted focus of %d to %d", current_side, new_focus)
             end)
         end,
         group = augroup_name,

--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -48,8 +48,6 @@ function ui.move_sides(scope)
 
             vim.cmd(keys)
 
-            wins = vim.api.nvim_tabpage_list_wins(state.active_tab)
-
             if (side == "left" and wins[1] ~= id) or (side == "right" and wins[#wins] ~= id) then
                 log.debug(
                     sscope,

--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -165,11 +165,12 @@ end
 ---@param start_idx number: the idx to start from in `wins`.
 ---@param step -1|1: the walk direction in `wins`, from `start_idx`.
 ---@param wins table: the table of wins ids to walk in.
----@param current_side number: the `left` or `right` side id..
----@param other_side number: the `left` or `right` side id..
+---@param current_side number: the `left` or `right` side id.
+---@param other_side number: the `left` or `right` side id.
+---@param previously_focused number: the previously focused window.
 ---@return number?
 ---@private
-function api.find_next_side_idx(start_idx, step, wins, current_side, other_side)
+function api.find_next_side_idx(start_idx, step, wins, current_side, other_side, previously_focused)
     local n = #wins
 
     for k = 1, n do
@@ -179,6 +180,7 @@ function api.find_next_side_idx(start_idx, step, wins, current_side, other_side)
         if
             not api.is_side_id(current_side, wins[index])
             and not api.is_side_id(other_side, wins[index])
+            and wins[index] ~= previously_focused
         then
             return index
         end

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -222,4 +222,24 @@ T["skipEnteringNoNeckPainBuffer"]["does not register if scratchPad feature is en
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1001)
 end
 
+T["skipEnteringNoNeckPainBuffer"]["one side only + full width split doesn't bring back to original position"] = function()
+    child.lua(
+        [[ require('no-neck-pain').setup({width=50, autocmds = { skipEnteringNoNeckPainBuffer = true }, buffers = { right = { enabled = false }}}) ]]
+    )
+    child.nnp()
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000 })
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
+
+    child.cmd("botright new")
+    child.wait()
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1002)
+
+    child.fn.win_gotoid(1001)
+    child.wait()
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

When having only one side, and a full width split focused (e.g. quickfix list, help), using `<C-w>w` to go to the next window brings us to the full width split, instead of going to the next available window.