### PR TITLE
feat: provide pre/post enable and pre/post disable callback methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .SUFFIXES:
 
-TESTFILES=options mappings API splits tabs integrations buffers colors autocmds scratchpad commands
+TESTFILES=options mappings API splits tabs integrations buffers colors autocmds scratchpad commands callbacks
 
 all: documentation lint luals test
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ require("no-neck-pain").setup({
         ---@type string
         scratchPad = "<Leader>ns",
     },
+    --- Allows you to provide custom code to run before (pre) and after (post) no-neck-pain steps (e.g. enabling).
+    --- See |NoNeckPain.callbacks|
+    ---@type table
+    callbacks = {
+        -- Runs right before centering the buffer
+        ---@type function|nil
+        ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+        preEnable = nil,
+        -- Runs right after the buffer is centered
+        ---@type function|nil
+        ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+        postEnable = nil,
+        -- Runs right before toggling NoNeckPain off
+        ---@type function|nil
+        preDisable = nil,
+        -- Runs right after NoNeckPain has been turned off
+        ---@type function|nil
+        ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+        preDisable = nil
+    },
     --- Common options that are set to both side buffers.
     --- See |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
     ---@type table

--- a/README.md
+++ b/README.md
@@ -193,20 +193,17 @@ require("no-neck-pain").setup({
     ---@type table
     callbacks = {
         -- Runs right before centering the buffer
-        ---@type function|nil
-        ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+        ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
         preEnable = nil,
         -- Runs right after the buffer is centered
-        ---@type function|nil
-        ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+        ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
         postEnable = nil,
         -- Runs right before toggling NoNeckPain off
-        ---@type function|nil
+        ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
         preDisable = nil,
         -- Runs right after NoNeckPain has been turned off
-        ---@type function|nil
-        ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
-        preDisable = nil
+        ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
+        postDisable = nil,
     },
     --- Common options that are set to both side buffers.
     --- See |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -174,35 +174,6 @@ Default values:
 
 <
 ------------------------------------------------------------------------------
-                                                      *NoNeckPain.callbacks*
-                           `NoNeckPain.callbacks`
-NoNeckPain's pre/post enable and pre/post disable callback methods.
-
-Type ~
-`(table)`
-Default values:
->lua
-  NoNeckPain.callbacks = {
-      -- Runs right before centering the buffer
-      ---@type function|nil
-      ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
-      preEnable = nil,
-      -- Runs right after the buffer is centered
-      ---@type function|nil
-      ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
-      postEnable = nil,
-      -- Runs right before toggling NoNeckPain off
-      ---@type function|nil
-      ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
-      preDisable = nil,
-      -- Runs right after NoNeckPain has been turned off
-      ---@type function|nil
-      ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
-      preDisable = nil
-  }
-
-<
-------------------------------------------------------------------------------
                                                       *NoNeckPain.bufferOptions*
                            `NoNeckPain.bufferOptions`
 NoNeckPain's buffer side buffer option.
@@ -306,27 +277,6 @@ Default values:
           -- When `false`, the mapping is not created.
           ---@type string
           scratchPad = "<Leader>ns",
-      },
-      --- Allows you to provide custom code to run before (pre) and after (post) no-neck-pain steps (e.g. enabling).
-      --- See |NoNeckPain.callbacks|
-      ---@type table
-      callbacks = {
-          -- Runs right before centering the buffer
-          ---@type function|nil
-          ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
-          preEnable = nil,
-          -- Runs right after the buffer is centered
-          ---@type function|nil
-          ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
-          postEnable = nil,
-          -- Runs right before toggling NoNeckPain off
-          ---@type function|nil
-          ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
-          preDisable = nil,
-          -- Runs right after NoNeckPain has been turned off
-          ---@type function|nil
-          ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
-          preDisable = nil
       },
       --- Common options that are set to both side buffers.
       --- See |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
@@ -438,6 +388,23 @@ Default values:
               ---@type string|nil
               filetype = nil,
           },
+      },
+      --- Allows you to provide custom code to run before (pre) and after (post) no-neck-pain steps (e.g. enabling).
+      --- See |NoNeckPain.callbacks|
+      ---@type table
+      callbacks = {
+          -- Runs right before centering the buffer
+          ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
+          preEnable = nil,
+          -- Runs right after the buffer is centered
+          ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
+          postEnable = nil,
+          -- Runs right before toggling NoNeckPain off
+          ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
+          preDisable = nil,
+          -- Runs right after NoNeckPain has been turned off
+          ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
+          postDisable = nil,
       },
   }
 

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -174,6 +174,35 @@ Default values:
 
 <
 ------------------------------------------------------------------------------
