### PR TITLE
fix(integrations): do not assert position

### DIFF
--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -46,7 +46,7 @@ window options `:h vim.wo`
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptionsWo = {
       ---@type boolean
       cursorline = false,
@@ -69,7 +69,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                     *NoNeckPain.bufferOptionsBo*
                           `NoNeckPain.bufferOptionsBo`
@@ -79,7 +78,7 @@ buffer options `:h vim.bo`
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptionsBo = {
       ---@type string
       filetype = "no-neck-pain",
@@ -94,7 +93,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                             *NoNeckPain.bufferOptionsScratchPad*
                       `NoNeckPain.bufferOptionsScratchPad`
@@ -106,7 +104,7 @@ note: quitting an unsaved scratchPad buffer is non-blocking, and the content is 
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptionsScratchPad = {
       -- When `true`, automatically sets the following options to the side buffers:
       -- - `autowriteall`
@@ -133,7 +131,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                 *NoNeckPain.bufferOptionsColors*
                         `NoNeckPain.bufferOptionsColors`
@@ -142,7 +139,7 @@ NoNeckPain's buffer color options.
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptionsColors = {
       -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
       -- Transparent backgrounds are supported by default.
@@ -176,7 +173,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                       *NoNeckPain.bufferOptions*
                            `NoNeckPain.bufferOptions`
@@ -185,7 +181,7 @@ NoNeckPain's buffer side buffer option.
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptions = {
       -- When `false`, the buffer won't be created.
       ---@type boolean
@@ -201,7 +197,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                             *NoNeckPain.options*
                               `NoNeckPain.options`
@@ -210,7 +205,7 @@ NoNeckPain's plugin config.
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.options = {
       -- Prints useful logs about triggered events, and reasons actions are executed.
       ---@type boolean
@@ -385,7 +380,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                             *NoNeckPain.setup()*
                          `NoNeckPain.setup`({options})

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -395,15 +395,6 @@ function NoNeckPain.defaults(options)
         "`minSideBufferWidth` must be equal or greater than 0."
     )
 
-    -- assert `integrations` values
-    for _, tree in pairs({ "NvimTree", "NeoTree" }) do
-        assert(
-            NoNeckPain.options.integrations[tree].position == "left"
-                or NoNeckPain.options.integrations[tree].position == "right",
-            string.format("%s position can only be `left` or `right`", tree)
-        )
-    end
-
     -- cleanup deprecated options to sanitize the saved config
     NoNeckPain.options.buffers.left.scratchPad.location = nil
     NoNeckPain.options.buffers.left.scratchPad.fileName = nil

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -86,34 +86,6 @@ T["setup"]["overrides default values"] = function()
     })
 end
 
-T["integrations"] = MiniTest.new_set()
-
-T["integrations"]["NvimTree throws with wrong values"] = function()
-    Helpers.expect.error(function()
-        child.lua([[ require('no-neck-pain').setup({
-                    integrations = {
-                        NvimTree = {
-                            position = "nope",
-                        },
-                    },
-                })
-            ]])
-    end)
-end
-
-T["integrations"]["NeoTree throws with wrong values"] = function()
-    Helpers.expect.error(function()
-        child.lua([[ require('no-neck-pain').setup({
-                    integrations = {
-                        NeoTree = {
-                            position = "nope",
-                        },
-                    },
-                })
-            ]])
-    end)
-end
-
 T["checkhealth"] = MiniTest.new_set()
 
 T["checkhealth"]["state is in sync"] = function()


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/400

This legacy assertion is not relevant anymore, we only care about if it's left or right now, the other positions are ignored