### PR TITLE
feat: allow safe `enableOnVimEnter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ require("no-neck-pain").setup({
         -- When `true`, enables the plugin when you start Neovim.
         -- If the main window is  a side tree (e.g. NvimTree) or a dashboard, the command is delayed until it finds a valid window.
         -- The command is cleaned once it has successfuly ran once.
-        ---@type boolean
+        -- When `safe`, debounces the plugin before enabling it.
+        -- This is recommended if you:
+        --  - use a dashboard plugin, or something that also triggers when Neovim is entered.
+        --  - usually leverage commands such as `nvim +line file` which are executed after Neovim has been entered.
+        ---@type boolean | "safe"
         enableOnVimEnter = false,
         -- When `true`, enables the plugin when you enter a new Tab.
         -- note: it does not trigger if you come back to an existing tab, to prevent unwanted interfer with user's decisions.

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -234,7 +234,11 @@ Default values:
           -- When `true`, enables the plugin when you start Neovim.
           -- If the main window is  a side tree (e.g. NvimTree) or a dashboard, the command is delayed until it finds a valid window.
           -- The command is cleaned once it has successfuly ran once.
-          ---@type boolean
+          -- When `safe`, debounces the plugin before enabling it.
+          -- This is recommended if you:
+          --  - use a dashboard plugin, or something that also triggers when Neovim is entered.
+          --  - usually leverage commands such as `nvim +line file` which are executed after Neovim has been entered.
+          ---@type boolean | "safe"
           enableOnVimEnter = false,
           -- When `true`, enables the plugin when you enter a new Tab.
           -- note: it does not trigger if you come back to an existing tab, to prevent unwanted interfer with user's decisions.

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -173,7 +173,11 @@ NoNeckPain.options = {
         -- When `true`, enables the plugin when you start Neovim.
         -- If the main window is  a side tree (e.g. NvimTree) or a dashboard, the command is delayed until it finds a valid window.
         -- The command is cleaned once it has successfuly ran once.
-        ---@type boolean
+        -- When `safe`, debounces the plugin before enabling it.
+        -- This is recommended if you:
+        --  - use a dashboard plugin, or something that also triggers when Neovim is entered.
+        --  - usually leverage commands such as `nvim +line file` which are executed after Neovim has been entered.
+        ---@type boolean | "safe"
         enableOnVimEnter = false,
         -- When `true`, enables the plugin when you enter a new Tab.
         -- note: it does not trigger if you come back to an existing tab, to prevent unwanted interfer with user's decisions.
@@ -415,6 +419,10 @@ function NoNeckPain.defaults(options)
         NoNeckPain.options.width = tonumber(
             vim.api.nvim_get_option_value("colorcolumn", { scope = "global" })
         ) or 0
+    end
+
+    if NoNeckPain.options.integrations.dashboard.enabled == true then
+        NoNeckPain.options.autocmds.enableOnVimEnter = "safe"
     end
 
     assert(NoNeckPain.options.width > 0, "`width` must be greater than 0.")

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -106,7 +106,7 @@ function NoNeckPain.setup(opts)
         })
     end
 
-    if _G.NoNeckPain.config.autocmds.enableOnVimEnter then
+    if _G.NoNeckPain.config.autocmds.enableOnVimEnter ~= nil then
         vim.api.nvim_create_autocmd({ "BufEnter" }, {
             pattern = "*",
             callback = function()
@@ -115,7 +115,7 @@ function NoNeckPain.setup(opts)
                     config.options.integrations.dashboard.enabled
                 )
 
-                if config.options.integrations.dashboard.enabled == true then
+                if config.options.autocmds.enableOnVimEnter == "safe" then
                     api.debounce(scope, function()
                         main.enable(scope)
                         if _G.NoNeckPain.state ~= nil then

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -106,7 +106,7 @@ function NoNeckPain.setup(opts)
         })
     end
 
-    if _G.NoNeckPain.config.autocmds.enableOnVimEnter ~= nil then
+    if _G.NoNeckPain.config.autocmds.enableOnVimEnter ~= nil and _G.NoNeckPain.config.autocmds.enableOnVimEnter ~= false then
         vim.api.nvim_create_autocmd({ "BufEnter" }, {
             pattern = "*",
             callback = function()


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/455

commands like `nvim +line file` are executed once nvim has been entered, which is similar to dashboard plugins executing things once entered.

using such commands or dashboards can create race conditions with how we shift windows around, `enableOnVimEnter` now allows `"safe"` to be provided, which debounces enabling the plugin until we found a suitable time (e.g. when other plugins have executed)

this however creates a small (few ms) layout shift that could be noticeable