### PR TITLE
fix: do not resize integration windows

### DIFF
--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -114,8 +114,9 @@ function NoNeckPain.setup(opts)
             pattern = "*",
             callback = function()
                 local scope = string.format(
-                    "enable_on_vim_enter:%s",
-                    config.options.integrations.dashboard.enabled
+                    "enable_on_vim_enter:%s:%s",
+                    config.options.integrations.dashboard.enabled,
+                    config.options.autocmds.enableOnVimEnter
                 )
 
                 if config.options.autocmds.enableOnVimEnter == "safe" then

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -486,21 +486,28 @@ function state:walk_layout(scope, tree, has_col_parent, resize_only)
                 self.set_layout_windows(self, scope, leafs)
             else
                 for _, sub_leaf in ipairs(leafs) do
+                    if sub_leaf[1] ~= "leaf" then
+                        goto continue
+                    end
+
                     local id = sub_leaf[2]
+
                     local supported, name, integration =
                         self.is_supported_integration(self, scope, id)
+
                     if supported and name and integration then
                         log.debug(scope, "skipping resize itegration %s with id %d", name, id)
+
                         goto continue
                     end
 
                     if
-                        sub_leaf[1] == "leaf"
-                        and self.get_side_id(self, "left") ~= id
+                        self.get_side_id(self, "left") ~= id
                         and self.get_side_id(self, "right") ~= id
                     then
                         self.resize_win(self, id, _G.NoNeckPain.config.width, "unregistered")
                     end
+
                     ::continue::
                 end
             end

--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -52,7 +52,7 @@ function ui.move_sides(scope)
                 log.debug(
                     sscope,
                     "wrong position after window move, focusing %s, should be %d, wins order %s",
-                    vim.api.nvim_get_current_win(),
+                    curr,
                     id,
                     vim.inspect(wins)
                 )

--- a/lua/no-neck-pain/util/event.lua
+++ b/lua/no-neck-pain/util/event.lua
@@ -57,7 +57,7 @@ function event.skip_enable(scope)
         return true
     end
 
-    return state.is_supported_integration(state, "event.skip_enable", nil)
+    return state.is_supported_integration(state, "event.skip_enable", 0)
 end
 
 return event

--- a/scripts/init_with_nvimtree.lua
+++ b/scripts/init_with_nvimtree.lua
@@ -6,7 +6,7 @@ vim.cmd("set rtp+=deps/nvimtree")
 require("nvim-tree").setup({ view = { width = 1 } })
 require("mini.test").setup()
 require("no-neck-pain").setup({
-    width = 1,
+    width = 20,
     minSideBufferWidth = 0,
     integrations = { NvimTree = { reopen = true } },
 })

--- a/scripts/init_with_outline.lua
+++ b/scripts/init_with_outline.lua
@@ -6,7 +6,7 @@ vim.cmd("set rtp+=deps/outline")
 require("mini.test").setup()
 require("outline").setup()
 require("no-neck-pain").setup({
-    width = 1,
+    width = 20,
     minSideBufferWidth = 0,
     integrations = { outline = { reopen = true } },
 })

--- a/scripts/init_with_tsplayground.lua
+++ b/scripts/init_with_tsplayground.lua
@@ -10,4 +10,12 @@ require("nvim-treesitter.configs").setup({
     },
 })
 require("mini.test").setup()
-require("no-neck-pain").setup({ debug = true, width = 20 })
+require("no-neck-pain").setup({
+    debug = true, width = 20,
+    integrations = {
+        TSPlayground = {
+            position = "left",
+            reopen = true,
+        },
+    }
+})

--- a/scripts/init_with_tsplayground.lua
+++ b/scripts/init_with_tsplayground.lua
@@ -11,11 +11,12 @@ require("nvim-treesitter.configs").setup({
 })
 require("mini.test").setup()
 require("no-neck-pain").setup({
-    debug = true, width = 20,
+    debug = true,
+    width = 20,
     integrations = {
         TSPlayground = {
             position = "left",
             reopen = true,
         },
-    }
+    },
 })

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -19,6 +19,36 @@ Helpers.expect.buf_width = MiniTest.new_expectation(
     error_message
 )
 
+Helpers.expect.min = MiniTest.new_expectation(
+    "variable in child process matches",
+    function(min, value)
+        if min < value then
+            local context = string.format('Left:  %s\nRight: %s', vim.inspect(min), vim.inspect(value))
+            MiniTest.error_expect('min', context)
+
+            return
+        end
+
+        return true
+    end,
+    error_message
+)
+
+Helpers.expect.max = MiniTest.new_expectation(
+    "variable in child process matches",
+    function(max, value)
+        if max > value then
+            local context = string.format('Left:  %s\nRight: %s', vim.inspect(max), vim.inspect(value))
+            MiniTest.error_expect('max', context)
+
+            return
+        end
+
+        return true
+    end,
+    error_message
+)
+
 Helpers.expect.global = MiniTest.new_expectation(
     "variable in child process matches",
     function(child, field, value)

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -23,8 +23,9 @@ Helpers.expect.min = MiniTest.new_expectation(
     "variable in child process matches",
     function(min, value)
         if min < value then
-            local context = string.format('Left:  %s\nRight: %s', vim.inspect(min), vim.inspect(value))
-            MiniTest.error_expect('min', context)
+            local context =
+                string.format("Left:  %s\nRight: %s", vim.inspect(min), vim.inspect(value))
+            MiniTest.error_expect("min", context)
 
             return
         end
@@ -38,8 +39,9 @@ Helpers.expect.max = MiniTest.new_expectation(
     "variable in child process matches",
     function(max, value)
         if max > value then
-            local context = string.format('Left:  %s\nRight: %s', vim.inspect(max), vim.inspect(value))
-            MiniTest.error_expect('max', context)
+            local context =
+                string.format("Left:  %s\nRight: %s", vim.inspect(max), vim.inspect(value))
+            MiniTest.error_expect("max", context)
 
             return
         end

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -482,7 +482,8 @@ T["TSPlayground"]["keeps sides open"] = function()
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 20)
+    Helpers.expect.min(child.lua_get("vim.api.nvim_win_get_width(1004)"), 18)
+    Helpers.expect.max(child.lua_get("vim.api.nvim_win_get_width(1004)"), 19)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
@@ -607,7 +608,7 @@ T["aerial"]["keeps sides open"] = function()
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 20)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 14)
     Helpers.expect.state(child, "tabs[1].wins.integrations.aerial.id", 1004)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -368,6 +368,7 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
     Helpers.expect.equality(child.get_current_win(), 1003)
     Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
 
     child.cmd("vsplit")
     child.wait()


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/467
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/453
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/450
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/411

we shouldn't have to resize the integrations, since we compute the width of a side based on the width of the integration
