### PR TITLE
fix: properly reset window options on `bd`

### DIFF
--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -10,8 +10,32 @@ local state = {
     active_tab = api.get_current_tab(),
     tabs = {},
     disabled_tabs = {},
+    initial_window_opts = {},
     previously_focused_win = vim.api.nvim_get_current_win(),
 }
+
+if state.initial_window_opts == nil or #state.initial_window_opts == 0 then
+    state.initial_window_opts = {}
+
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(state.active_tab)) do
+        if not api.is_relative_window(win) then
+            -- keep this list in sync with config.NoNeckPain.bufferOptionsWo
+            for _, opt in ipairs({
+                "cursorline",
+                "cursorcolumn",
+                "colorcolumn",
+                "number",
+                "relativenumber",
+                "foldenable",
+                "list",
+                "wrap",
+                "linebreak",
+            }) do
+                state.initial_window_opts[opt] = vim.api.nvim_win_get_option(win, opt)
+            end
+        end
+    end
+end
 
 --- Sets the state to its original value.
 ---

--- a/tests/test_options.lua
+++ b/tests/test_options.lua
@@ -90,4 +90,25 @@ T["fallbackOnBufferDelete"]["still allows nvim to quit"] = function()
     end)
 end
 
+T["fallbackOnBufferDelete"]["invoking :bd properly resets window options"] = function()
+    child.lua([[ require('no-neck-pain').setup({width=50,fallbackOnBufferDelete=true}) ]])
+
+    Helpers.expect.config(child, "fallbackOnBufferDelete", true)
+    child.nnp()
+
+    Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
+
+    child.cmd("badd 1")
+    child.cmd("bd")
+    child.loop.sleep(500)
+
+    if child.fn.has("nvim-0.10") == 0 then
+        Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1003, left = 1004, right = 1005 })
+    else
+        Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1004, left = 1005, right = 1006 })
+    end
+
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_option(0, 'linebreak')"), false)
+end
+
 return T


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/449

when creating a new window from neovim/vim commands, it uses `win_alloc` (https://github.com/neovim/neovim/blob/master/src/nvim/window.c#L5127) which copies the currently focused window option, which leads to this issue of line number disappearing because the last opened window is a side buffer, that has different window option.

sadly, `win_alloc_first` (https://github.com/neovim/neovim/blob/master/src/nvim/window.c#L4052) isn't publicly exposed, so the only solution is to copy the user's window option at startup