### PR TITLE
fix: do not reroute to invalid (deleted) window

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.10.1
+          version: v0.10.2
 
       - name: generate documentation
         run: make documentation-ci
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 1
     strategy:
       matrix:
-        neovim_version: ['v0.9.5', 'v0.10.1']
+        neovim_version: ['v0.9.5', 'v0.10.2']
 
     steps:
       - uses: actions/checkout@v4

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -262,8 +262,6 @@ function main.enable(scope)
 
                         vim.cmd("rightbelow vertical split")
 
-                        vim.print(opened_buffers)
-
                         if vim.tbl_count(opened_buffers) > 0 then
                             local bufname, _ = next(opened_buffers)
                             if vim.startswith(bufname, "NoNamePain") then
@@ -391,6 +389,14 @@ function main.enable(scope)
                 end
 
                 local new_focus = wins[idx] or state.get_previously_focused_win(state)
+
+                if not vim.api.nvim_win_is_valid(new_focus) then
+                    return log.debug(
+                        p.event,
+                        "aborting reroute, %d is not a valid window",
+                        new_focus
+                    )
+                end
 
                 vim.api.nvim_set_current_win(new_focus)
 

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -260,11 +260,11 @@ T["skipEnteringNoNeckPainBuffer"]["does not reroute to invalid windows"] = funct
     child.wait()
 
     if child.fn.has("nvim-0.10") == 0 then
-        Helpers.expect.equality(child.get_wins_in_tab(), { 1005, 1004, 1006 })
-        Helpers.expect.equality(child.api.nvim_get_current_win(), 1004)
-    else
         Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1003, 1005 })
         Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
+    else
+        Helpers.expect.equality(child.get_wins_in_tab(), { 1005, 1004, 1006 })
+        Helpers.expect.equality(child.api.nvim_get_current_win(), 1004)
     end
 end
 

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -259,8 +259,13 @@ T["skipEnteringNoNeckPainBuffer"]["does not reroute to invalid windows"] = funct
     child.cmd("bd")
     child.wait()
 
-    Helpers.expect.equality(child.get_wins_in_tab(), { 1005, 1004, 1006 })
-    Helpers.expect.equality(child.api.nvim_get_current_win(), 1004)
+    if child.fn.has("nvim-0.10") == 0 then
+        Helpers.expect.equality(child.get_wins_in_tab(), { 1005, 1004, 1006 })
+        Helpers.expect.equality(child.api.nvim_get_current_win(), 1004)
+    else
+        Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1003, 1005 })
+        Helpers.expect.equality(child.api.nvim_get_current_win(), 1003)
+    end
 end
 
 return T

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -242,4 +242,25 @@ T["skipEnteringNoNeckPainBuffer"]["one side only + full width split doesn't brin
     Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
 end
 
+T["skipEnteringNoNeckPainBuffer"]["does not reroute to invalid windows"] = function()
+    child.lua(
+        [[ require('no-neck-pain').setup({width=50, autocmds = { skipEnteringNoNeckPainBuffer = true }}) ]]
+    )
+    child.nnp()
+
+    child.cmd("e foo")
+    child.wait()
+    child.cmd("e bar")
+    child.wait()
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1000)
+
+    child.cmd("bd")
+    child.wait()
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1005, 1004, 1006 })
+    Helpers.expect.equality(child.api.nvim_get_current_win(), 1004)
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/415

we assume the window list is valid, but in case of `bd`, it actually deletes the window, which then makes the plugin fallback to a new set of window

we should make sure the window is valid before actually rerouting