### PR TITLE
chore: revert TermClose handler

### DIFF
--- a/lua/no-neck-pain/main.lua
+++ b/lua/no-neck-pain/main.lua
@@ -228,14 +228,11 @@ function main.enable(scope)
         desc = "Keeps track of the state after entering new windows",
     })
 
-    vim.api.nvim_create_autocmd({ "QuitPre", "BufDelete", "TermClose" }, {
+    vim.api.nvim_create_autocmd({ "QuitPre", "BufDelete" }, {
         callback = function(p)
             vim.schedule(function()
                 local s = string.format("%s:%d", p.event, vim.api.nvim_get_current_win())
-                if
-                    not state:is_active_tab_registered()
-                    or (event.skip() and p.event ~= "TermClose")
-                then
+                if not state:is_active_tab_registered() or event.skip() then
                     return
                 end
 


### PR DESCRIPTION
## 📃 Summary

revert https://github.com/shortcuts/no-neck-pain.nvim/pull/504
closes https://github.com/shortcuts/no-neck-pain.nvim/issues/507

fzflua uses term cmds to handle pickers which triggers the TermClose event