### PR TITLE
fix(splits): check curr id before rerouting

### DIFF
--- a/tests/test_commands.lua
+++ b/tests/test_commands.lua
@@ -29,7 +29,6 @@ T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = fu
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 100)
 
-    -- need to know why the child isn't precise enough
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 80)
 
     child.cmd("NoNeckPainResize 20")
@@ -37,7 +36,7 @@ T["commands"]["NoNeckPainResize sets the config width and resizes windows"] = fu
 
     Helpers.expect.global(child, "_G.NoNeckPain.config.width", 20)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 18)
 end
 
 T["commands"]["NoNeckPainResize throws with the plugin disabled"] = function()


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/407

check the win validity before rerouting
prevent early return when we need to redraw the ui