### PR TITLE
fix: do not skip relative windows on re-route

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -332,7 +332,7 @@ function main.enable(scope)
         callback = function(p)
             vim.schedule(function()
                 p.event = string.format("%s:skip_entering", p.event)
-                if not state.is_active_tab_registered(state) or event.skip() then
+                if not state.is_active_tab_registered(state) then
                     return log.debug(p.event, "skip")
                 end
 


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/411

we shouldn't skip registering relative windows, otherwise it would be re-routed to the exact same window