### PR TITLE
fix: properly compute remaining width after integrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ test:
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua MiniTest.run({ execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
 
+test-race:
+	for i in {1..10}; do make test || break ; done
+
 test-nightly:
 	bob use nightly
 	make test
@@ -18,6 +21,10 @@ $(addprefix test-, $(TESTFILES)): test-%:
 	nvim --version | head -n 1 && echo ''
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua \
 		-c "lua MiniTest.run_file('tests/test_$*.lua', { execute = { reporter = MiniTest.gen_reporter.stdout({ group_depth = 2 }) } })"
+
+$(addprefix test-race-, $(TESTFILES)): test-race-%:
+	for i in {1..10}; do make test-$* || break ; done
+
 deps:
 	./scripts/clone_deps.sh 1 || true
 
@@ -27,7 +34,7 @@ deps-lint:
 	luarocks install lanes --force
 	luarocks install luacheck --force
 
-test-ci: deps test
+test-ci: deps test-race
 
 documentation:
 	nvim --headless --noplugin -u ./scripts/minimal_init.lua -c "lua require('mini.doc').generate()" -c "qa!"

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -20,7 +20,7 @@ Toggles the debug mode of the plugin.
 Sets the config `width` to the given `width` value and resizes the NoNeckPain windows.
 
 Parameters ~
-{width} `(number:)` any positive integer superior to 0.
+{width} `(number)`: any positive integer superior to 0.
 
 ------------------------------------------------------------------------------
                                                       *NoNeckPain.toggle_side()*
@@ -28,7 +28,7 @@ Parameters ~
 Toggles the config `${side}.enabled` and re-inits the plugin.
 
 Parameters ~
-{side} "left" | "right": the side to toggle.
+{side} "`(left)`" | "right": the side to toggle.
 
 ------------------------------------------------------------------------------
                                                            *NoNeckPain.enable()*

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -5,9 +5,14 @@
 Toggle the plugin by calling the `enable`/`disable` methods respectively.
 
 ------------------------------------------------------------------------------
-                                                 *NoNeckPain.toggleScratchPad()*
-                        `NoNeckPain.toggleScratchPad`()
+                                                *NoNeckPain.toggle_scratchPad()*
+                        `NoNeckPain.toggle_scratchPad`()
 Toggles the scratchPad feature of the plugin.
+
+------------------------------------------------------------------------------
+                                                     *NoNeckPain.toggle_debug()*
+                          `NoNeckPain.toggle_debug`()
+Toggles the debug mode of the plugin.
 
 ------------------------------------------------------------------------------
                                                            *NoNeckPain.resize()*
@@ -281,6 +286,10 @@ Default values:
           -- When `false`, the mapping is not created.
           ---@type string
           scratchPad = "<Leader>ns",
+          -- Sets a global mapping to Neovim, which allows you to toggle the debug mode.
+          -- When `false`, the mapping is not created.
+          ---@type string
+          debug = "<Leader>nd",
       },
       --- Common options that are set to both side buffers.
       --- See |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.

--- a/doc/no-neck-pain.txt
+++ b/doc/no-neck-pain.txt
@@ -23,8 +23,8 @@ Parameters ~
 {width} `(number:)` any positive integer superior to 0.
 
 ------------------------------------------------------------------------------
-                                                       *NoNeckPain.toggleSide()*
-                        `NoNeckPain.toggleSide`({side})
+                                                      *NoNeckPain.toggle_side()*
+                        `NoNeckPain.toggle_side`({side})
 Toggles the config `${side}.enabled` and re-inits the plugin.
 
 Parameters ~

--- a/doc/tags
+++ b/doc/tags
@@ -9,5 +9,6 @@ NoNeckPain.options	no-neck-pain.txt	/*NoNeckPain.options*
 NoNeckPain.resize()	no-neck-pain.txt	/*NoNeckPain.resize()*
 NoNeckPain.setup()	no-neck-pain.txt	/*NoNeckPain.setup()*
 NoNeckPain.toggle()	no-neck-pain.txt	/*NoNeckPain.toggle()*
-NoNeckPain.toggleScratchPad()	no-neck-pain.txt	/*NoNeckPain.toggleScratchPad()*
 NoNeckPain.toggleSide()	no-neck-pain.txt	/*NoNeckPain.toggleSide()*
+NoNeckPain.toggle_debug()	no-neck-pain.txt	/*NoNeckPain.toggle_debug()*
+NoNeckPain.toggle_scratchPad()	no-neck-pain.txt	/*NoNeckPain.toggle_scratchPad()*

--- a/doc/tags
+++ b/doc/tags
@@ -9,6 +9,6 @@ NoNeckPain.options	no-neck-pain.txt	/*NoNeckPain.options*
 NoNeckPain.resize()	no-neck-pain.txt	/*NoNeckPain.resize()*
 NoNeckPain.setup()	no-neck-pain.txt	/*NoNeckPain.setup()*
 NoNeckPain.toggle()	no-neck-pain.txt	/*NoNeckPain.toggle()*
-NoNeckPain.toggleSide()	no-neck-pain.txt	/*NoNeckPain.toggleSide()*
 NoNeckPain.toggle_debug()	no-neck-pain.txt	/*NoNeckPain.toggle_debug()*
 NoNeckPain.toggle_scratchPad()	no-neck-pain.txt	/*NoNeckPain.toggle_scratchPad()*
+NoNeckPain.toggle_side()	no-neck-pain.txt	/*NoNeckPain.toggle_side()*

--- a/lua/no-neck-pain/config.lua
+++ b/lua/no-neck-pain/config.lua
@@ -220,6 +220,10 @@ NoNeckPain.options = {
         -- When `false`, the mapping is not created.
         ---@type string
         scratchPad = "<Leader>ns",
+        -- Sets a global mapping to Neovim, which allows you to toggle the debug mode.
+        -- When `false`, the mapping is not created.
+        ---@type string
+        debug = "<Leader>nd",
     },
     --- Common options that are set to both side buffers.
     --- See |NoNeckPain.bufferOptions| for option scoped to the `left` and/or `right` buffer.
@@ -501,6 +505,7 @@ function NoNeckPain.setup(options)
         widthUp = ":NoNeckPainWidthUp<CR>",
         widthDown = ":NoNeckPainWidthDown<CR>",
         scratchPad = ":NoNeckPainScratchPad<CR>",
+        debug = ":NoNeckPainDebug<CR>",
     })
 
     return NoNeckPain.options

--- a/lua/no-neck-pain/init.lua
+++ b/lua/no-neck-pain/init.lua
@@ -15,7 +15,7 @@ function NoNeckPain.toggle()
 end
 
 --- Toggles the scratchPad feature of the plugin.
-function NoNeckPain.toggleScratchPad()
+function NoNeckPain.toggle_scratchPad()
     if _G.NoNeckPain.state == nil or not _G.NoNeckPain.state.enabled then
         error("no-neck-pain.nvim must be enabled, run `NoNeckPain` first.")
     end
@@ -25,6 +25,19 @@ function NoNeckPain.toggleScratchPad()
     end
 
     main.toggle_scratchPad()
+end
+
+--- Toggles the debug mode of the plugin.
+function NoNeckPain.toggle_debug()
+    if _G.NoNeckPain.state == nil or not _G.NoNeckPain.state.enabled then
+        error("no-neck-pain.nvim must be enabled, run `NoNeckPain` first.")
+    end
+
+    if _G.NoNeckPain.config == nil then
+        _G.NoNeckPain.config = config.options
+    end
+
+    _G.NoNeckPain.config.debug = not _G.NoNeckPain.config.debug
 end
 
 --- Sets the config `width` to the given `width` value and resizes the NoNeckPain windows.
@@ -51,7 +64,7 @@ end
 --- Toggles the config `${side}.enabled` and re-inits the plugin.
 ---
 ---@param side "left" | "right": the side to toggle.
-function NoNeckPain.toggleSide(side)
+function NoNeckPain.toggle_side(side)
     if _G.NoNeckPain.state == nil or not _G.NoNeckPain.state.enabled then
         error("no-neck-pain.nvim must be enabled, run `NoNeckPain` first.")
     end

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -133,15 +133,6 @@ function main.init(scope)
         end
     end
 
-    -- if we still have side buffers and something else opened than the `curr`
-    -- there might be width issues so we the resize_win opened vsplits.
-    if
-        state.check_sides(state, "or", true)
-        and state.get_columns(state) > state.get_nb_sides(state) + 1
-    then
-        state.walk_layout(state, scope, vim.fn.winlayout(state.active_tab), false, true)
-    end
-
     state.save(state)
 end
 

--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -231,9 +231,7 @@ function main.enable(scope)
                 end
 
                 if init then
-                    api.debounce(s, function()
-                        return main.init(s)
-                    end)
+                    api.debounce(s, main.init)
                 end
             end)
         end,

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -401,12 +401,11 @@ end
 ---@param scope string: the caller of the method.
 ---@param id number: the id of the window.
 ---@param width number: the width to apply to the window.
----@param side "left"|"right"|"curr"|"unregistered": the side of the window being resized, used for logging only.
 ---@private
-function state:resize_win(scope, id, width, side)
+function state:resize_win(scope, id, width)
     log.debug(scope, "win %d with width %d", id, width)
 
-    if vim.api.nvim_win_is_valid(id) then
+    if id ~= nil and vim.api.nvim_win_is_valid(id) then
         vim.api.nvim_win_set_width(id, width)
     else
         log.debug(scope, "win is not valid")
@@ -508,7 +507,7 @@ function state:walk_layout(scope, tree, has_col_parent, resize_only)
                         self.get_side_id(self, "left") ~= id
                         and self.get_side_id(self, "right") ~= id
                     then
-                        self.resize_win(self, scope, id, _G.NoNeckPain.config.width, "unregistered")
+                        self.resize_win(self, scope, id, _G.NoNeckPain.config.width)
                     end
 
                     ::continue::

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -403,10 +403,14 @@ end
 ---@param side "left"|"right"|"curr"|"unregistered": the side of the window being resized, used for logging only.
 ---@private
 function state:resize_win(id, width, side)
-    log.debug(side, "resizing %d with padding %d", id, width)
+    local scope = string.format("resize_win_%s", side)
+
+    log.debug(scope, "win %d with width %d", id, width)
 
     if vim.api.nvim_win_is_valid(id) then
         vim.api.nvim_win_set_width(id, width)
+    else
+        log.debug(scope, "win is not valid")
     end
 end
 

--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -398,13 +398,12 @@ end
 
 --- Resizes a window if it's valid.
 ---
+---@param scope string: the caller of the method.
 ---@param id number: the id of the window.
 ---@param width number: the width to apply to the window.
 ---@param side "left"|"right"|"curr"|"unregistered": the side of the window being resized, used for logging only.
 ---@private
-function state:resize_win(id, width, side)
-    local scope = string.format("resize_win_%s", side)
-
+function state:resize_win(scope, id, width, side)
     log.debug(scope, "win %d with width %d", id, width)
 
     if vim.api.nvim_win_is_valid(id) then
@@ -500,7 +499,7 @@ function state:walk_layout(scope, tree, has_col_parent, resize_only)
                         self.is_supported_integration(self, scope, id)
 
                     if supported and name and integration then
-                        log.debug(scope, "skipping resize itegration %s with id %d", name, id)
+                        log.debug(scope, "skipping resize integration %s with id %d", name, id)
 
                         goto continue
                     end
@@ -509,7 +508,7 @@ function state:walk_layout(scope, tree, has_col_parent, resize_only)
                         self.get_side_id(self, "left") ~= id
                         and self.get_side_id(self, "right") ~= id
                     then
-                        self.resize_win(self, id, _G.NoNeckPain.config.width, "unregistered")
+                        self.resize_win(self, scope, id, _G.NoNeckPain.config.width, "unregistered")
                     end
 
                     ::continue::

--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -171,7 +171,7 @@ function ui.create_side_buffers()
 
             if padding > _G.NoNeckPain.config.minSideBufferWidth then
                 api.debounce(scope, function()
-                    state.resize_win(state, scope, state.get_side_id(state, side), padding, side)
+                    state.resize_win(state, scope, state.get_side_id(state, side), padding)
 
                     -- if we columns other than side buffer and curr,
                     -- we should resize every windows that are not an integration
@@ -180,7 +180,7 @@ function ui.create_side_buffers()
                     if state.get_columns(state) > state.get_nb_sides(state) + 1 then
                         state.walk_layout(
                             state,
-                            "ui.create_side_buffers:unregistered",
+                            string.format("%s:unregistered", scope),
                             vim.fn.winlayout(state.active_tab),
                             false,
                             true

--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -167,11 +167,14 @@ function ui.create_side_buffers()
     for _, side in pairs(constants.SIDES) do
         if state.is_side_enabled_and_valid(state, side) then
             local padding = wins[side].padding or ui.get_side_width(side)
+            local scope = string.format("ui.create_side_buffers:%s", side)
 
             if padding > _G.NoNeckPain.config.minSideBufferWidth then
-                state.resize_win(state, state.get_side_id(state, side), padding, side)
+                api.debounce(scope, function()
+                    state.resize_win(state, state.get_side_id(state, side), padding, side)
+                end)
             else
-                ui.close_win("ui.create_side_buffers", state.get_side_id(state, side), side)
+                ui.close_win(scope, state.get_side_id(state, side), side)
                 state.set_side_id(state, nil, side)
             end
         end
@@ -215,7 +218,7 @@ function ui.get_side_width(side)
             then
                 local width = vim.api.nvim_win_get_width(opts.id)
 
-                log.debug(scope, "%s opened with width %d", name, integration_width)
+                log.debug(scope, "%s opened with width %d", name, width)
 
                 integration_width = integration_width + width
             end
@@ -224,16 +227,12 @@ function ui.get_side_width(side)
         end
     end
 
-    log.debug(scope, "%d/%d columns after integration removal", columns, state.get_columns(state))
-
-    if integration_width > 0 then
-        log.debug(
-            scope,
-            "%d total width integrations - %d columns remaining",
-            integration_width,
-            columns
-        )
-    end
+    log.debug(
+        scope,
+        "%d total width integrations - %d columns remaining",
+        integration_width,
+        columns
+    )
 
     local columns_width = 0
 

--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -171,7 +171,21 @@ function ui.create_side_buffers()
 
             if padding > _G.NoNeckPain.config.minSideBufferWidth then
                 api.debounce(scope, function()
-                    state.resize_win(state, state.get_side_id(state, side), padding, side)
+                    state.resize_win(state, scope, state.get_side_id(state, side), padding, side)
+
+                    -- if we columns other than side buffer and curr,
+                    -- we should resize every windows that are not an integration
+                    -- or a side, in order to make sure the resize of the side
+                    -- does not squeeze them
+                    if state.get_columns(state) > state.get_nb_sides(state) + 1 then
+                        state.walk_layout(
+                            state,
+                            "ui.create_side_buffers:unregistered",
+                            vim.fn.winlayout(state.active_tab),
+                            false,
+                            true
+                        )
+                    end
                 end)
             else
                 ui.close_win(scope, state.get_side_id(state, side), side)
@@ -221,9 +235,9 @@ function ui.get_side_width(side)
                 log.debug(scope, "%s opened with width %d", name, width)
 
                 integration_width = integration_width + width
-            end
 
-            columns = columns - 1
+                columns = columns - 1
+            end
         end
     end
 

--- a/plugin/no-neck-pain.lua
+++ b/plugin/no-neck-pain.lua
@@ -9,11 +9,11 @@ vim.api.nvim_create_user_command("NoNeckPain", function()
 end, { desc = "Toggles the plugin." })
 
 vim.api.nvim_create_user_command("NoNeckPainToggleLeftSide", function()
-    require("no-neck-pain").toggleSide("left")
+    require("no-neck-pain").toggle_side("left")
 end, { desc = "Toggles the left side buffer (open/close)." })
 
 vim.api.nvim_create_user_command("NoNeckPainToggleRightSide", function()
-    require("no-neck-pain").toggleSide("right")
+    require("no-neck-pain").toggle_side("right")
 end, { desc = "Toggles the right side buffer (open/close)." })
 
 vim.api.nvim_create_user_command("NoNeckPainResize", function(tbl)
@@ -33,5 +33,9 @@ vim.api.nvim_create_user_command("NoNeckPainWidthDown", function()
 end, { desc = "Decrease the width of the main window by 5." })
 
 vim.api.nvim_create_user_command("NoNeckPainScratchPad", function()
-    require("no-neck-pain").toggleScratchPad()
+    require("no-neck-pain").toggle_scratchPad()
 end, { desc = "Toggles the scratchPad feature of the plugin." })
+
+vim.api.nvim_create_user_command("NoNeckPainDebug", function()
+    require("no-neck-pain").toggle_debug()
+end, { desc = "Toggles the debug mode of the plugin." })

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,3 +1,5 @@
+local api = dofile("lua/no-neck-pain/util/api.lua")
+
 -- imported from https://github.com/echasnovski/mini.nvim
 local Helpers = {}
 
@@ -19,18 +21,23 @@ Helpers.expect.buf_width = MiniTest.new_expectation(
     error_message
 )
 
-Helpers.expect.min = MiniTest.new_expectation(
+Helpers.expect.buf_width_in_range = MiniTest.new_expectation(
     "variable in child process matches",
-    function(min, value)
-        if min < value then
-            local context =
-                string.format("Left:  %s\nRight: %s", vim.inspect(min), vim.inspect(value))
-            MiniTest.error_expect("min", context)
+    function(child, winid, min, max)
+        local i = 0
+        repeat
+            child.wait(100 + i * i * 10)
 
-            return
-        end
+            local width = child.lua_get("vim.api.nvim_win_get_width(" .. winid .. ")")
 
-        return true
+            if width <= max and width >= min then
+                return true
+            end
+
+            i = i + 1
+        until i == 10
+
+        error(string.format("Left:  %s\nRight: %s", vim.inspect(max), vim.inspect(width)))
     end,
     error_message
 )

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -25,10 +25,11 @@ Helpers.expect.buf_width_in_range = MiniTest.new_expectation(
     "variable in child process matches",
     function(child, winid, min, max)
         local i = 0
+        local width = 0
         repeat
             child.wait(100 + i * i * 10)
 
-            local width = child.lua_get("vim.api.nvim_win_get_width(" .. winid .. ")")
+            width = child.lua_get("vim.api.nvim_win_get_width(" .. winid .. ")")
 
             if width <= max and width >= min then
                 return true

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -36,8 +36,9 @@ T["setup"]["sets exposed methods and default options value"] = function()
     Helpers.expect.global_type(child, "_G.NoNeckPain.setup", "function")
     Helpers.expect.global_type(child, "_G.NoNeckPain.resize", "function")
     Helpers.expect.global_type(child, "_G.NoNeckPain.disable", "function")
-    Helpers.expect.global_type(child, "_G.NoNeckPain.toggleSide", "function")
-    Helpers.expect.global_type(child, "_G.NoNeckPain.toggleScratchPad", "function")
+    Helpers.expect.global_type(child, "_G.NoNeckPain.toggle_side", "function")
+    Helpers.expect.global_type(child, "_G.NoNeckPain.toggle_scratchPad", "function")
+    Helpers.expect.global_type(child, "_G.NoNeckPain.toggle_debug", "function")
 
     -- config
     Helpers.expect.global_type(child, "_G.NoNeckPain.config", "table")
@@ -64,6 +65,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
             toggleRightSide = "<Leader>nqr",
             widthUp = "<Leader>n=",
             widthDown = "<Leader>n-",
+            debug = "<Leader>nd",
         },
         callbacks = {},
         buffers = {
@@ -219,6 +221,7 @@ T["setup"]["overrides default values"] = function()
             toggleRightSide = "<Leader>nqr",
             widthUp = "<Leader>n=",
             widthDown = "<Leader>n-",
+            debug = "<Leader>nd",
         },
         buffers = {
             setNames = false,

--- a/tests/test_autocmds.lua
+++ b/tests/test_autocmds.lua
@@ -56,8 +56,8 @@ T["auto command"]["does not shift when opening/closing float window"] = function
         right = 1002,
     })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 13, 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 13, 15)
 
     child.api.nvim_open_win(
         0,
@@ -72,8 +72,8 @@ T["auto command"]["does not shift when opening/closing float window"] = function
         right = 1002,
     })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 13, 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 13, 15)
 
     -- Close float window keeps the buffer here with the same width
     child.fn.win_gotoid(1003)
@@ -86,8 +86,8 @@ T["auto command"]["does not shift when opening/closing float window"] = function
         right = 1002,
     })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 13, 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 13, 15)
 end
 
 T["skipEnteringNoNeckPainBuffer"] = MiniTest.new_set()

--- a/tests/test_buffers.lua
+++ b/tests/test_buffers.lua
@@ -222,8 +222,7 @@ T["curr"]["have the width from the config"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
     child.nnp()
 
-    -- need to know why the child isn't precise enough
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 46, 48)
 end
 
 T["curr"]["closing `curr` window without any other window quits Neovim"] = function()
@@ -249,23 +248,23 @@ T["left/right"]["setNames doesn't throw when re-creating side buffers"] = functi
     -- enable
     child.nnp()
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 13, 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 13, 15)
 
     -- toggle
     child.nnp()
     child.nnp()
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 13, 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 13, 15)
 end
 
 T["left/right"]["have the same width"] = function()
     child.lua([[ require('no-neck-pain').setup({width=50}) ]])
     child.nnp()
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 13, 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 13, 15)
 end
 
 T["left/right"]["only creates a `left` buffer when `right.enabled` is `false`"] = function()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -481,15 +481,15 @@ T["TSPlayground"]["keeps sides open"] = function()
     child.wait()
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 4)
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1004, 1000, 1002 })
 
-    Helpers.expect.min(child.lua_get("vim.api.nvim_win_get_width(1004)"), 18)
-    Helpers.expect.max(child.lua_get("vim.api.nvim_win_get_width(1004)"), 19)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
         id = 1004,
         open = "TSPlaygroundToggle",
     })
+    Helpers.expect.buf_width_in_range(child, "1004", 18, 19)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -549,8 +549,8 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
 
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 28, 30)
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 28)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
@@ -578,7 +578,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
         left = 1001,
         right = nil,
     })
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 38, 40)
 end
 
 T["aerial"] = MiniTest.new_set()

--- a/tests/test_integrations.lua
+++ b/tests/test_integrations.lua
@@ -489,7 +489,7 @@ T["TSPlayground"]["keeps sides open"] = function()
         id = 1004,
         open = "TSPlaygroundToggle",
     })
-    Helpers.expect.buf_width_in_range(child, "1004", 18, 19)
+    Helpers.expect.buf_width_in_range(child, "1004", 26, 30)
 
     Helpers.expect.state(child, "tabs[1].wins.main", {
         curr = 1000,
@@ -549,8 +549,8 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
 
     Helpers.expect.state(child, "tabs[1].wins.columns", 3)
 
-    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 28, 30)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 28)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 18, 20)
+    Helpers.expect.buf_width_in_range(child, "1003", 26, 38)
     Helpers.expect.state(child, "tabs[1].wins.integrations.TSPlayground", {
         close = "TSPlaygroundToggle",
         fileTypePattern = "tsplayground",
@@ -578,7 +578,7 @@ T["TSPlayground"]["reduces `left` side if only active when integration is on `ri
         left = 1001,
         right = nil,
     })
-    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 38, 40)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 28, 40)
 end
 
 T["aerial"] = MiniTest.new_set()

--- a/tests/test_mappings.lua
+++ b/tests/test_mappings.lua
@@ -67,7 +67,8 @@ T["setup"]["overrides default values"] = function()
             widthDown = "<Leader>k=",
             toggleLeftSide = "<Leader>kl",
             toggleRightSide = "<Leader>kr",
-            scratchPad = "<Leader>ks"
+            scratchPad = "<Leader>ks",
+            debug = "<Leader>kd"
         }
     })]])
 
@@ -79,6 +80,7 @@ T["setup"]["overrides default values"] = function()
         toggleRightSide = "<Leader>kr",
         widthDown = "<Leader>k=",
         widthUp = "<Leader>k-",
+        debug = "<Leader>kd",
     })
 end
 
@@ -97,6 +99,7 @@ T["setup"]["allow widthUp and widthDown to be configurable"] = function()
         toggle = "<Leader>np",
         toggleLeftSide = "<Leader>nql",
         toggleRightSide = "<Leader>nqr",
+        debug = "<Leader>nd",
         widthDown = {
             mapping = "<Leader>k=",
             value = 99,
@@ -117,7 +120,8 @@ T["setup"]["does not create mappings if false"] = function()
             toggleRightSide = false,
             widthUp = false,
             widthDown = false,
-            scratchPad = false
+            scratchPad = false,
+            debug = false
         }
     })]])
 
@@ -129,6 +133,7 @@ T["setup"]["does not create mappings if false"] = function()
         toggleRightSide = false,
         widthUp = false,
         widthDown = false,
+        debug = false,
     })
 
     -- toggle plugin state

--- a/tests/test_options.lua
+++ b/tests/test_options.lua
@@ -22,8 +22,8 @@ T["minSideBufferWidth"]["closes side buffer respecting the given value"] = funct
 
     Helpers.expect.state(child, "tabs[1].wins.main", { curr = 1000, left = 1001, right = 1002 })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 13, 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 13, 15)
 
     child.lua([[
         require('no-neck-pain').disable()

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -72,8 +72,8 @@ T["split"]["keeps side buffers"] = function()
     child.cmd("q")
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 30)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 28)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 28, 30)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 28, 30)
 end
 
 T["split"]["keeps correct focus"] = function()
@@ -109,11 +109,11 @@ T["split"]["correctly starts nnp with previously opened splits"] = function()
 
     child.nnp()
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 30)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 28)
+    Helpers.expect.buf_width_in_range(child, "1002", 28, 30)
+    Helpers.expect.buf_width_in_range(child, "1003", 28, 30)
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1000)"), 20)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1001)"), 20)
+    Helpers.expect.buf_width_in_range(child, "1000", 18, 20)
+    Helpers.expect.buf_width_in_range(child, "1001", 18, 20)
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1002, 1001, 1000, 1003 })
 end
@@ -152,15 +152,15 @@ T["vsplit"]["correctly size splits when opening helper with side buffers open"] 
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 19)
+    Helpers.expect.buf_width_in_range(child, "1003", 29, 30)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 5, 7)
 
     child.cmd("h")
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 5, 7)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
@@ -184,7 +184,8 @@ T["vsplit"]["preserve vsplit width when having side buffers"] = function()
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1002, 1000 })
 
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1002)"), 26)
+    Helpers.expect.buf_width_in_range(child, "1002", 36, 38)
+    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
 end
 
 T["vsplit"]["closing `curr` makes `split` the new `curr`"] = function()
@@ -353,7 +354,7 @@ T["vsplit/split"]["closing help page doens't break layout"] = function()
 
     Helpers.expect.equality(child.get_current_win(), 1003)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 24, 26)
 end
 
 T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
@@ -367,8 +368,8 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
     Helpers.expect.equality(child.get_current_win(), 1003)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 20)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 18, 20)
+    Helpers.expect.buf_width_in_range(child, "1003", 18, 20)
 
     child.cmd("vsplit")
     child.wait()
@@ -376,8 +377,8 @@ T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1004, 1003, 1000, 1002 })
     Helpers.expect.equality(child.get_current_win(), 1004)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 38)
-    Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1003)"), 20)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 38, 40)
+    Helpers.expect.buf_width_in_range(child, "1003", 18, 20)
 end
 
 return T

--- a/tests/test_splits.lua
+++ b/tests/test_splits.lua
@@ -152,15 +152,15 @@ T["vsplit"]["correctly size splits when opening helper with side buffers open"] 
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.buf_width_in_range(child, "1003", 29, 30)
-    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 5, 7)
+    Helpers.expect.buf_width_in_range(child, "1003", 18, 20)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 18, 20)
 
     child.cmd("h")
 
     Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.lua_get("vim.api.nvim_win_get_width(1004)"), 80)
-    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 5, 7)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 18, 20)
 end
 
 T["vsplit"]["correctly position side buffers when there's enough space"] = function()
@@ -344,17 +344,20 @@ T["vsplit/split"]["closing help page doens't break layout"] = function()
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
 
     child.cmd("split")
+    Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
+
     child.cmd("h")
     Helpers.expect.equality(child.get_wins_in_tab(), { 1004, 1001, 1003, 1000, 1002 })
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.curr", 48)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 46, 48)
 
+    Helpers.expect.equality(child.get_current_win(), 1004)
     child.cmd("q")
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1003, 1000, 1002 })
 
     Helpers.expect.equality(child.get_current_win(), 1003)
 
-    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 24, 26)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.curr", 26, 48)
 end
 
 T["vsplit/split"]["splits and vsplits keeps a correct size"] = function()

--- a/tests/test_tabs.lua
+++ b/tests/test_tabs.lua
@@ -50,8 +50,8 @@ T["tabs"]["side buffers coexist on many tabs"] = function()
     Helpers.expect.equality(child.get_wins_in_tab(), { 1001, 1000, 1002 })
     Helpers.expect.state(child, "active_tab", 1)
 
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[1].wins.main.right", 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 13, 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 13, 15)
 
     -- tab 2
     child.cmd("tabnew")
@@ -70,8 +70,8 @@ T["tabs"]["side buffers coexist on many tabs"] = function()
     Helpers.expect.state(child, "active_tab", 3)
 
     -- width is preserved as on tab 1
-    Helpers.expect.buf_width(child, "tabs[3].wins.main.left", 15)
-    Helpers.expect.buf_width(child, "tabs[3].wins.main.right", 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.left", 13, 15)
+    Helpers.expect.buf_width_in_range(child, "_G.NoNeckPain.state.tabs[1].wins.main.right", 13, 15)
 
     Helpers.expect.equality(child.get_wins_in_tab(1), { 1001, 1000, 1002 })
     Helpers.expect.equality(child.get_wins_in_tab(3), { 1007, 1006, 1008 })


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/453
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/470

the width of an integration doesn't need to be accounted as a vsplit occupied width, but should rather just be deduced from the remaining width for the side buffers