+                                                      *NoNeckPain.callbacks*
+                           `NoNeckPain.callbacks`
+NoNeckPain's pre/post enable and pre/post disable callback methods.
+
+Type ~
+`(table)`
+Default values:
+>lua
+  NoNeckPain.callbacks = {
+      -- Runs right before centering the buffer
+      ---@type function|nil
+      ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+      preEnable = nil,
+      -- Runs right after the buffer is centered
+      ---@type function|nil
+      ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+      postEnable = nil,
+      -- Runs right before toggling NoNeckPain off
+      ---@type function|nil
+      ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+      preDisable = nil,
+      -- Runs right after NoNeckPain has been turned off
+      ---@type function|nil
+      ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+      preDisable = nil
+  }
+
+<
+------------------------------------------------------------------------------
                                                       *NoNeckPain.bufferOptions*
                            `NoNeckPain.bufferOptions`
 NoNeckPain's buffer side buffer option.
@@ -277,6 +306,27 @@ Default values:
           -- When `false`, the mapping is not created.
           ---@type string
           scratchPad = "<Leader>ns",
+      },
+      --- Allows you to provide custom code to run before (pre) and after (post) no-neck-pain steps (e.g. enabling).
+      --- See |NoNeckPain.callbacks|
+      ---@type table
+      callbacks = {
+          -- Runs right before centering the buffer
+          ---@type function|nil
+          ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+          preEnable = nil,
+          -- Runs right after the buffer is centered
+          ---@type function|nil
+          ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+          postEnable = nil,
+          -- Runs right before toggling NoNeckPain off
+          ---@type function|nil
+          ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+          preDisable = nil,
+          -- Runs right after NoNeckPain has been turned off
+          ---@type function|nil
+          ---@param state { enabled: bool, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number }
+          preDisable = nil
       },
       --- Common options that are set to both side buffers.
       --- See |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -328,6 +328,18 @@ NoNeckPain.options = {
             filetype = nil,
         },
     },
+    -- Allows you to provide custom code to run before (pre) and after (post) no-neck-pain steps (e.g. enabling).
+    ---@type table
+    callbacks = {
+        ---@type function|nil
+        preEnable   = nil,
+        ---@type function|nil
+        postEnable  = nil,
+        ---@type function|nil
+        preDisable  = nil,
+        ---@type function|nil
+        postDisable = nil
+    }
 }
 
 ---@private

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -328,18 +328,23 @@ NoNeckPain.options = {
             filetype = nil,
         },
     },
-    -- Allows you to provide custom code to run before (pre) and after (post) no-neck-pain steps (e.g. enabling).
+    --- Allows you to provide custom code to run before (pre) and after (post) no-neck-pain steps (e.g. enabling).
+    --- See |NoNeckPain.callbacks|
     ---@type table
     callbacks = {
-        ---@type function|nil
-        preEnable   = nil,
-        ---@type function|nil
-        postEnable  = nil,
-        ---@type function|nil
-        preDisable  = nil,
-        ---@type function|nil
-        postDisable = nil
-    }
+        -- Runs right before centering the buffer
+        ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
+        preEnable = nil,
+        -- Runs right after the buffer is centered
+        ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
+        postEnable = nil,
+        -- Runs right before toggling NoNeckPain off
+        ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
+        preDisable = nil,
+        -- Runs right after NoNeckPain has been turned off
+        ---@type fun(state: { enabled: boolean, active_tab: number, tabs: number[], disabled_tabs: number[], previously_focused_win: number })|nil
+        postDisable = nil,
+    },
 }
 
 ---@private

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -13,15 +13,9 @@ local main = {}
 ---@private
 function main.toggle(scope)
     if state.has_tabs(state) and state.is_active_tab_registered(state) then
-        if _G.NoNeckPain.config.callbacks.preDisable ~= nil then
-            _G.NoNeckPain.config.callbacks.preDisable(state)
-        end
         return main.disable(scope)
     end
 
-    if _G.NoNeckPain.config.callbacks.preEnable ~= nil then
-        _G.NoNeckPain.config.callbacks.preEnable(state)
-    end
     main.enable(scope)
 end
 
@@ -158,6 +152,10 @@ end
 function main.enable(scope)
     if event.skip_enable(scope) then
         return
+    end
+
+    if _G.NoNeckPain.config.callbacks.preEnable ~= nil then
+        _G.NoNeckPain.config.callbacks.preEnable(state)
     end
 
     state.set_active_tab(state, api.get_current_tab())
@@ -418,12 +416,15 @@ function main.enable(scope)
     if _G.NoNeckPain.config.callbacks.postEnable ~= nil then
         _G.NoNeckPain.config.callbacks.postEnable(state)
     end
