### PR TITLE
fix(scratchPad): restore focus when disabling

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -26,8 +26,6 @@ function main.toggle_scratch_pad()
         return
     end
 
-    -- store the current win to later restore focus
-    local curr_win = vim.api.nvim_get_current_win()
     local current_state = state.tabs[state.active_tab].scratchpad_enabled
 
     -- save new state of the scratch_pad and update tabs
@@ -43,7 +41,7 @@ function main.toggle_scratch_pad()
     end
 
     -- restore focus
-    vim.api.nvim_set_current_win(curr_win)
+    vim.api.nvim_set_current_win(state.get_previously_focused_win(state))
 
     state.save(state)
 end


### PR DESCRIPTION
## 📃 Summary

when enabling the scratch pad, we restore the focus to the previously focused window, however disabling it doesn't restore it.

this pr now properly restores the focus so that the cursor doesn't stay on the unusable side buffer