### PR TITLE
fix: prevent non-focusable windows from being focused

### DIFF
--- a/lua/no-neck-pain/util/api.lua
+++ b/lua/no-neck-pain/util/api.lua
@@ -181,6 +181,7 @@ function api.find_next_side_idx(start_idx, step, wins, current_side, other_side,
             not api.is_side_id(current_side, wins[index])
             and not api.is_side_id(other_side, wins[index])
             and wins[index] ~= previously_focused
+            and vim.api.nvim_win_get_config(wins[index]).focusable
         then
             return index
         end


### PR DESCRIPTION
## 📃 Summary

Related discussion: #414 

Normally, windows created with `focusable = false` cannot be focused by user interactions. However, the current logic for skipping past side buffers can cause such a window to become focused.

This change makes it so that only focusable windows are considered as skip targets.