-
 end
 
 --- Disables the plugin for the given tab, clear highlight groups and autocmds, closes side buffers and resets the internal state.
 ---@private
 function main.disable(scope)
+    if _G.NoNeckPain.config.callbacks.preDisable ~= nil then
+        _G.NoNeckPain.config.callbacks.preDisable(state)
+    end
+
     local active_tab = state.active_tab
 
     log.debug(scope, "calling disable for tab %d", active_tab)

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -13,9 +13,15 @@ local main = {}
 ---@private
 function main.toggle(scope)
     if state.has_tabs(state) and state.is_active_tab_registered(state) then
+        if _G.NoNeckPain.config.callbacks.preDisable ~= nil then
+            _G.NoNeckPain.config.callbacks.preDisable(state)
+        end
         return main.disable(scope)
     end
 
+    if _G.NoNeckPain.config.callbacks.preEnable ~= nil then
+        _G.NoNeckPain.config.callbacks.preEnable(state)
+    end
     main.enable(scope)
 end
 
@@ -408,6 +414,11 @@ function main.enable(scope)
     })
 
     state.save(state)
+
+    if _G.NoNeckPain.config.callbacks.postEnable ~= nil then
+        _G.NoNeckPain.config.callbacks.postEnable(state)
+    end
+
 end
 
 --- Disables the plugin for the given tab, clear highlight groups and autocmds, closes side buffers and resets the internal state.
@@ -484,6 +495,10 @@ function main.disable(scope)
     state.set_tab_disabled(state, active_tab)
 
     state.save(state)
+
+    if _G.NoNeckPain.config.callbacks.postDisable ~= nil then
+        _G.NoNeckPain.config.callbacks.postDisable(state)
+    end
 end
 
 return main

--- a/scripts/init_callbacks.lua
+++ b/scripts/init_callbacks.lua
@@ -1,0 +1,26 @@
+vim.cmd([[let &rtp.=','.getcwd()]])
+
+vim.cmd("set rtp+=deps/mini.nvim")
+
+-- Auto open enabled for the test
+require("no-neck-pain").setup({
+    width = 50,
+    minSideBufferWidth = 5,
+    callbacks = {
+        preEnable = function(state)
+            _G.NoNeckPainPreEnable = state.enabled
+        end,
+        postEnable = function(state)
+            _G.NoNeckPainPostEnable = state.enabled
+        end,
+        preDisable = function(state)
+            _G.NoNeckPainPreDisable = state.enabled
+        end,
+        postDisable = function(state)
+            _G.NoNeckPainPreEnable = nil
+            _G.NoNeckPainPostEnable = nil
+            _G.NoNeckPainPostDisable = state.enabled
+        end,
+    },
+})
+require("mini.test").setup()

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -65,6 +65,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
             widthUp = "<Leader>n=",
             widthDown = "<Leader>n-",
         },
+        callbacks = {},
         buffers = {
             setNames = false,
             colors = { blend = 0 },
@@ -209,6 +210,7 @@ T["setup"]["overrides default values"] = function()
             reloadOnColorSchemeChange = true,
             skipEnteringNoNeckPainBuffer = true,
         },
+        callbacks = {},
         mappings = {
             enabled = true,
             scratchPad = "<Leader>ns",

--- a/tests/test_callbacks.lua
+++ b/tests/test_callbacks.lua
@@ -1,0 +1,44 @@
+local Helpers = dofile("tests/helpers.lua")
+
+local child = Helpers.new_child_neovim()
+
+local T = MiniTest.new_set({
+    hooks = {
+        -- This will be executed before every (even nested) case
+        pre_case = function()
+            -- Restart child process with custom 'init.lua' script
+            child.restart({ "-u", "scripts/minimal_init.lua" })
+        end,
+        -- This will be executed one after all tests from this set are finished
+        post_once = child.stop,
+    },
+})
+
+T["setup"] = MiniTest.new_set()
+
+T["setup"]["execute preEnable"] = function()
+    child.restart({ "-u", "scripts/init_callbacks.lua" })
+    child.nnp()
+
+    Helpers.expect.global_type(child, "_G.NoNeckPainPreEnable", "boolean")
+    Helpers.expect.global(child, "_G.NoNeckPainPreEnable", false)
+
+    Helpers.expect.global_type(child, "_G.NoNeckPainPostEnable", "boolean")
+    Helpers.expect.global(child, "_G.NoNeckPainPostEnable", true)
+
+    Helpers.expect.global_type(child, "_G.NoNeckPainPreDisable", "nil")
+    Helpers.expect.global_type(child, "_G.NoNeckPainPostDisable", "nil")
+
+    child.nnp()
+
+    Helpers.expect.global_type(child, "_G.NoNeckPainPreEnable", "nil")
+    Helpers.expect.global_type(child, "_G.NoNeckPainPostEnable", "nil")
+
+    Helpers.expect.global_type(child, "_G.NoNeckPainPreDisable", "boolean")
+    Helpers.expect.global(child, "_G.NoNeckPainPreDisable", true)
+
+    Helpers.expect.global_type(child, "_G.NoNeckPainPostDisable", "boolean")
+    Helpers.expect.global(child, "_G.NoNeckPainPostDisable", false)
+end
+
+return T

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -386,12 +386,6 @@ T["neo-tree"]["properly enables nnp with tree already opened"] = function()
 
     child.nnp()
 
-    if child.fn.has("nvim-0.9") == 0 then
-        Helpers.expect.equality(child.get_wins_in_tab(), { 1003, 1002, 1000, 1005 })
-    else
-        Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1002, 1000, 1005 })
-    end
-
     Helpers.expect.state(child, "enabled", true)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.NeoTree", {

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -386,6 +386,12 @@ T["neo-tree"]["properly enables nnp with tree already opened"] = function()
 
     child.nnp()
 
