### PR TITLE
feat(highlight): create namespace and empty groups by default

### DIFF
--- a/lua/no-neck-pain/state.lua
+++ b/lua/no-neck-pain/state.lua
@@ -480,11 +480,10 @@ end
 ----- namespace =======================================================
 ---@private
 
---- Creates a namespace for the given `side` and stores it in the state.
+--- Creates a namespace for the given `win` and stores it in the state.
 ---
----@param side "left"|"right": the side.
+---@param side number: the side window id.
 ---@return number: the created namespace id.
----@return string: the name of the created namespace.
 ---@private
 function state:set_namespace(side)
     if self.namespaces == nil then
@@ -496,7 +495,7 @@ function state:set_namespace(side)
 
     self.namespaces[side] = id
 
-    return id, name
+    return id
 end
 
 --- Clears the given `side` namespace and resets its state value.

--- a/tests/test_API.lua
+++ b/tests/test_API.lua
@@ -37,7 +37,7 @@ T["setup"]["sets exposed methods and default options value"] = function()
     Helpers.expect.global_type(child, "_G.NoNeckPain.resize", "function")
     Helpers.expect.global_type(child, "_G.NoNeckPain.disable", "function")
     Helpers.expect.global_type(child, "_G.NoNeckPain.toggle_side", "function")
-    Helpers.expect.global_type(child, "_G.NoNeckPain.toggle_scratchPad", "function")
+    Helpers.expect.global_type(child, "_G.NoNeckPain.toggle_scratch_pad", "function")
     Helpers.expect.global_type(child, "_G.NoNeckPain.toggle_debug", "function")
 
     -- config


### PR DESCRIPTION
## 📃 Summary

closes https://github.com/shortcuts/no-neck-pain.nvim/issues/494

it is currently not (easily) possible to provide custom highlight groups to the no-neck-pain windows without playing with the nvim api. This PR adds default namespace and groups tied to the no-neck-pain windows so that one can easily link custom highlights to it.

also drop support fold old apis