### PR TITLE
fix: 'Invalid window id ...' error when restoring a session saved with an invisible Scratch Window (#430)

### DIFF
--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -158,9 +158,9 @@ function ui.create_side_buffers()
                 else
                     ui.init_side_options(side, state.get_side_id(state, side))
                 end
-            end
 
-            colors.init(state.get_side_id(state, side), side)
+                colors.init(state.get_side_id(state, side), side)
+            end
         end
     end
 

--- a/scripts/init_auto_open.lua
+++ b/scripts/init_auto_open.lua
@@ -6,5 +6,6 @@ vim.cmd("set rtp+=deps/mini.nvim")
 require("no-neck-pain").setup({
     width = 50,
     autocmds = { enableOnVimEnter = true, enableOnTabEnter = true },
+    buffers = { colors = { background = "tokyonight-moon" } },
 })
 require("mini.test").setup()

--- a/scripts/init_auto_open.lua
+++ b/scripts/init_auto_open.lua
@@ -5,6 +5,7 @@ vim.cmd("set rtp+=deps/mini.nvim")
 -- Auto open enabled for the test
 require("no-neck-pain").setup({
     width = 50,
+    minSideBufferWidth = 5,
     autocmds = { enableOnVimEnter = true, enableOnTabEnter = true },
     buffers = { colors = { background = "tokyonight-moon" } },
 })

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -109,6 +109,32 @@ T["setup"]["`left` or `right` buffer options overrides `common` ones"] = functio
     })
 end
 
+T["setup"]["does not throw on invalid windows"] = function()
+    child.restart({ "-u", "scripts/init_auto_open.lua" })
+    child.wait()
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
+    Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
+
+    child.cmd("e aaa.txt")
+    child.cmd("vnew aaa.txt")
+    child.cmd("mksession! deps/mk.vim")
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
+    Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
+
+    child.restart({ "-u", "scripts/init_auto_open.lua" })
+    child.wait()
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
+
+    child.cmd("source deps/mk.vim")
+    child.wait()
+
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1000, 1003, 1004, 1005 })
+    Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
+end
+
 T["setup"]["`common` options spreads it to `left` and `right` buffers"] = function()
     child.cmd([[colorscheme peachpuff]])
     child.lua([[

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -110,8 +110,8 @@ T["setup"]["`left` or `right` buffer options overrides `common` ones"] = functio
 end
 
 T["setup"]["does not throw on invalid windows"] = function()
-    child.set_size(30, 30)
     child.restart({ "-u", "scripts/init_auto_open.lua" })
+    child.set_size(80, 80)
     child.wait()
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -110,6 +110,7 @@ T["setup"]["`left` or `right` buffer options overrides `common` ones"] = functio
 end
 
 T["setup"]["does not throw on invalid windows"] = function()
+    child.set_size(30, 30)
     child.restart({ "-u", "scripts/init_auto_open.lua" })
     child.wait()
 


### PR DESCRIPTION
## 📃 Summary

Please see https://github.com/shortcuts/no-neck-pain.nvim/issues/430

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/430

## 📸 Preview

none