### PR TITLE
fix(tabs): prevent wrong resize on tabnew

### DIFF
--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -46,7 +46,7 @@ window options `:h vim.wo`
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptionsWo = {
       ---@type boolean
       cursorline = false,
@@ -69,7 +69,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                     *NoNeckPain.bufferOptionsBo*
                           `NoNeckPain.bufferOptionsBo`
@@ -79,7 +78,7 @@ buffer options `:h vim.bo`
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptionsBo = {
       ---@type string
       filetype = "no-neck-pain",
@@ -94,7 +93,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                             *NoNeckPain.bufferOptionsScratchPad*
                       `NoNeckPain.bufferOptionsScratchPad`
@@ -106,7 +104,7 @@ note: quitting an unsaved scratchPad buffer is non-blocking, and the content is 
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptionsScratchPad = {
       -- When `true`, automatically sets the following options to the side buffers:
       -- - `autowriteall`
@@ -133,7 +131,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                 *NoNeckPain.bufferOptionsColors*
                         `NoNeckPain.bufferOptionsColors`
@@ -142,7 +139,7 @@ NoNeckPain's buffer color options.
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptionsColors = {
       -- Hexadecimal color code to override the current background color of the buffer. (e.g. #24273A)
       -- Transparent backgrounds are supported by default.
@@ -176,7 +173,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                       *NoNeckPain.bufferOptions*
                            `NoNeckPain.bufferOptions`
@@ -185,7 +181,7 @@ NoNeckPain's buffer side buffer option.
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.bufferOptions = {
       -- When `false`, the buffer won't be created.
       ---@type boolean
@@ -201,7 +197,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                             *NoNeckPain.options*
                               `NoNeckPain.options`
@@ -210,7 +205,7 @@ NoNeckPain's plugin config.
 Type ~
 `(table)`
 Default values:
->
+>lua
   NoNeckPain.options = {
       -- Prints useful logs about triggered events, and reasons actions are executed.
       ---@type boolean
@@ -385,7 +380,6 @@ Default values:
   }
 
 <
-
 ------------------------------------------------------------------------------
                                                             *NoNeckPain.setup()*
                          `NoNeckPain.setup`({options})

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -130,7 +130,7 @@ function NoNeckPain.setup(opts)
     end
 
     if _G.NoNeckPain.config.autocmds.enableOnTabEnter then
-        vim.api.nvim_create_autocmd({ "TabEnter" }, {
+        vim.api.nvim_create_autocmd({ "TabNewEntered" }, {
             callback = function(p)
                 vim.schedule(function()
                     if _G.NoNeckPain.state == nil or not _G.NoNeckPain.state.enabled then

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -154,10 +154,12 @@ function main.enable(scope)
         return
     end
 
-    log.debug(scope, "calling enable for tab %d", api.get_current_tab())
+    state.set_active_tab(state, api.get_current_tab())
+
+    log.debug(scope, "calling enable for tab %d", state.active_tab)
 
     state.set_enabled(state)
-    state.set_tab(state, api.get_current_tab())
+    state.set_tab(state, state.active_tab)
 
     local augroup_name = api.get_augroup_name(state.active_tab)
     vim.api.nvim_create_augroup(augroup_name, { clear = true })
@@ -177,7 +179,7 @@ function main.enable(scope)
                 local tab = state.get_tab(state)
 
                 if tab ~= nil then
-                    if api.get_current_tab() ~= tab.id then
+                    if state.active_tab ~= tab.id then
                         return
                     end
                 end
@@ -192,11 +194,11 @@ function main.enable(scope)
     vim.api.nvim_create_autocmd({ "TabEnter" }, {
         callback = function(p)
             api.debounce(p.event, function()
+                state.set_active_tab(state, api.get_current_tab())
+
                 log.debug(p.event, "tab %d entered", state.active_tab)
 
                 state.refresh_tabs(state, p.event)
-
-                state.set_active_tab(state, api.get_current_tab())
             end)
         end,
         group = augroup_name,

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -489,7 +489,7 @@ function state:scan_layout(scope)
     self.init_columns(self)
     self.init_integrations(self)
 
-    local layout = vim.fn.winlayout(self.active_tab)
+    local layout = vim.fn.winlayout()
 
     -- when opening vim with nnp autocmds, nothing else than a curr window
     if layout[1] == "leaf" then

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -50,12 +50,17 @@ T["tabs"]["side buffers coexist on many tabs"] = function()
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "active_tab", 1)
 
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+
     -- tab 2
     child.cmd("tabnew")
     child.nnp()
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1003, 1005 })
     Helpers.expect.state(child, "active_tab", 2)
+
+    child.cmd("tabclose")
 
     -- tab 3
     child.cmd("tabnew")
@@ -64,8 +69,11 @@ T["tabs"]["side buffers coexist on many tabs"] = function()
     Helpers.expect.equality(child.get_wins_in_tab(), { 1007, 1006, 1008 })
     Helpers.expect.state(child, "active_tab", 3)
 
+    -- width is preserved as on tab 1
+    Helpers.expect.buf_width(child, "tabs[3].wins.main.left", 15)
+    Helpers.expect.buf_width(child, "tabs[3].wins.main.right", 15)
+
     Helpers.expect.equality(child.get_wins_in_tab(1), { 1001, 1000, 1002 })
-    Helpers.expect.equality(child.get_wins_in_tab(2), { 1004, 1003, 1005 })
     Helpers.expect.equality(child.get_wins_in_tab(3), { 1007, 1006, 1008 })
 end
 


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/399

the tab was somehow invalid when scanning the layout, we can let nvim determine the current tab, since we never scan a tab other than the active one.

also add a test to prevent regression