### PR TITLE
fix: subtract `integration_width` first to calculate the side buffer width

### DIFF
--- a/lua/no-neck-pain/ui.lua
+++ b/lua/no-neck-pain/ui.lua
@@ -257,7 +257,7 @@ function ui.get_side_width(side)
 
     log.debug(scope, "%d total width columns - %d columns remaining", columns_width, columns)
 
-    local final = math.floor((vim.o.columns - columns_width) / 2) - integration_width
+    local final = math.floor((vim.o.columns - columns_width - integration_width) / 2)
 
     if final <= _G.NoNeckPain.config.minSideBufferWidth then
         log.debug(scope, "%d/%d not enough space", final, vim.o.columns)


### PR DESCRIPTION
When *no-neck-pain* is active, opening *neo-tree* increases the side buffer width by a lot. This fixes the calculation.