+    if child.fn.has("nvim-0.10") == 0 then
+        Helpers.expect.equality(child.get_wins_in_tab(), { 1003, 1002, 1000, 1004 })
+    else
+        Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1002, 1000, 1005 })
+    end
+
     Helpers.expect.state(child, "enabled", true)
 
     Helpers.expect.state(child, "tabs[1].wins.integrations.NeoTree", {
@@ -395,11 +401,19 @@ T["neo-tree"]["properly enables nnp with tree already opened"] = function()
         open = "Neotree reveal",
     })
 
-    Helpers.expect.state(child, "tabs[1].wins.main", {
-        curr = 1000,
-        left = 1004,
-        right = 1005,
-    })
+    if child.fn.has("nvim-0.10") == 0 then
+        Helpers.expect.state(child, "tabs[1].wins.main", {
+            curr = 1000,
+            left = 1003,
+            right = 1004,
+        })
+    else
+        Helpers.expect.state(child, "tabs[1].wins.main", {
+            curr = 1000,
+            left = 1004,
+            right = 1005,
+        })
+    end
 end
 
 T["TSPlayground"] = MiniTest.new_set()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -386,7 +386,11 @@ T["neo-tree"]["properly enables nnp with tree already opened"] = function()
 
     child.nnp()
 
-    Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1002, 1000, 1005 })
+    if child.fn.has("nvim-0.10") == 0 then
+        Helpers.expect.equality(child.get_wins_in_tab(), { 1003, 1002, 1000, 1005 })
+    else
+        Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1002, 1000, 1005 })
+    end
 
     Helpers.expect.state(child, "enabled", true)
 

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -386,7 +386,7 @@ T["neo-tree"]["properly enables nnp with tree already opened"] = function()
 
     child.nnp()
 
-    if child.fn.has("nvim-0.10") == 0 then
+    if child.fn.has("nvim-0.9") == 0 then
         Helpers.expect.equality(child.get_wins_in_tab(), { 1003, 1002, 1000, 1005 })
     else
         Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1002, 1000, 1005 })


### PR DESCRIPTION
## 📃 Summary

This PR is a follow up of https://github.com/shortcuts/no-neck-pain.nvim/pull/448, closes https://github.com/shortcuts/no-neck-pain.nvim/issues/111

----

This is for the feature mentioned in #111, or at least some of it: User can specify callbacks in the config, that will run before and after the buffer is centered or restored. Nothing happens by default.
Callbacks take no arguments, because I don't know what values exist that would be useful to the user.

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/111

## 📸 Preview
For example, to disable the individual status line, and hide the command line, but restore both options when toggling this plugin off:
```lua
    require("no-neck-pain").setup({
    -- Some options ...
        callbacks = {
            preEnable = function()
                vim.opt.laststatus = 0
                vim.opt.cmdheight  = 0
            end,
            postDisable = function()
                vim.opt.laststatus = 2
                vim.opt.cmdheight  = 1
            end
        },
    -- Some more options ...
})
```

## Notes:
* I wouldn't know how to add tests for this feature, and maybe there is a better way of doing this. I just made a pull request because this feature was the thing I missed the most.

* [Goyo.vim](https://github.com/junegunn/goyo.vim) does this by providing `GoyoEnter` and `GoyoLeave` autocommands. I suppose there is an advantage in being able to define autocmd's at any point, but I can't think of anything that can't be defined during the initial configuration.

* Thank you for making this plugin. It is the only text-centering plugin that didn't require me to change other parts of my config.