### PR TITLE
Update constants.lua

### DIFF
--- a/lua/no-neck-pain/util/constants.lua
+++ b/lua/no-neck-pain/util/constants.lua
@@ -82,6 +82,6 @@ constants.INTEGRATIONS = {
 --- Dashboards filetypes that delays the plugin enable step until next buffer entered.
 ---
 ---@private
-constants.DASHBOARDS = { "dashboard", "alpha", "starter" }
+constants.DASHBOARDS = { "dashboard", "alpha", "starter", "snacks_dashboard" }
 
 return constants


### PR DESCRIPTION
Support for folke/snacks.nvim dashboard

## 📃 Summary

Folke recently released a new dashboard plug-in as part of snacks.nvim. snacks_dashboard is the filetype it uses, so this would allow no-neck-pain to ignore those files